### PR TITLE
automated_finding: expand scheduled discovery to PLOS/PMC + add cross-run dedup

### DIFF
--- a/automated_finding/irw_batch_updated.py
+++ b/automated_finding/irw_batch_updated.py
@@ -50,7 +50,7 @@ import pandas as pd
 
 from irw_triage_updated import load_table, triage_dataset, irw_metadata
 
-UA = {"User-Agent": "irw-batch/1.0 (research; contact your-email)"}
+UA = {"User-Agent": "irw-batch/1.0 (research; contact itemresponsewarehouse@stanford.edu)"}
 TABULAR_EXT = (".csv", ".tsv", ".tab", ".xlsx", ".xls",
                ".sav", ".dta", ".sas7bdat", ".rdata", ".rda", ".rds")
 PER_DOMAIN_DELAY = 1.5          # seconds between hits to the same domain
@@ -369,6 +369,37 @@ def process_one(row: dict) -> dict:
 def _key(row: dict) -> str:
     return row.get("doi") or row.get("url") or row.get("title", "")
 
+# Permanent, cross-run record of every candidate key (doi/url/title, same
+# as _key()) this script has ever triaged -- distinct from CHECKPOINT,
+# which is scoped to a single (possibly interrupted) run and, without
+# --resume, gets wiped on every fresh invocation. Shared by every manual
+# `python irw_batch_updated.py ...` call and by the scheduled monthly/
+# weekly repos routine alike, so a candidate one already triaged doesn't
+# get re-downloaded by the other. Mirrors irw_discover_plos.py's/
+# irw_discover_pmc.py's SEEN_DOIS_PATH design.
+SEEN_KEYS_PATH = "repo_triage_seen_keys.csv"
+
+
+def load_seen_keys(path: str = SEEN_KEYS_PATH) -> set:
+    if not os.path.exists(path):
+        return set()
+    with open(path, newline="", encoding="utf-8") as f:
+        return {row["key"] for row in csv.DictReader(f) if row.get("key")}
+
+
+def append_seen_keys(keys, path: str = SEEN_KEYS_PATH) -> None:
+    import datetime as _dt
+    if not keys:
+        return
+    file_exists = os.path.exists(path)
+    today = _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%d")
+    with open(path, "a", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["key", "date"])
+        if not file_exists:
+            writer.writeheader()
+        writer.writerows({"key": k, "date": today} for k in keys)
+
+
 def load_done(path: str) -> dict:
     done = {}
     if os.path.exists(path):
@@ -395,8 +426,16 @@ FLAG_ORDER = ["good", "human_assistance", "not_item_response",
               "download_failed", "error"]
 
 def run_batch(candidates_csv: str, out_csv: str, limit: int | None,
-              resume: bool, checkpoint: str = CHECKPOINT) -> pd.DataFrame:
+              resume: bool, checkpoint: str = CHECKPOINT,
+              ignore_seen_keys: bool = False) -> pd.DataFrame:
     rows = list(csv.DictReader(open(candidates_csv, encoding="utf-8")))
+
+    global_seen = set() if ignore_seen_keys else load_seen_keys()
+    if global_seen:
+        print(f"Excluding {len(global_seen):,} candidates already triaged in a prior "
+              f"run (manual or scheduled -- see {SEEN_KEYS_PATH})")
+        rows = [r for r in rows if _key(r) not in global_seen]
+
     if limit:
         rows = rows[:limit]
 
@@ -407,6 +446,7 @@ def run_batch(candidates_csv: str, out_csv: str, limit: int | None,
         os.remove(checkpoint)   # fresh run
 
     results = list(done.values())
+    newly_seen = []
     for i, row in enumerate(rows, 1):
         k = _key(row)
         if k in done:
@@ -416,7 +456,11 @@ def run_batch(candidates_csv: str, out_csv: str, limit: int | None,
         res = process_one(row)
         append_checkpoint(checkpoint, k, res)
         results.append(res)
+        newly_seen.append(k)
         print(f"        -> {res['flag']}", flush=True)
+
+    if not ignore_seen_keys:
+        append_seen_keys(newly_seen)
 
     df = pd.DataFrame(results)
     if not df.empty:
@@ -435,9 +479,14 @@ def main():
                     help="process only the first N (use this to test first!)")
     ap.add_argument("--resume", action="store_true",
                     help="skip rows already in the checkpoint")
+    ap.add_argument("--ignore-seen-keys", action="store_true",
+                    help=f"don't consult/update {SEEN_KEYS_PATH} (the cross-run dedup "
+                         "store shared with the scheduled repos routine) -- use to "
+                         "deliberately re-triage a candidate, e.g. after a script fix")
     args = ap.parse_args()
 
-    df = run_batch(args.candidates_csv, args.out, args.limit, args.resume)
+    df = run_batch(args.candidates_csv, args.out, args.limit, args.resume,
+                    ignore_seen_keys=args.ignore_seen_keys)
     print("\n" + "=" * 50)
     if df.empty:
         print("No results.")

--- a/automated_finding/irw_discover_monthly.py
+++ b/automated_finding/irw_discover_monthly.py
@@ -24,7 +24,8 @@ hit counts) and BATCH_LOG.md (which batches such terms fed) before trusting
 it as-is.
 
 Run:
