### PR TITLE
Sync irw-auto-itemtext skill: instructions/section_prompt boundary + two prior fixes

### DIFF
--- a/itemtext/.claude/skills/irw-auto-itemtext/SKILL.md
+++ b/itemtext/.claude/skills/irw-auto-itemtext/SKILL.md
@@ -101,14 +101,31 @@ Build the 4-tab structure (see `references/itemtext_standard.md` for exact colum
 in memory or as a scratch CSV — you don't have to actually create Sheets tabs, just
 produce data shaped like them before merging:
 
-- **instrument/instructions** — full instrument name + literal instructions text.
-- **section_id/section_prompt** — only for testlets/shared-passage items. If the
-  instrument has no such grouping, still emit one `section_id` per item (e.g.
-  `<table>_1`) with a blank `section_prompt`, rather than omitting the column — the
-  merge step needs a join key.
+- **instrument/instructions** — full instrument name + literal instructions text that
+  applies to the entire table regardless of `section_id`.
+- **section_id/section_prompt** — only for testlets/shared-passage items, and scoped to
+  just the items sharing that `section_id` (e.g. a passage or context given before a
+  testlet). If the instrument has no such grouping, still emit one `section_id` per item
+  (e.g. `<table>_1`) with a blank `section_prompt`, rather than omitting the column — the
+  merge step needs a join key. Never record the same span of source text in both
+  `instructions` and `section_prompt` — decide which one it belongs to (whole-table
+  framing goes in `instructions`; testlet/passage-specific text goes in `section_prompt`
+  only, even if it reads like instructional language) and record it once. See
+  `references/itemtext_standard.md` for the full rule.
 - **item/item_text/correct_response** — `item` values must be exactly the ones from
   Step 2's ground truth, not invented. `correct_response` blank when there's no scoring
-  key; semicolon-separated when multiple answers are correct (e.g. `A;C`).
+  key; semicolon-separated when multiple answers are correct (e.g. `A;C`). **When the
+  ground-truth `item` values are bare integers** (e.g. `1`, `2`, `3` rather than named
+  codes like `q1_anx`), you have to reconstruct which paper item each integer refers to
+  — usually by position/order in the instrument. Confirming that `resp`'s type and range
+  look plausible for that item (e.g. "a 1–5 Likert item exists") is not sufficient
+  validation on its own, since many items in the same instrument share the same response
+  range and would pass that check regardless of which one you picked. Before assigning
+  `item_text` to a specific bare-integer `item`, cross-check the paper's stated item
+  count and presentation order, and any distinguishing wording/position cues (item
+  numbering in a table/appendix, subscale grouping, reverse-scored markers) — don't rely
+  on range-matching alone. If the mapping is genuinely ambiguous, say so and log it per
+  Step 6b rather than guessing.
 - **resp/option_text** — `resp` values must be exactly the ones from Step 2's ground
   truth. Map extracted option text onto that existing numeric/ordinal coding — for a
   standard Likert-style instrument this is usually the ascending order the paper
@@ -117,6 +134,14 @@ produce data shaped like them before merging:
   a categorical/lettered code with no way to tie it to the existing numeric `resp`), put
   the raw option in a `raw_resp` column instead of forcing it into `resp` — see
   `gilbert_meta_11` for a real example of this pattern.