-    python irw_discover_monthly.py                      # full run, osf+dataverse
+    python irw_discover_monthly.py                      # full run (~100 terms), osf+dataverse
+    python irw_discover_monthly.py --mode weekly         # HIGH_YIELD_TERMS subset (~15 terms)
     python irw_discover_monthly.py --dry-run             # show since-dates only, no queries
     python irw_discover_monthly.py --sources osf dataverse surf aussda scholars_portal
 """
@@ -169,6 +170,30 @@ TERM_LIST = [
     "employability skills",
 ]
 
+# Small, proven-yield subset for a weekly pass -- same shortlist used by
+# irw_discover_plos_monthly.py / irw_discover_pmc_monthly.py's
+# HIGH_YIELD_TERMS (kept identical across connectors on purpose, since the
+# yield signal is about the construct, not the source). Edit freely as
+# per-source yield data comes in; they don't need to stay in sync going
+# forward.
+HIGH_YIELD_TERMS = [
+    "self-esteem",
+    "grit",
+    "self-efficacy",
+    "depression",
+    "anxiety",
+    "burnout",
+    "perceived stress",
+    "well-being",
+    "life satisfaction",
+    "loneliness",
+    "academic motivation",
+    "work engagement",
+    "resilience",
+    "procrastination",
+    "growth mindset",
+]
+
 DEFAULT_SOURCES = ["osf", "dataverse"]
 
 
@@ -209,6 +234,11 @@ def append_log_rows(rows: list[dict], log_path: str = LOG_PATH) -> None:
 
 def main():
     ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=["weekly", "full"], default="full",
+                     help="weekly: HIGH_YIELD_TERMS subset (~15 terms), for a frequent "
+                          "small-scope pass. full: TERM_LIST (~100 terms), the original "
+                          "monthly sweep. Default 'full' preserves this script's original "
+                          "behavior for the existing scheduled routine.")
     ap.add_argument("--sources", metavar="NAME", nargs="+", default=DEFAULT_SOURCES,
                      help=f"sources to query (choices: {', '.join(SOURCE_MAP)})")
     ap.add_argument("--default-lookback-days", type=int, default=90,
@@ -216,7 +246,7 @@ def main():
     ap.add_argument("--dry-run", action="store_true",
                      help="print each term's computed --since date and exit, no queries run")
     ap.add_argument("--out", default=None,
-                     help=f"output CSV (default: {OUT_PREFIX}<today>.csv)")
+                     help=f"output CSV (default: {OUT_PREFIX}<mode>_<today>.csv)")
     args = ap.parse_args()
 
     unknown = set(args.sources) - set(SOURCE_MAP)
@@ -224,22 +254,24 @@ def main():
         ap.error(f"Unknown sources: {', '.join(unknown)}. Choices: {', '.join(SOURCE_MAP)}")
     active_sources = [SOURCE_MAP[s] for s in args.sources]
 
+    terms = HIGH_YIELD_TERMS if args.mode == "weekly" else TERM_LIST
+
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     fallback_since = (datetime.now(timezone.utc) - timedelta(days=args.default_lookback_days)).strftime("%Y-%m-%d")
 
     since_by_term = {}
-    for term in TERM_LIST:
+    for term in terms:
         prior = last_run_date(term)
         since_by_term[term] = prior if prior else fallback_since
 
     if args.dry_run:
-        print(f"Sources: {', '.join(args.sources)}")
+        print(f"Mode: {args.mode} ({len(terms)} terms). Sources: {', '.join(args.sources)}")
         for term, since in since_by_term.items():
             origin = "prior monthly run" if last_run_date(term) else f"first run, {args.default_lookback_days}d lookback"
             print(f"  {term!r}: since={since} ({origin})")
         return
 
-    out_path = args.out or f"{OUT_PREFIX}{today}.csv"
+    out_path = args.out or f"{OUT_PREFIX}{args.mode}_{today}.csv"
     exclude = _load_auto_exclusions()
     if exclude:
         print(f"Excluding {len(exclude):,} DOIs already in the IRW dictionary")
@@ -249,7 +281,7 @@ def main():
     writer = csv.DictWriter(outf, fieldnames=fieldnames)
     writer.writeheader()
 
-    hits_by_term = {term: 0 for term in TERM_LIST}
+    hits_by_term = {term: 0 for term in terms}
 
     def on_hit(h, term):
         hits_by_term[term] += 1

--- a/automated_finding/irw_discover_plos.py
+++ b/automated_finding/irw_discover_plos.py
@@ -50,7 +50,7 @@ from irw_discover_updated import Hit, is_relevant, norm_doi, _load_auto_exclusio
 from irw_batch_updated import check_license, TABULAR_EXT, polite_get, FileTooLarge
 from irw_triage_updated import load_table, triage_dataset
 
-UA = {"User-Agent": "irw-discovery-scout/1.0 (research; contact your-email)"}
+UA = {"User-Agent": "irw-discovery-scout/1.0 (research; contact itemresponsewarehouse@stanford.edu)"}
 PLOS_SEARCH_API = "https://api.plos.org/search"
 PLOS_ARTICLE_URL = "https://journals.plos.org/{slug}/article?id={doi}"
 
@@ -301,6 +301,39 @@ FIELDNAMES = ["source", "journal", "doi", "title", "url", "license", "flag",
               "n_responses", "n_participants", "n_items", "density",
               "n_other_files"]
 
+# Permanent, cross-run record of every DOI this connector has ever
+# triaged -- shared by manual (`python irw_discover_plos.py ...`) and
+# scheduled (irw_discover_plos_monthly.py) invocations alike, so a term
+# searched by hand and the same term in the scheduled high-yield list don't
+# re-download and re-triage the same candidate. Distinct from `--resume`,
+# which only dedups within a single --out file. Not the same signal as
+# "already in the IRW dictionary" (_load_auto_exclusions) -- a candidate
+# can be seen here (attempted) long before it's shipped (or ever, if it was
+# rejected) there.
+SEEN_DOIS_PATH = "plos_seen_dois.csv"
+
+
+def load_seen_dois(path: str = SEEN_DOIS_PATH) -> set:
+    import os
+    if not os.path.exists(path):
+        return set()
+    with open(path, newline="", encoding="utf-8") as f:
+        return {row["doi"] for row in csv.DictReader(f) if row.get("doi")}
+
+
+def append_seen_dois(dois, path: str = SEEN_DOIS_PATH) -> None:
+    import os
+    from datetime import datetime, timezone
+    if not dois:
+        return
+    file_exists = os.path.exists(path)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    with open(path, "a", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["doi", "date"])
+        if not file_exists:
+            writer.writeheader()
+        writer.writerows({"doi": d, "date": today} for d in dois)
+
 # Native readstat/openpyxl code (pyreadstat's .sav parser especially) can
 # segfault outright on a corrupt file -- that's a C-level crash, not a
 # catchable Python exception, so a bare try/except around process_one()
@@ -385,6 +418,10 @@ def main():
     ap.add_argument("--journals", default=DEFAULT_JOURNAL,
                     help="comma-separated journal slugs to search, from: "
                          f"{', '.join(JOURNALS)} (default: {DEFAULT_JOURNAL})")
+    ap.add_argument("--ignore-seen-dois", action="store_true",
+                    help=f"don't consult/update {SEEN_DOIS_PATH} (the cross-run dedup "
+                         "store shared with irw_discover_plos_monthly.py) -- use to "
+                         "deliberately re-triage a DOI, e.g. after a script fix")
     args = ap.parse_args()
 
     journals = [j.strip() for j in args.journals.split(",") if j.strip()]
@@ -393,11 +430,17 @@ def main():
         raise SystemExit(f"Unknown journal slug(s): {bad}. Choose from: {list(JOURNALS)}")
 
     exclude = _load_auto_exclusions()
-    print(f"Excluding {len(exclude):,} DOIs already in the IRW dictionary\n")
+    print(f"Excluding {len(exclude):,} DOIs already in the IRW dictionary")
+
+    global_seen = set() if args.ignore_seen_dois else load_seen_dois()
+    if global_seen:
+        print(f"Excluding {len(global_seen):,} DOIs already triaged in a prior run "
+              f"(manual or scheduled -- see {SEEN_DOIS_PATH})")
 
     already_done = _load_done_dois(args.out) if args.resume else set()
     if already_done:
-        print(f"Resuming: {len(already_done)} DOIs already in {args.out}, skipping them\n")
+        print(f"Resuming: {len(already_done)} DOIs already in {args.out}, skipping them")
+    print()
 
     outf = open(args.out, "a" if args.resume and already_done else "w",
                 newline="", encoding="utf-8")
@@ -406,6 +449,7 @@ def main():
         writer.writeheader()
 
     seen = set(already_done)
+    newly_seen = []
     n_done = 0
     pool = _new_pool()
     try:
@@ -413,9 +457,10 @@ def main():
             for q in args.queries:
                 print(f"[{journal}] [query] {q}", flush=True)
                 for hit in from_plos(q, journal):
-                    if hit.doi in seen or hit.doi in exclude:
+                    if hit.doi in seen or hit.doi in exclude or hit.doi in global_seen:
                         continue
                     seen.add(hit.doi)
+                    newly_seen.append(hit.doi)
                     row, pool = process_one_isolated(hit, pool)
                     writer.writerow(row)
                     outf.flush()
@@ -430,6 +475,8 @@ def main():
     finally:
         pool.shutdown(wait=False)
         outf.close()
+        if not args.ignore_seen_dois:
+            append_seen_dois(newly_seen)
 
     print(f"\n{n_done} candidates processed -> {args.out}")
 

--- a/automated_finding/irw_discover_plos_monthly.py
+++ b/automated_finding/irw_discover_plos_monthly.py
@@ -1,0 +1,192 @@
+"""
+irw_discover_plos_monthly.py
+==============================
+Incremental scheduled discovery+triage for irw_discover_plos.py. Meant to be
+invoked on a schedule (see the `schedule` skill), in two modes:
+
+  --mode weekly  a small, proven-high-yield term subset (HIGH_YIELD_TERMS),
+                 run every week -- kept small on purpose so a full
+                 discover+triage pass (real downloads, not just search) stays
+                 cheap and bounded.
+  --mode full    the same broad ~100-term construct list irw_discover_monthly.py
+                 uses for the repo connector (imported from there, not
+                 duplicated here), run monthly.
+
+Why incrementality here isn't a --since date filter (unlike
+irw_discover_monthly.py's repo connector): the PLOS Solr search API this
+script's discovery layer (irw_discover_plos.py's search_plos) uses has no
+date-range parameter wired up. Instead, incrementality rides on
+irw_discover_plos.py's own SEEN_DOIS_PATH (plos_seen_dois.csv) -- a
+persistent, cross-run record of every DOI *either* a manual
+(`python irw_discover_plos.py ...`) *or* this scheduled script has ever
+attempted, regardless of what triage flag it got. That store is shared
+deliberately: without it, a term you search by hand today and the same
+term showing up in HIGH_YIELD_TERMS next week would re-download and
+re-triage the same candidates, wasting PLOS API/CDN load and producing
+duplicate rows across PRs. This script does not maintain its own separate
+seen-DOI file -- it calls irw_discover_plos.py's load_seen_dois() /
+append_seen_dois() directly.
+
+--limit bounds each run's total triaged-candidate count (real downloads are
+the expensive, rate-limit-relevant part -- see README.md's triage timing
+note). If a run hits the cap, remaining terms for that mode are left
+untried and picked up on the next scheduled run naturally (seen-DOI state
+persists across runs) -- print a clear notice so a human doesn't assume the
+term list was fully covered.
+
+Run:
+    python irw_discover_plos_monthly.py --mode weekly
+    python irw_discover_plos_monthly.py --mode full --limit 150
+    python irw_discover_plos_monthly.py --mode weekly --dry-run
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import argparse
+from datetime import datetime, timezone
+
+from irw_discover_updated import _load_auto_exclusions
+from irw_discover_plos import (
+    from_plos, process_one_isolated, _new_pool, JOURNALS, DEFAULT_JOURNAL,
+    FIELDNAMES, SEEN_DOIS_PATH, load_seen_dois, append_seen_dois,
+)
+from irw_discover_monthly import TERM_LIST as FULL_TERM_LIST
+
+LOG_PATH = "search_terms_log.csv"
+OUT_PREFIX = "plos_monthly_candidates_"
+
+# Small, proven-yield subset for the weekly pass -- pulled from constructs
+# BATCH_LOG.md calls out as having produced real, processed PLOS hits (not
+# just present in the relevance vocabulary). Same shortlist logic as
+# irw_discover_monthly.py's TERM_LIST comment: bare/root construct terms,
+# not "X scale"/"X questionnaire" phrasing. Edit freely as yield data comes
+# in -- this is a starting point, not a final answer.
+HIGH_YIELD_TERMS = [
+    "self-esteem",
+    "grit",
+    "self-efficacy",
+    "depression",
+    "anxiety",
+    "burnout",
+    "perceived stress",
+    "well-being",
+    "life satisfaction",
+    "loneliness",
+    "academic motivation",
+    "work engagement",
+    "resilience",
+    "procrastination",
+    "growth mindset",
+]
+
+DEFAULT_LIMIT_BY_MODE = {"weekly": 60, "full": 150}
+
+
+def _append_log_rows(rows: list[dict], path: str = LOG_PATH) -> None:
+    fieldnames = ["date", "query", "output_file", "notes"]
+    file_exists = os.path.exists(path)
+    with open(path, "a", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        if not file_exists:
+            writer.writeheader()
+        writer.writerows(rows)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=["weekly", "full"], default="weekly")
+    ap.add_argument("--journals", default=DEFAULT_JOURNAL,
+                     help="comma-separated journal slugs to search, from: "
+                          f"{', '.join(JOURNALS)} (default: {DEFAULT_JOURNAL})")
+    ap.add_argument("--limit", type=int, default=None,
+                     help="cap total candidates triaged this run "
+                          f"(default: weekly={DEFAULT_LIMIT_BY_MODE['weekly']}, "
+                          f"full={DEFAULT_LIMIT_BY_MODE['full']})")
+    ap.add_argument("--out", default=None,
+                     help=f"output CSV (default: {OUT_PREFIX}<mode>_<today>.csv)")
+    ap.add_argument("--dry-run", action="store_true",
+                     help="print term/journal counts and seen-DOI store size, no queries run")
+    args = ap.parse_args()
+
+    journals = [j.strip() for j in args.journals.split(",") if j.strip()]
+    bad = [j for j in journals if j not in JOURNALS]
+    if bad:
+        raise SystemExit(f"Unknown journal slug(s): {bad}. Choose from: {list(JOURNALS)}")
+
+    terms = HIGH_YIELD_TERMS if args.mode == "weekly" else FULL_TERM_LIST
+    limit = args.limit if args.limit is not None else DEFAULT_LIMIT_BY_MODE[args.mode]
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    seen = load_seen_dois()
+
+    if args.dry_run:
+        print(f"Mode: {args.mode} ({len(terms)} terms) x journals: {', '.join(journals)}")
+        print(f"Seen-DOI store ({SEEN_DOIS_PATH}): {len(seen):,} DOIs already attempted "
+              f"by any manual or scheduled run (never re-triaged)")
+        print(f"Limit this run: {limit}")
+        return
+
+    exclude = _load_auto_exclusions()
+    print(f"Excluding {len(exclude):,} DOIs already in the IRW dictionary")
+    print(f"Excluding {len(seen):,} DOIs already triaged in a prior run "
+          f"(manual or scheduled -- see {SEEN_DOIS_PATH})")
+
+    out_path = args.out or f"{OUT_PREFIX}{args.mode}_{today}.csv"
+    outf = open(out_path, "w", newline="", encoding="utf-8")
+    writer = csv.DictWriter(outf, fieldnames=FIELDNAMES, extrasaction="ignore")
+    writer.writeheader()
+
+    skip = seen | exclude
+    newly_attempted = []
+    n_done = 0
+    terms_fully_covered = 0
+    pool = _new_pool()
+    capped = False
+    try:
+        for term in terms:
+            print(f"\n[term] {term!r}", flush=True)
+            any_hit = False
+            for journal in journals:
+                for hit in from_plos(term, journal):
+                    any_hit = True
+                    if hit.doi in skip:
+                        continue
+                    skip.add(hit.doi)
+                    newly_attempted.append(hit.doi)
+                    row, pool = process_one_isolated(hit, pool)
+                    writer.writerow(row)
+                    outf.flush()
+                    n_done += 1
+                    print(f"  [{row['flag']:18}] {hit.title[:70]}", flush=True)
+                    if n_done >= limit:
+                        capped = True
+                        break
+                if capped:
+                    break
+            if not capped:
+                terms_fully_covered += 1
+            if capped:
+                print(f"\nHit --limit={limit}; stopping. Remaining terms picked up next run "
+                      f"(seen-DOI state persists).", flush=True)
+                break
+    finally:
+        pool.shutdown(wait=False)
+        outf.close()
+        append_seen_dois(newly_attempted)
+
+    print(f"\n{n_done} candidates triaged -> {out_path}")
+    print(f"{terms_fully_covered}/{len(terms)} terms fully covered this run")
+
+    _append_log_rows([{
+        "date": today,
+        "query": f"[{args.mode}] {len(terms)} terms x journals={','.join(journals)}",
+        "output_file": out_path,
+        "notes": f"plos monthly-script automated run; mode={args.mode}; "
+                 f"{n_done} candidates triaged; {terms_fully_covered}/{len(terms)} terms covered",
+    }])
+
+
+if __name__ == "__main__":
+    main()

--- a/automated_finding/irw_discover_pmc.py
+++ b/automated_finding/irw_discover_pmc.py
@@ -344,6 +344,37 @@ def _load_done_dois(path: str) -> set:
         return {row["doi"] for row in csv.DictReader(f) if row.get("doi")}
 
 
+# Permanent, cross-run record of every DOI this connector has ever triaged
+# -- shared by manual (`python irw_discover_pmc.py ...`) and scheduled
+# (irw_discover_pmc_monthly.py) invocations alike, so a term searched by
+# hand and the same term in the scheduled high-yield list don't
+# re-download and re-triage the same candidate. See irw_discover_plos.py's
+# identical SEEN_DOIS_PATH for the full rationale (same design, mirrored).
+SEEN_DOIS_PATH = "pmc_seen_dois.csv"
+
+
+def load_seen_dois(path: str = SEEN_DOIS_PATH) -> set:
+    import os
+    if not os.path.exists(path):
+        return set()
+    with open(path, newline="", encoding="utf-8") as f:
+        return {row["doi"] for row in csv.DictReader(f) if row.get("doi")}
+
+
+def append_seen_dois(dois, path: str = SEEN_DOIS_PATH) -> None:
+    import os
+    from datetime import datetime, timezone
+    if not dois:
+        return
+    file_exists = os.path.exists(path)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    with open(path, "a", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["doi", "date"])
+        if not file_exists:
+            writer.writeheader()
+        writer.writerows({"doi": d, "date": today} for d in dois)
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("queries", nargs="*", default=["item response theory"])
@@ -356,6 +387,10 @@ def main():
     ap.add_argument("--journals", default=DEFAULT_JOURNALS,
                     help="comma-separated journal slugs to search, from: "
                          f"{', '.join(JOURNALS)} (default: all)")