+
+**Match the source's terseness.** Transcribe `instructions`, `section_prompt`,
+`item_text`, and `option_text` at the same level of brevity as the source material. If
+the paper's instructions are one short sentence, keep it one short sentence — don't
+expand it into an explanatory paraphrase. If item stems are terse phrases (e.g. "Felt
+nervous"), keep them terse; don't pad them into full explanatory sentences or add
+clarifying boilerplate that isn't in the original text. The goal is a literal transcript,
+not a rewrite for clarity.
 
 Merge the four pieces (`items` as the base, then `sections`, `instrument`, `responses`,
 each via `merge(..., all.x=TRUE)` on shared key columns) into one data frame — this is

--- a/itemtext/.claude/skills/irw-auto-itemtext/references/itemtext_standard.md
+++ b/itemtext/.claude/skills/irw-auto-itemtext/references/itemtext_standard.md
@@ -1,7 +1,8 @@
 # IRW Item Text Schema
 
 Verbatim field definitions, copied from https://itemresponsewarehouse.org/itemtext.html
-(2026-07-27) so this skill doesn't need to re-fetch the page every run. This is the
+(2026-08-11, as of datapages/irw commit `3da46a86662018e6f9bf09cfd89ee4ac51c6e947`
+/ PR #97) so this skill doesn't need to re-fetch the page every run. This is the
 schema of the **merged** `{table}__items.csv` — the output of joining the four
 per-table tabs (instrument, sections, items, responses) on `table` / `section_id` / `item`.
 
@@ -17,6 +18,14 @@ per-table tabs (instrument, sections, items, responses) on `table` / `section_id
 | `correct_response` | Scoring key for a given `item`. Blank when there is no correct answer; multiple correct answers are semicolon-separated (e.g. `A;C`). |
 | `option_text` | Literal text for a specific response option available for an item. May legitimately be missing for behavior-scored items. |
 | `resp` | Response value assigned to a specific `option_text` — must match the numeric/ordinal values already present in the live response-level IRW dataset (`irw::irw_fetch(table)$resp`). |
+
+`instructions` and `section_prompt` are scoped differently: `instructions` applies to
+the entire table regardless of `section_id`; `section_prompt` applies only to the items
+sharing one or more specific `section_id` values. The same span of source text should
+never be recorded in both fields. If framing or task-level text applies across the whole
+table, record it once in `instructions`. If it is specific to a subset of items sharing
+a `section_id` (e.g. a passage or context given before a testlet), record it in
+`section_prompt` only, even if it superficially resembles instructional language.
 
 **`resp_raw`** (per the public schema page): when the scoring key can't be recovered —
 i.e. the item is on some categorical/lettered coding in the source material that doesn't

--- a/itemtext/.claude/skills/irw-auto-itemtext/scripts/validate_items.R
+++ b/itemtext/.claude/skills/irw-auto-itemtext/scripts/validate_items.R
@@ -48,6 +48,22 @@ if (length(missing_from_items) == 0 && length(extra_in_items) == 0) {
     }
 }
 
+cat("\n=== Bare-integer item check ===\n")
+item_vals <- unique(df$item)
+looks_bare_integer <- length(item_vals) > 0 && all(grepl("^[0-9]+$", trimws(as.character(item_vals))))
+if (looks_bare_integer) {
+    cat("CAUTION: this table's `item` values are bare integers (e.g. \"",
+        item_vals[1], "\") rather than named codes. An exact item-set match (above) only ",
+        "confirms the *set* of integers is right, not that each integer's item_text was ",
+        "mapped to the correct paper item -- resp type/range plausibility is not enough ",
+        "evidence either, since multiple items typically share the same range. Manually ",
+        "confirm the item order/count against the paper (position in the instrument, ",
+        "subscale grouping, reverse-scored markers) before treating this as validated. ",
+        "See SKILL.md Step 4.\n", sep = "")
+} else {
+    cat("Item identifiers are not bare integers -- no extra reconstruction caution needed.\n")
+}
+
 cat("\n=== Resp set check ===\n")
 if (!has_resp) {
     if (!is.na(raw_resp_col)) {


### PR DESCRIPTION
## Summary

Source-commit reference: this itemtext.qmd-derived change tracks
**datapages/irw commit `3da46a86662018e6f9bf09cfd89ee4ac51c6e947`** (PR #97,
"Clarify instructions vs section_prompt boundary in item-text standard",
merged into `datapages/irw:main` 2026-08-11), which inserted the following
rule into `itemtext.qmd`:

> `instructions` and `section_prompt` are scoped differently: `instructions`
> applies to the entire table regardless of `section_id`; `section_prompt`
> applies only to the items sharing one or more specific `section_id`
> values. The same span of source text should never be recorded in both
> fields. If framing or task-level text applies across the whole table,
> record it once in `instructions`. If it is specific to a subset of items
> sharing a `section_id` (e.g. a passage or context given before a testlet),
> record it in `section_prompt` only, even if it superficially resembles
> instructional language.

This PR brings `itemtext/.claude/skills/irw-auto-itemtext/` in sync with
that standard, and folds in two previously-flagged gaps in the same skill
that were confirmed (via `git log` + reading the current files) to not yet
be present anywhere in the repo.

- `references/itemtext_standard.md`: added the boundary rule as a short
  prose note directly below the `| Field | Definition |` table (it spans
  two fields so doesn't fit one row), and updated the header provenance
  note from the stale "(2026-07-27)" date to today's date plus the source
  commit/PR (`3da46a86662018e6f9bf09cfd89ee4ac51c6e947` / PR #97).
- `SKILL.md` Step 4: the `instrument/instructions` and
  `section_id/section_prompt` bullets already paraphrase each field's role;
  restated the same boundary rule there so no ambiguous/un-synced copy is
  left in the skill.
- `scripts/validate_items.R`: added a "Bare-integer item check" section
  (Fix 1) that flags tables whose `item` values are bare integers and
  reminds the runner that item-set/resp-range matching alone doesn't verify
  the reconstructed item-to-text mapping is correct.
- `SKILL.md` Step 4: added matching guidance for bare-integer item
  reconstruction (Fix 1) and a "Match the source's terseness" note (Fix 2)
  so generated text mirrors the source's brevity instead of adding
  explanatory boilerplate.

## Test plan

- [ ] `Rscript itemtext/.claude/skills/irw-auto-itemtext/scripts/validate_items.R <table> <items_csv>` still runs and now prints a "Bare-integer item check" section before "Resp set check".
- [ ] Read `references/itemtext_standard.md` and `SKILL.md` Step 4 to confirm the new prose reads naturally and doesn't duplicate/conflict with existing bullets.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01NvrbrY1BgjUpfcqVLFtzVo