+    ap.add_argument("--ignore-seen-dois", action="store_true",
+                    help=f"don't consult/update {SEEN_DOIS_PATH} (the cross-run dedup "
+                         "store shared with irw_discover_pmc_monthly.py) -- use to "
+                         "deliberately re-triage a DOI, e.g. after a script fix")
     args = ap.parse_args()
 
     journals = [j.strip() for j in args.journals.split(",") if j.strip()]
@@ -364,11 +399,17 @@ def main():
         raise SystemExit(f"Unknown journal slug(s): {bad}. Choose from: {list(JOURNALS)}")
 
     exclude = _load_auto_exclusions()
-    print(f"Excluding {len(exclude):,} DOIs already in the IRW dictionary\n")
+    print(f"Excluding {len(exclude):,} DOIs already in the IRW dictionary")
+
+    global_seen = set() if args.ignore_seen_dois else load_seen_dois()
+    if global_seen:
+        print(f"Excluding {len(global_seen):,} DOIs already triaged in a prior run "
+              f"(manual or scheduled -- see {SEEN_DOIS_PATH})")
 
     already_done = _load_done_dois(args.out) if args.resume else set()
     if already_done:
-        print(f"Resuming: {len(already_done)} DOIs already in {args.out}, skipping them\n")
+        print(f"Resuming: {len(already_done)} DOIs already in {args.out}, skipping them")
+    print()
 
     outf = open(args.out, "a" if args.resume and already_done else "w",
                 newline="", encoding="utf-8")
@@ -377,6 +418,7 @@ def main():
         writer.writeheader()
 
     seen = set(already_done)
+    newly_seen = []
     n_done = 0
     pool = _new_pool()
     try:
@@ -384,9 +426,10 @@ def main():
             for q in args.queries:
                 print(f"[{journal}] [query] {q}", flush=True)
                 for hit in from_pmc(q, journal):
-                    if hit.doi in seen or hit.doi in exclude:
+                    if hit.doi in seen or hit.doi in exclude or hit.doi in global_seen:
                         continue
                     seen.add(hit.doi)
+                    newly_seen.append(hit.doi)
                     row, pool = process_one_isolated(hit, pool)
                     writer.writerow(row)
                     outf.flush()
@@ -401,6 +444,8 @@ def main():
     finally:
         pool.shutdown(wait=False)
         outf.close()
+        if not args.ignore_seen_dois:
+            append_seen_dois(newly_seen)
 
     print(f"\n{n_done} candidates processed -> {args.out}")
 

--- a/automated_finding/irw_discover_pmc_monthly.py
+++ b/automated_finding/irw_discover_pmc_monthly.py
@@ -1,0 +1,172 @@
+"""
+irw_discover_pmc_monthly.py
+==============================
+Incremental scheduled discovery+triage for irw_discover_pmc.py. Same shape
+and rationale as irw_discover_plos_monthly.py -- see that file's module
+docstring for the full explanation of why incrementality here is a
+persistent seen-DOI store (pmc_seen_dois.csv, shared with manual
+irw_discover_pmc.py runs) rather than a --since date filter: Europe PMC's
+search endpoint has no date-range parameter wired up here either.
+
+  --mode weekly  a small, proven-high-yield term subset (HIGH_YIELD_TERMS),
+                 run every week across the JOURNALS list.
+  --mode full    the same broad ~100-term construct list irw_discover_monthly.py
+                 uses for the repo connector (imported from there, not
+                 duplicated here), run monthly.
+
+--limit bounds each run's total triaged-candidate count for the same
+rate-limit/runtime reasons as the PLOS version.
+
+Run:
+    python irw_discover_pmc_monthly.py --mode weekly
+    python irw_discover_pmc_monthly.py --mode full --limit 150
+    python irw_discover_pmc_monthly.py --mode weekly --dry-run
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import argparse
+from datetime import datetime, timezone
+
+from irw_discover_updated import _load_auto_exclusions
+from irw_discover_pmc import (
+    from_pmc, process_one_isolated, _new_pool, JOURNALS, DEFAULT_JOURNALS,
+    FIELDNAMES, SEEN_DOIS_PATH, load_seen_dois, append_seen_dois,
+)
+from irw_discover_monthly import TERM_LIST as FULL_TERM_LIST
+
+LOG_PATH = "search_terms_log.csv"
+OUT_PREFIX = "pmc_monthly_candidates_"
+
+# Same shortlist as irw_discover_plos_monthly.py's HIGH_YIELD_TERMS --
+# proven-yield constructs, kept identical across connectors on purpose
+# since the yield signal is about the construct, not the source. Edit
+# freely as per-source yield data comes in; they don't need to stay in
+# sync going forward.
+HIGH_YIELD_TERMS = [
+    "self-esteem",
+    "grit",
+    "self-efficacy",
+    "depression",
+    "anxiety",
+    "burnout",
+    "perceived stress",
+    "well-being",
+    "life satisfaction",
+    "loneliness",
+    "academic motivation",
+    "work engagement",
+    "resilience",
+    "procrastination",
+    "growth mindset",
+]
+
+DEFAULT_LIMIT_BY_MODE = {"weekly": 60, "full": 150}
+
+
+def _append_log_rows(rows: list[dict], path: str = LOG_PATH) -> None:
+    fieldnames = ["date", "query", "output_file", "notes"]
+    file_exists = os.path.exists(path)
+    with open(path, "a", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        if not file_exists:
+            writer.writeheader()
+        writer.writerows(rows)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=["weekly", "full"], default="weekly")
+    ap.add_argument("--journals", default=DEFAULT_JOURNALS,
+                     help="comma-separated journal slugs to search, from: "
+                          f"{', '.join(JOURNALS)} (default: all)")
+    ap.add_argument("--limit", type=int, default=None,
+                     help="cap total candidates triaged this run "
+                          f"(default: weekly={DEFAULT_LIMIT_BY_MODE['weekly']}, "
+                          f"full={DEFAULT_LIMIT_BY_MODE['full']})")
+    ap.add_argument("--out", default=None,
+                     help=f"output CSV (default: {OUT_PREFIX}<mode>_<today>.csv)")
+    ap.add_argument("--dry-run", action="store_true",
+                     help="print term/journal counts and seen-DOI store size, no queries run")
+    args = ap.parse_args()
+
+    journals = [j.strip() for j in args.journals.split(",") if j.strip()]
+    bad = [j for j in journals if j not in JOURNALS]
+    if bad:
+        raise SystemExit(f"Unknown journal slug(s): {bad}. Choose from: {list(JOURNALS)}")
+
+    terms = HIGH_YIELD_TERMS if args.mode == "weekly" else FULL_TERM_LIST
+    limit = args.limit if args.limit is not None else DEFAULT_LIMIT_BY_MODE[args.mode]
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    seen = load_seen_dois()
+
+    if args.dry_run:
+        print(f"Mode: {args.mode} ({len(terms)} terms) x journals: {', '.join(journals)}")
+        print(f"Seen-DOI store ({SEEN_DOIS_PATH}): {len(seen):,} DOIs already attempted "
+              f"by any manual or scheduled run (never re-triaged)")
+        print(f"Limit this run: {limit}")
+        return
+
+    exclude = _load_auto_exclusions()
+    print(f"Excluding {len(exclude):,} DOIs already in the IRW dictionary")
+    print(f"Excluding {len(seen):,} DOIs already triaged in a prior run "
+          f"(manual or scheduled -- see {SEEN_DOIS_PATH})")
+
+    out_path = args.out or f"{OUT_PREFIX}{args.mode}_{today}.csv"
+    outf = open(out_path, "w", newline="", encoding="utf-8")
+    writer = csv.DictWriter(outf, fieldnames=FIELDNAMES, extrasaction="ignore")
+    writer.writeheader()
+
+    skip = seen | exclude
+    newly_attempted = []
+    n_done = 0
+    terms_fully_covered = 0
+    pool = _new_pool()
+    capped = False
+    try:
+        for term in terms:
+            print(f"\n[term] {term!r}", flush=True)
+            for journal in journals:
+                for hit in from_pmc(term, journal):
+                    if hit.doi in skip:
+                        continue
+                    skip.add(hit.doi)
+                    newly_attempted.append(hit.doi)
+                    row, pool = process_one_isolated(hit, pool)
+                    writer.writerow(row)
+                    outf.flush()
+                    n_done += 1
+                    print(f"  [{row['flag']:18}] {hit.title[:70]}", flush=True)
+                    if n_done >= limit:
+                        capped = True
+                        break
+                if capped:
+                    break
+            if not capped:
+                terms_fully_covered += 1
+            if capped:
+                print(f"\nHit --limit={limit}; stopping. Remaining terms picked up next run "
+                      f"(seen-DOI state persists).", flush=True)
+                break
+    finally:
+        pool.shutdown(wait=False)
+        outf.close()
+        append_seen_dois(newly_attempted)
+
+    print(f"\n{n_done} candidates triaged -> {out_path}")
+    print(f"{terms_fully_covered}/{len(terms)} terms fully covered this run")
+
+    _append_log_rows([{
+        "date": today,
+        "query": f"[{args.mode}] {len(terms)} terms x journals={','.join(journals)}",
+        "output_file": out_path,
+        "notes": f"pmc monthly-script automated run; mode={args.mode}; "
+                 f"{n_done} candidates triaged; {terms_fully_covered}/{len(terms)} terms covered",
+    }])
+
+
+if __name__ == "__main__":
+    main()

--- a/automated_finding/irw_discover_updated.py
+++ b/automated_finding/irw_discover_updated.py
@@ -37,7 +37,7 @@ from dataclasses import dataclass, asdict
 
 import requests
 
-UA = {"User-Agent": "irw-discovery-scout/1.0 (research; contact your-email)"}
+UA = {"User-Agent": "irw-discovery-scout/1.0 (research; contact itemresponsewarehouse@stanford.edu)"}
 
 # ---------------------------------------------------------------------------
 # RELEVANCE FILTER (tiered)


### PR DESCRIPTION
## Summary
- Adds `irw_discover_plos_monthly.py` / `irw_discover_pmc_monthly.py`, mirroring `irw_discover_monthly.py`'s incremental design, to support scheduling PLOS and PMC discovery+triage the same way the repos connector already is.
- Adds a persistent, cross-run seen-DOI/seen-key store shared between manual and scheduled invocations for all three connectors (`plos_seen_dois.csv`, `pmc_seen_dois.csv`, `repo_triage_seen_keys.csv`), so a term searched by hand and the same term in a scheduled run don't re-download/re-triage the same candidate.
- Adds `--mode {weekly,full}` to `irw_discover_monthly.py` (default `full`, unchanged behavior) so the repos connector can also run a small proven-yield term subset on a tighter cadence.
- Fixes the `User-Agent` contact email placeholder (`your-email`) to `itemresponsewarehouse@stanford.edu` across all four discovery/triage scripts — needed before any of this runs unattended on a schedule.

This is prep for wiring up 6 cloud routines (monthly full-sweep + weekly high-yield, per source) — none of the new scheduling itself is in this PR, just the underlying script support.

## Test plan
- [x] `python3 -c "import ast; ..."` syntax-checks all touched/new files
- [x] `python3 irw_discover_monthly.py --mode weekly --dry-run` — confirms mode selection and since-date lookup work
- [x] `python3 irw_discover_plos_monthly.py --mode weekly --dry-run` / `irw_discover_pmc_monthly.py --mode weekly --dry-run` — confirms imports resolve and seen-DOI store loads
- [ ] Ben: spot-check a small manual `--limit` run of each script against live APIs before the cloud routines go live

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hjps4gNNusUycGcY43L7Mu