### PR TITLE
Add PII skip-entirely policy; ship 6 papers -> 17 tables from PMC connector + PLOS batches

### DIFF
--- a/automated_finding/.claude/skills/irw-automated-finding/SKILL.md
+++ b/automated_finding/.claude/skills/irw-automated-finding/SKILL.md
@@ -235,6 +235,29 @@ One additional hard rule applies at this stage that isn't in
 `datastandard.md`, because it's a pipeline/triage concern rather than an
 output-format one:
 
+- **PII in the raw source file — skip the dataset entirely, don't
+  scrub-and-ship.** `datastandard.md`'s "no PII" checklist item is phrased
+  as "don't include it in the output," which reads as permission to drop
+  the offending column(s) and process the rest. That's not the policy for
+  this pipeline: if the raw supplementary file contains real names,
+  emails, birthdates, IP/GPS, or national ID numbers *anywhere* — even in
+  a column that would never be selected as an item or covariate — treat
+  the whole candidate as skip, the same tier as an unresolvable license,
+  not a fixable QC warning. Decided 2026-08-12 after two PMC-connector
+  candidates surfaced real PII (a participant email column on a study of
+  LGB medical students' mental health — skipped outright given the
+  compounding sensitivity of email + stigmatized-identity data on a
+  narrow population; a real `date of birth` column on an otherwise
+  unremarkable nursing-profession opinion survey — also skipped, even
+  though that case looked "lower severity" and the standard fix would
+  have just been dropping one column). The point of a blanket rule is to
+  not re-litigate severity per candidate — a source file containing PII at
+  all is reason enough to skip, regardless of how contained the fix would
+  otherwise look. Log the skip in `BATCH_LOG.md` with what the PII was and
+  why, same as a license-blocked candidate, but there is no
+  `pii_blocked_candidates.csv` standing file — unlike a license issue,
+  there's no path to later un-blocking a PII-flagged candidate, so nothing
+  needs to persist past the batch writeup.
 - **License.** Only proceed if the license is explicitly verified as open
   (`cc0`, `cc-by`, `cc-by-sa`, or equivalent) on the source page itself. A
   triage `license` of `unknown` does not count as verified — skip. A bare

--- a/automated_finding/BATCH_LOG.md
+++ b/automated_finding/BATCH_LOG.md
@@ -7486,3 +7486,170 @@ tables), `han_2015_peer_assisted_learning.py`,
 `he_2019_flipped_classroom.py` (2 tables), `theobald_2017_group_dynamics.py`.
 `human_review_plos_batch25.csv` (87 rows, from `irw_retriage_ha.py`)
 staged for the "Human eye" sheet.
+
+## Europe-PMC connector batch 1 (2026-08-12)
+
+First real batch run of `irw_discover_pmc.py` (mode 2), the new
+Europe-PMC-based multi-journal connector added this session (see
+`journal_scout/journal_yield_summary.md` for how the 11-journal
+`JOURNALS` list was chosen, and the SKILL.md "Europe-PMC-based
+multi-journal search" section for how the connector works).
+
+**Term selection**: recycled 10 terms already validated against PLOS ONE
+from `search_terms_log.csv` (per the "Term selection" rule in that mode's
+SKILL.md section — a term proven to surface real candidates elsewhere is
+worth trying on a new search surface before inventing new ones): Rosenberg
+self-esteem scale, Perceived Stress Scale, Satisfaction with Life Scale,
+Ten Item Personality Inventory, State-Trait Anxiety Inventory, Pittsburgh
+Sleep Quality Index, Raven's Progressive Matrices, Self-Compassion Scale,
+PANAS, Strengths and Difficulties Questionnaire. Run against all 11
+journals in `JOURNALS` (PLOS excluded by design — stays on
+`irw_discover_plos.py`).
+
+**Result**: 888 candidates processed (`pmc_batch1_triage.csv`), 0
+crashed/timeout. Flags: 466 `no_usable_file`, 274 `license_restricted`,
+117 `human_assistance`, 13 `not_item_response`, 7 `good`, 6 `error`, 4
+`download_failed`, 1 `file_too_large`. Two journals (Multivariate
+Behavioral Research, Applied Psychological Measurement) returned zero
+candidates for these terms — consistent with `journal_scout`'s finding
+that both are very low-volume in Europe PMC, not a bug. PeerJ's `good`
+rate (5/160 ≈ 3.1%) came in well above the ~1% PLOS ONE baseline, matching
+`journal_scout`'s prediction that PeerJ would outperform PLOS ONE on
+data-like supplementary yield.
+
+**Manual review of all 7 `good` candidates** (a `good` flag here needs a
+human glance more than usual — same caution as the PLOS pipeline, since
+`irw_discover_pmc.py` also only inspects the first tabular file in the
+archive, not the whole manifest):
+
+- **Rejected, false positive — PCIQ-F** (`10.1186/s12874-021-01376-w`,
+  bmcmrm): the auto-picked file is an item-development/face-validity
+  review table (panel clarity/importance ratings + an editorial "decision
+  taken" column like "Rewritten"), not respondent-level item responses.
+- **Rejected, false positive — cannabis anxiety/depression**
+  (`10.7717/peerj.2782`, peerj): despite the title, the auto-picked file
+  is a substance-use/exclusion-screening form (caffeine/alcohol/
+  tobacco/cannabis use in the last 8/24h, psychiatric history) — not the
+  actual anxiety/depression scale. No other tabular file exists in the
+  archive to recover the real scale data from.
+- **Shipped as-is (2)**: PANAS fibromyalgia and Maslach Burnout
+  Inventory-Student Survey — both clean single-instrument files, no
+  covariate/item mixups.
+- **Shipped after manual re-work (3 papers -> 9 tables)**: Hospice
+  Comfort Questionnaire (auto-picked file was a strict subset of a richer
+  file with 12 additional covariates — used the richer one instead);
+  Cloninger personality study (one file bundled 4 distinct instruments —
+  TCI, SWLS, PANAS, a Social Support scale — split into 4 tables per
+  datastandard.md's one-scale-per-file rule); spinal cord injury QoL (one
+  file bundled WHOQOL-BREF + SWLS + 13 demographic/clinical covariates the
+  auto-triage had counted as items — split into 2 tables, covariates moved
+  out). All three needed the file/column-level review that `good` alone
+  doesn't guarantee — see each script's QC-note comment for specifics.
+
+Every response scale was verified per-item (not merged min/max) with no
+values isolated to a single item, and confirmed as pure integers (no
+imputation artifacts) before shipping. License confirmed CC BY 4.0 on all
+5 papers via Europe PMC's own `license` field (not scraped HTML).
+
+**Result: 5 papers -> 11 tables** (`biblio_pmc_batch1.csv`, 11 rows), all
+CC BY 4.0, all N>=189. Scripts in `data/`: `estevezlopez_2016_panas.py`,
+`lopezgomez_2025_mbi_ss.py` (3 tables), `xu_2025_hcq_p.py`,
+`lee_2024_cloninger.py` (4 tables), `altahla_2024_sci_qol.py` (2 tables).
+
+### PMC connector batch 1 — retriage of the 117 `human_assistance` rows (2026-08-12)
+
+`pmc_batch1_triage.csv` was deleted after the `good` rows above were
+captured, per the normal end-of-batch cleanup — but that meant its 117
+`human_assistance` rows never got the `irw_retriage_ha.py` (Step 2b) pass
+the PLOS pipeline does routinely. Regenerated the triage CSV by rerunning
+the same 10 terms from batch 1 (887 candidates this time vs 888 — one row
+came back `timeout` instead of clean, otherwise an exact match including
+the same 7 `good` hits) and ran `irw_retriage_ha.py` on it.
+
+**Retriage result** (117 rows): 20 `not_item_response` (drop), 33
+`aggregate_continuous` (drop), 33 `human_review` (genuinely ambiguous —
+written to `human_review_pmc_batch1.csv`, staged for the "Human eye"
+sheet), 31 `worth_retrying` (plausible data worth a second look — see
+open `TODO.md` item). 31/888 ≈ 3.5%, in line with the ~2-4% additional
+yield this step recovers on PLOS batches.
+
+### PMC connector batch 2 + PLOS ONE batch 26 (2026-08-12)
+
+Two more discovery runs kicked off in parallel — Europe PMC (mode 2) and
+PLOS (mode 1) hit different domains (`www.ebi.ac.uk` vs
+`api.plos.org`/`journals.plos.org`), so `polite_get`'s per-domain rate
+limiter doesn't create any contention between them.
+
+- **PMC connector batch 2** (`pmc_batch2_triage.csv`): 10 more terms
+  recycled from the PLOS-validated pool in `search_terms_log.csv`:
+  Warwick-Edinburgh Mental Wellbeing Scale, Yale Food Addiction Scale,
+  Yale-Brown Obsessive Compulsive Scale, Wisconsin Card Sorting Task,
+  Zimbardo Time Perspective Inventory, body image, attachment style,
+  burnout, alexithymia, career decision making. Run against all 11
+  `JOURNALS`.
+- **PLOS ONE batch 26** (`plos_batch26_triage.csv`): 10 terms recycled
+  from the repo-connector-validated pool (not yet run against PLOS):
+  UCLA Loneliness Scale, resilience scale, narcissism scale, gratitude
+  scale, mindfulness scale, rumination scale, empathy scale, aggression
+  scale, creativity scale, religiosity scale. Run against
+  `plosone,mentalhealth,globalpublichealth`.
+
+### PLOS ONE batch 26 — result (2026-08-12)
+
+497 candidates processed. Flags: 381 `no_usable_file`, 107
+`human_assistance`, 6 `not_item_response`, 1 `error`, 1 `download_failed`,
+1 `good`.
+
+**The 1 `good` candidate was reviewed and skipped, not shipped**:
+"Mental health in gay, lesbian and bisexual medical students"
+(`10.1371/journal.pmen.0000108`, PLOS Mental Health, N=404). The
+supplementary file has a literal `Endereço de e-mail` (Portuguese for
+"Email address") column — real participant emails attached to detailed
+psychological data (Beck Depression Inventory, STAI, an internalized-
+homophobia/sexual-identity scale, a resilience scale, a QoL scale) for a
+small, narrow population (LGB medical students, likely one institution).
+A hard PII violation under `datastandard.md`'s checklist regardless of the
+paper's own CC BY license, and the combination of identity + mental-health
+data + a narrow population is a re-identification risk that goes beyond
+"just drop the email column" — skipped entirely per ben-domingue's
+decision (2026-08-12), not processed further. (Also, independent of the
+PII issue: the file bundles ~6 distinct instruments across 206 columns
+with conditional gay/lesbian-vs-bisexual branching, so this would have
+been a substantial multi-table split even without the PII problem.)
+
+107 `human_assistance` rows not yet retriaged (open item, see `TODO.md`).
+
+Both this batch and PMC connector batch 2 (previous entry) hit different
+domains, confirmed no rate-limit contention running concurrently.
+
+### PMC connector batch 2 — result (2026-08-12)
+
+412 candidates processed. Flags: 234 `no_usable_file`, 126
+`license_restricted`, 43 `human_assistance`, 6 `not_item_response`, 2
+`good`, 1 `download_failed`.
+
+**New standing policy, decided this batch**: any PII in a raw source file
+now means skip the whole candidate, not scrub-and-ship the offending
+column. See the new hard rule in this file's SKILL.md Step 4 and
+`feedback_pii_skip_entirely` in auto-memory. Applied to both `good`
+candidates below:
+
+- **Skipped — nursing profession social-representation survey**
+  (`10.7717/peerj.13903`, peerj, N=141, 48 items): raw file has a real
+  `date of birth` column (actual birthdates, e.g. `1995-05-04`, not just
+  birth years) plus a couple of open-text "please specify who" columns.
+  On its own this would have been a routine fix (drop the DOB column, ship
+  the rest — the 48 opinion items themselves are not sensitive), but per
+  the new blanket policy it's skipped outright rather than re-litigated as
+  "low severity."
+- **Shipped — AI computing leasing adoption survey**
+  (`10.1016/j.heliyon.2024.e36620`, heliyon, N=281): clean, no PII,
+  sequential `NO` id. 18 items split into 6 three-item constructs
+  (innovation, risk, performance expectancy, price value,
+  task-technology fit, usage), 1-7 scale, matching the `multi_scale*`
+  flag. See `data/` script below for the split.
+
+**Result: 1 paper -> 6 tables** (`biblio_pmc_batch2.csv`, 6 rows). Script:
+`data/sun_2024_ai_leasing_adoption.py`.
+
+43 `human_assistance` rows not yet retriaged (open item, see `TODO.md`).

--- a/automated_finding/TODO.md
+++ b/automated_finding/TODO.md
@@ -3,6 +3,52 @@
 Currently open action items only. For the full batch-by-batch history and
 context behind these (and everything already resolved), see `BATCH_LOG.md`.
 
+- [x] **`automated_finding/biblio_pmc_batch1.csv`** (11 rows, 5 papers ->
+  11 tables, from the first real `irw_discover_pmc.py` batch, 2026-08-12)
+  uploaded to Redivis and pasted into the dictionary sheet (confirmed
+  2026-08-12, ben-domingue); file and all 11 `irw_output/*.csv` files gone
+  from disk as expected. See `BATCH_LOG.md`'s "Europe-PMC connector batch
+  1" entry for full per-paper detail, including the two rejected false
+  positives (PCIQ-F, cannabis anxiety/depression) and the three
+  multi-scale-split papers (Hospice Comfort Questionnaire, Cloninger
+  personality study, spinal cord injury QoL). MBI-SS response scale
+  (0=never..6=always) confirmed against the paper's own Methods text,
+  2026-08-12 — not a missingness sentinel.
+
+- [ ] **`automated_finding/human_review_pmc_batch1.csv`** (33 rows, PMC
+  connector batch 1's `human_review` rows from `irw_retriage_ha.py`,
+  2026-08-12) needs to be pasted into the "Human eye" sheet.
+
+- [ ] **PMC connector batch 1 — 31 `worth_retrying` rows from
+  `irw_retriage_ha.py` not yet reviewed** (2026-08-12): plausible data
+  worth a second look — mostly text-coded Likert responses needing
+  decoding, low-confidence id-column mappings needing a manual check, or
+  apparent longitudinal/repeated-measures duplicates needing a `wave`
+  column. See `pmc_batch1_retriage.csv`'s `worth_retrying` rows (kept on
+  disk, not deleted, since this item is still open) for the full list with
+  URLs and per-row reasoning.
+
+- [x] **PLOS ONE batch 26** (2026-08-12, `plos_batch26_triage.csv`, 497
+  candidates): its 1 `good` candidate (LGB medical students mental health
+  study) was reviewed and skipped — real participant email addresses in
+  the supplementary file, a hard PII violation regardless of the paper's
+  CC BY license. See `BATCH_LOG.md`'s "PLOS ONE batch 26" entry.
+
+- [ ] **PLOS ONE batch 26 — 107 `human_assistance` rows not yet
+  retriaged** (2026-08-12). `plos_batch26_triage.csv` kept on disk for
+  this.
+
+- [x] **`automated_finding/biblio_pmc_batch2.csv`** (6 rows, 1 paper -> 6
+  tables, from PMC connector batch 2, 2026-08-12) uploaded to Redivis and
+  pasted into the dictionary sheet (confirmed 2026-08-12, ben-domingue);
+  file and all 6 `irw_output/sun_2024_*.csv` files gone from disk as
+  expected. See `BATCH_LOG.md`'s "PMC connector batch 2 — result" entry.
+  Its other `good` candidate (nursing profession survey) was skipped per
+  the new PII policy (real `date of birth` column).
+
+- [ ] **PMC connector batch 2 — 43 `human_assistance` rows not yet
+  retriaged** (2026-08-12). `pmc_batch2_triage.csv` kept on disk for this.
+
 - [x] **`automated_finding/biblio_plos_batch25.csv`** (23 rows, 6 papers ->
   23 tables, from PLOS ONE batch 25's `good` (3 fresh) + `worth_retrying`
   (4 fresh) pool, 2026-08-11) uploaded to Redivis and pasted into the

--- a/automated_finding/search_terms_log.csv
+++ b/automated_finding/search_terms_log.csv
@@ -3171,3 +3171,33 @@ date,query,output_file,notes
 2026-08-11,work meaningfulness,plos_batch25_triage.csv,PLOS batch 25 - recycled non-PLOS English term
 2026-08-11,turnover intention,plos_batch25_triage.csv,PLOS batch 25 - recycled non-PLOS English term
 2026-08-11,ethical leadership,plos_batch25_triage.csv,PLOS batch 25 - recycled non-PLOS English term
+2026-08-12,Rosenberg self-esteem scale,pmc_batch1_triage.csv,PMC connector batch 1 - recycled PLOS-validated term
+2026-08-12,Perceived Stress Scale,pmc_batch1_triage.csv,PMC connector batch 1 - recycled PLOS-validated term
+2026-08-12,Satisfaction with Life Scale,pmc_batch1_triage.csv,PMC connector batch 1 - recycled PLOS-validated term
+2026-08-12,Ten Item Personality Inventory,pmc_batch1_triage.csv,PMC connector batch 1 - recycled PLOS-validated term
+2026-08-12,State-Trait Anxiety Inventory,pmc_batch1_triage.csv,PMC connector batch 1 - recycled PLOS-validated term
+2026-08-12,Pittsburgh Sleep Quality Index,pmc_batch1_triage.csv,PMC connector batch 1 - recycled PLOS-validated term
+2026-08-12,Raven's Progressive Matrices,pmc_batch1_triage.csv,PMC connector batch 1 - recycled PLOS-validated term
+2026-08-12,Self-Compassion Scale,pmc_batch1_triage.csv,PMC connector batch 1 - recycled PLOS-validated term
+2026-08-12,PANAS,pmc_batch1_triage.csv,PMC connector batch 1 - recycled PLOS-validated term
+2026-08-12,Strengths and Difficulties Questionnaire,pmc_batch1_triage.csv,PMC connector batch 1 - recycled PLOS-validated term
+2026-08-12,Warwick-Edinburgh Mental Wellbeing Scale,pmc_batch2_triage.csv,PMC connector batch 2 - recycled PLOS-validated term
+2026-08-12,Yale Food Addiction Scale,pmc_batch2_triage.csv,PMC connector batch 2 - recycled PLOS-validated term
+2026-08-12,Yale-Brown Obsessive Compulsive Scale,pmc_batch2_triage.csv,PMC connector batch 2 - recycled PLOS-validated term
+2026-08-12,Wisconsin Card Sorting Task,pmc_batch2_triage.csv,PMC connector batch 2 - recycled PLOS-validated term
+2026-08-12,Zimbardo Time Perspective Inventory,pmc_batch2_triage.csv,PMC connector batch 2 - recycled PLOS-validated term
+2026-08-12,body image,pmc_batch2_triage.csv,PMC connector batch 2 - recycled PLOS-validated term
+2026-08-12,attachment style,pmc_batch2_triage.csv,PMC connector batch 2 - recycled PLOS-validated term
+2026-08-12,burnout,pmc_batch2_triage.csv,PMC connector batch 2 - recycled PLOS-validated term
+2026-08-12,alexithymia,pmc_batch2_triage.csv,PMC connector batch 2 - recycled PLOS-validated term
+2026-08-12,career decision making,pmc_batch2_triage.csv,PMC connector batch 2 - recycled PLOS-validated term
+2026-08-12,UCLA Loneliness Scale,plos_batch26_triage.csv,PLOS batch 26 - recycled non-PLOS English term
+2026-08-12,resilience scale,plos_batch26_triage.csv,PLOS batch 26 - recycled non-PLOS English term
+2026-08-12,narcissism scale,plos_batch26_triage.csv,PLOS batch 26 - recycled non-PLOS English term
+2026-08-12,gratitude scale,plos_batch26_triage.csv,PLOS batch 26 - recycled non-PLOS English term
+2026-08-12,mindfulness scale,plos_batch26_triage.csv,PLOS batch 26 - recycled non-PLOS English term
+2026-08-12,rumination scale,plos_batch26_triage.csv,PLOS batch 26 - recycled non-PLOS English term
+2026-08-12,empathy scale,plos_batch26_triage.csv,PLOS batch 26 - recycled non-PLOS English term
+2026-08-12,aggression scale,plos_batch26_triage.csv,PLOS batch 26 - recycled non-PLOS English term
+2026-08-12,creativity scale,plos_batch26_triage.csv,PLOS batch 26 - recycled non-PLOS English term
+2026-08-12,religiosity scale,plos_batch26_triage.csv,PLOS batch 26 - recycled non-PLOS English term

--- a/data/altahla_2024_sci_qol.py
+++ b/data/altahla_2024_sci_qol.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Source: https://peerj.com/articles/18709/ (PMC11670754)
+# DOI: 10.7717/peerj.18709
+#
+# Altahla et al. (2024), "Quality of life and subjective well-being
+# comparison between traumatic, nontraumatic chronic spinal cord injury,
+# and healthy individuals in China." PeerJ. CC BY 4.0. N=189. Found via
+# irw_discover_pmc.py (Europe PMC "Satisfaction with Life Scale" query
+# against PeerJ).
+#
+# QC note: the single supplementary file bundles WHOQOL-BREF (26 items,
+# verbatim item wording, 1-5 scale) and the Satisfaction with Life Scale
+# (5 items, verbatim wording, 1-7 scale) back-to-back in one sheet, plus
+# 13 demographic/clinical columns that irw_discover_pmc.py's auto-triage
+# counted as items rather than covariates -- split into 2 IRW files here
+# per datastandard.md's one-scale-per-file rule, with the 13 columns moved
+# to cov_*. Item columns use the source's own verbatim question text as
+# header, which is why they're renamed here to whoqol_N / swls_N
+# (sequential, in the source's own item order) rather than kept verbatim
+# -- full sentences make poor item identifiers.
+
+import io
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OUT_DIR = REPO_ROOT / "automated_finding" / "irw_output"
+
+SUPPL_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/PMC11670754/supplementaryFiles"
+MEMBER = "peerj-12-18709-s001.xlsx"
+UA = {"User-Agent": "IRW-Finder/1.0 (ben.domingue@gmail.com)"}
+
+COV_RENAME = {
+    "cov_1": "cov_gender",
+    "cov_2": "cov_married",
+    "cov_3": "cov_age_group",
+    "cov_4": "cov_education",
+    "cov_5": "cov_employed",
+    "cov_6": "cov_injury_duration",
+    "cov_7": "cov_age_at_injury",
+    "cov_8": "cov_injury_type",
+    "cov_9": "cov_ais_severity",
+    "cov_10": "cov_injury_level",
+    "cov_11": "cov_paralysis_type",
+    "cov_12": "cov_injury_cause",
+    "cov_13": "cov_injury_state",
+}
+
+
+def convert():
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    r = requests.get(SUPPL_URL, headers=UA, timeout=120)
+    r.raise_for_status()
+    zf = zipfile.ZipFile(io.BytesIO(r.content))
+    df = pd.read_excel(io.BytesIO(zf.read(MEMBER)))
+
+    cols = list(df.columns)
+    id_col, whoqol_cols, swls_cols, cov_source_cols = (
+        cols[0], cols[1:27], cols[27:32], cols[32:45])
+    assert len(whoqol_cols) == 26 and len(swls_cols) == 5 and len(cov_source_cols) == 13
+
+    df = df.rename(columns={id_col: "id"})
+    df = df.rename(columns={c: f"cov_{i+1}" for i, c in enumerate(cov_source_cols)})
+    df = df.rename(columns=COV_RENAME)
+    cov_cols = list(COV_RENAME.values())
+    for c in cov_cols:
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+
+    scales = {
+        "altahla_2024_whoqol_bref": {c: f"whoqol_{i+1}" for i, c in enumerate(whoqol_cols)},
+        "altahla_2024_swls": {c: f"swls_{i+1}" for i, c in enumerate(swls_cols)},
+    }
+
+    for out_name, item_rename in scales.items():
+        d = df.rename(columns=item_rename)
+        item_cols = list(item_rename.values())
+        long = d.melt(id_vars=["id"] + cov_cols, value_vars=item_cols,
+                       var_name="item", value_name="resp")
+        long["resp"] = pd.to_numeric(long["resp"], errors="coerce")
+        long = long.dropna(subset=["resp"]).reset_index(drop=True)
+        long = long[["id", "item", "resp"] + cov_cols]
+
+        out_path = OUT_DIR / f"{out_name}.csv"
+        long.to_csv(out_path, index=False)
+        print(f"{out_name}: rows={len(long)} ids={long['id'].nunique()} "
+              f"items={long['item'].nunique()} resp={long['resp'].min():.0f}-{long['resp'].max():.0f}")
+
+
+if __name__ == "__main__":
+    convert()

--- a/data/estevezlopez_2016_panas.py
+++ b/data/estevezlopez_2016_panas.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Source: https://peerj.com/articles/1822/ (PMC4817417)
+# DOI: 10.7717/peerj.1822
+#
+# Estevez-Lopez et al. (2016), "Factor structure of the Positive and
+# Negative Affect Schedule (PANAS) in adult women with fibromyalgia from
+# Southern Spain: the al-Andalus project." CC BY 4.0. N=442. Standard
+# 20-item PANAS, 5-point Likert (1-5). Found via irw_discover_pmc.py
+# (Europe PMC "PANAS" query against PeerJ); supplementary file fetched
+# through Europe PMC's supplementaryFiles endpoint (PMC4817417).
+
+import io
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OUT_DIR = REPO_ROOT / "automated_finding" / "irw_output"
+
+OUT_NAME = "estevezlopez_2016_panas"
+SUPPL_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/PMC4817417/supplementaryFiles"
+MEMBER = "peerj-04-1822-s001.xlsx"
+UA = {"User-Agent": "IRW-Finder/1.0 (ben.domingue@gmail.com)"}
+
+# Source columns are "1st_item".."20th_item" -- positional, not otherwise
+# meaningful -- renamed to a scale-specific sequential label.
+ITEM_COLS = [f"{n}{s}_item" for n, s in [
+    (1, "st"), (2, "nd"), (3, "rd")] + [(i, "th") for i in range(4, 21)]]
+
+
+def convert():
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    r = requests.get(SUPPL_URL, headers=UA, timeout=120)
+    r.raise_for_status()
+    zf = zipfile.ZipFile(io.BytesIO(r.content))
+    df = pd.read_excel(io.BytesIO(zf.read(MEMBER)))
+
+    df = df.rename(columns={"Participant": "id"})
+    rename_items = {c: f"panas_{i+1}" for i, c in enumerate(ITEM_COLS)}
+    df = df.rename(columns=rename_items)
+    item_cols = list(rename_items.values())
+
+    long = df.melt(id_vars=["id"], value_vars=item_cols,
+                    var_name="item", value_name="resp")
+    long["resp"] = pd.to_numeric(long["resp"], errors="coerce")
+    long = long.dropna(subset=["resp"]).reset_index(drop=True)
+    long = long[["id", "item", "resp"]]
+
+    out_path = OUT_DIR / f"{OUT_NAME}.csv"
+    long.to_csv(out_path, index=False)
+    print(f"{OUT_NAME}: rows={len(long)} ids={long['id'].nunique()} "
+          f"items={long['item'].nunique()} resp={long['resp'].min():.0f}-{long['resp'].max():.0f}")
+
+
+if __name__ == "__main__":
+    convert()

--- a/data/lee_2024_cloninger.py
+++ b/data/lee_2024_cloninger.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Source: https://peerj.com/articles/18379/ (PMC11566513)
+# DOI: 10.7717/peerj.18379
+#
+# Lee et al. (2024), "The associations between well-being and Cloninger's
+# personality dimensions in a Korean community sample." PeerJ. CC BY 4.0.
+# N=527. Found via irw_discover_pmc.py (Europe PMC "Satisfaction with Life
+# Scale" query against PeerJ).
+#
+# QC note: the single supplementary file bundles FOUR distinct instruments
+# in one sheet -- split here into 4 IRW files per datastandard.md's
+# one-scale-per-file rule, rather than shipped as one 193-item table (what
+# irw_discover_pmc.py's auto-triage originally flagged "good" on):
+#   - Cloninger's Temperament and Character Inventory (i1-i140, 0-4 scale)
+#   - Satisfaction with Life Scale (SWLS1-5, 1-7 scale)
+#   - PANAS (PANAS1-20, 1-5 scale)
+#   - a Social Support scale (Social Support_01-25, 1-5 scale)
+# A single "Subjective health" item and age/sex are carried as covariates
+# on every file rather than shipped as their own 1-item table (never ship
+# a table with only 1 distinct item).
+
+import io
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OUT_DIR = REPO_ROOT / "automated_finding" / "irw_output"
+
+SUPPL_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/PMC11566513/supplementaryFiles"
+MEMBER = "peerj-12-18379-s002.xlsx"
+UA = {"User-Agent": "IRW-Finder/1.0 (ben.domingue@gmail.com)"}
+
+COV_RENAME = {
+    "age": "cov_age",
+    "sex": "cov_gender",
+    "Subjective health": "cov_subjective_health",
+}
+
+
+def convert():
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    r = requests.get(SUPPL_URL, headers=UA, timeout=120)
+    r.raise_for_status()
+    zf = zipfile.ZipFile(io.BytesIO(r.content))
+    df = pd.read_excel(io.BytesIO(zf.read(MEMBER)))
+    df = df.rename(columns={"ID": "id", **COV_RENAME})
+    cov_cols = list(COV_RENAME.values())
+
+    scales = {
+        "lee_2024_tci": [c for c in df.columns if c.startswith("i") and c[1:].isdigit()],
+        "lee_2024_swls": [c for c in df.columns if c.startswith("SWLS")],
+        "lee_2024_panas": [c for c in df.columns if c.startswith("PANAS")],
+        "lee_2024_social_support": [c for c in df.columns if c.startswith("Social Support")],
+    }
+
+    for out_name, item_cols in scales.items():
+        long = df.melt(id_vars=["id"] + cov_cols, value_vars=item_cols,
+                        var_name="item", value_name="resp")
+        long["resp"] = pd.to_numeric(long["resp"], errors="coerce")
+        long = long.dropna(subset=["resp"]).reset_index(drop=True)
+        long = long[["id", "item", "resp"] + cov_cols]
+
+        out_path = OUT_DIR / f"{out_name}.csv"
+        long.to_csv(out_path, index=False)
+        print(f"{out_name}: rows={len(long)} ids={long['id'].nunique()} "
+              f"items={long['item'].nunique()} resp={long['resp'].min():.0f}-{long['resp'].max():.0f}")
+
+
+if __name__ == "__main__":
+    convert()

--- a/data/lopezgomez_2025_mbi_ss.py
+++ b/data/lopezgomez_2025_mbi_ss.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Source: https://www.nature.com/articles/s41598-024-84829-8 (PMC11729910)
+# DOI: 10.1038/s41598-024-84829-8
+#
+# Lopez-Gomez et al. (2025), "Psychometric study of the Maslach Burnout
+# Inventory-Student Survey on Thai university students." Scientific
+# Reports. CC BY 4.0. N=432. Standard MBI-SS, 15 items across its 3
+# canonical subscales, each treated as its own IRW file per
+# datastandard.md's "subscale treated as a distinct construct" rule:
+# Exhaustion (5 items), Cynicism (4 items), Professional Efficacy (6
+# items). All items share the same 0-6 frequency scale ("Never" to
+# "Every day"). Found via irw_discover_pmc.py (Europe PMC "Strengths and
+# Difficulties Questionnaire" query against Scientific Reports -- a
+# full-text match, not a title match; this paper isn't about the SDQ, the
+# term just appears somewhere in its body text); supplementary file
+# fetched through Europe PMC's supplementaryFiles endpoint (PMC11729910).
+
+import io
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OUT_DIR = REPO_ROOT / "automated_finding" / "irw_output"
+
+SUPPL_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/PMC11729910/supplementaryFiles"
+MEMBER = "41598_2024_84829_MOESM1_ESM.xlsx"
+UA = {"User-Agent": "IRW-Finder/1.0 (ben.domingue@gmail.com)"}
+
+SCALES = {
+    "lopezgomez_2025_mbi_exhaustion": ["EX1", "EX2", "EX3", "EX4", "EX5"],
+    "lopezgomez_2025_mbi_cynicism": ["CY1", "CY2", "CY3", "CY4"],
+    "lopezgomez_2025_mbi_efficacy": ["PE1", "PE2", "PE3", "PE4", "PE5", "PE6"],
+}
+
+
+def convert():
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    r = requests.get(SUPPL_URL, headers=UA, timeout=120)
+    r.raise_for_status()
+    zf = zipfile.ZipFile(io.BytesIO(r.content))
+    df = pd.read_excel(io.BytesIO(zf.read(MEMBER)))
+    df = df.rename(columns={"ID": "id"})
+
+    for out_name, item_cols in SCALES.items():
+        long = df.melt(id_vars=["id"], value_vars=item_cols,
+                        var_name="item", value_name="resp")
+        long["resp"] = pd.to_numeric(long["resp"], errors="coerce")
+        long = long.dropna(subset=["resp"]).reset_index(drop=True)
+        long = long[["id", "item", "resp"]]
+
+        out_path = OUT_DIR / f"{out_name}.csv"
+        long.to_csv(out_path, index=False)
+        print(f"{out_name}: rows={len(long)} ids={long['id'].nunique()} "
+              f"items={long['item'].nunique()} resp={long['resp'].min():.0f}-{long['resp'].max():.0f}")
+
+
+if __name__ == "__main__":
+    convert()

--- a/data/sun_2024_ai_leasing_adoption.py
+++ b/data/sun_2024_ai_leasing_adoption.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Source: https://www.sciencedirect.com/science/article/pii/S2405844024126514 (PMC11385760)
+# DOI: 10.1016/j.heliyon.2024.e36620
+#
+# Sun W, Tohirovich Dedahanov A, Li WP, Young Shin H. (2024). "Sanctions
+# and opportunities: Factors affecting China's high-tech SMEs adoption of
+# artificial intelligence computing leasing business." Heliyon. CC BY 4.0.
+# N=281. Found via irw_discover_pmc.py (Europe PMC "attachment style"
+# query against Heliyon -- a full-text match, not a title match).
+#
+# QC note: the single supplementary file bundles 6 distinct 3-item
+# constructs (a classic technology-adoption/UTAUT-style survey structure)
+# -- split here into 6 IRW files per datastandard.md's one-scale-per-file
+# rule, rather than shipped as one 18-item table. All 18 items share the
+# same 1-7 scale. No covariates or PII in the source file.
+
+import io
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OUT_DIR = REPO_ROOT / "automated_finding" / "irw_output"
+
+SUPPL_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/PMC11385760/supplementaryFiles"
+MEMBER = "mmc1.xlsx"
+UA = {"User-Agent": "IRW-Finder/1.0 (ben.domingue@gmail.com)"}
+
+SCALES = {
+    "sun_2024_innovation": ["innovation1", "innovation2", "innovation3"],
+    "sun_2024_risk": ["Risk1", "Risk2", "Risk3"],
+    "sun_2024_performance_expectancy": ["PerformanceE1", "PerformanceE2", "PerformanceE3"],
+    "sun_2024_price_value": ["Pricevalue1", "Pricevalue2", "Pricevalue3"],
+    "sun_2024_task_tech_fit": ["TTF1", "TTF2", "TTF3"],
+    "sun_2024_usage": ["Usage1", "Usage2", "Usage3"],
+}
+
+
+def convert():
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    r = requests.get(SUPPL_URL, headers=UA, timeout=120)
+    r.raise_for_status()
+    zf = zipfile.ZipFile(io.BytesIO(r.content))
+    df = pd.read_excel(io.BytesIO(zf.read(MEMBER)))
+    df = df.rename(columns={"NO": "id"})
+
+    for out_name, item_cols in SCALES.items():
+        long = df.melt(id_vars=["id"], value_vars=item_cols,
+                        var_name="item", value_name="resp")
+        long["resp"] = pd.to_numeric(long["resp"], errors="coerce")
+        long = long.dropna(subset=["resp"]).reset_index(drop=True)
+        long = long[["id", "item", "resp"]]
+
+        out_path = OUT_DIR / f"{out_name}.csv"
+        long.to_csv(out_path, index=False)
+        print(f"{out_name}: rows={len(long)} ids={long['id'].nunique()} "
+              f"items={long['item'].nunique()} resp={long['resp'].min():.0f}-{long['resp'].max():.0f}")
+
+
+if __name__ == "__main__":
+    convert()

--- a/data/xu_2025_hcq_p.py
+++ b/data/xu_2025_hcq_p.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Source: https://peerj.com/articles/19562/ (PMC12164812)
+# DOI: 10.7717/peerj.19562
+#
+# Xu et al. (2025), "Adaptation and validation of the Chinese version of
+# the Hospice Comfort Questionnaire-Patient (HCQ-P)." PeerJ. CC BY 4.0.
+# N=360. 49-item HCQ-P, 1-6 Likert. Found via irw_discover_pmc.py (Europe
+# PMC "Satisfaction with Life Scale" query against PeerJ -- a full-text
+# match, not a title match).
+#
+# QC note: the archive has two candidate data files -- s001.xlsx and
+# s002.xlsx. s002.xlsx (id + 49 items only) is what irw_discover_pmc.py's
+# auto-triage picked (it reads the first tabular file in the zip's own
+# order, not the "best" one). s001.xlsx has the SAME 49 items PLUS 12
+# demographic/clinical covariates and is used here instead -- do not
+# switch back to s002.xlsx, it's a strict subset. Two rows have a
+# non-numeric "year" (age) value (one stray digit-string, one garbage
+# "z w") -- coerced to NaN via pd.to_numeric rather than dropped, since a
+# bad covariate value shouldn't cost the row's item responses. A free-text
+# cancer-diagnosis column ("diag-eng", e.g. "Cervical Cancer Surgery") is
+# dropped rather than kept as a covariate -- too heterogeneous/free-form to
+# be a clean covariate; the coded diag/oper/chem/radio columns already
+# capture the clinically relevant categories.
+
+import io
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OUT_DIR = REPO_ROOT / "automated_finding" / "irw_output"
+
+OUT_NAME = "xu_2025_hcq_p"
+SUPPL_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/PMC12164812/supplementaryFiles"
+MEMBER = "peerj-13-19562-s001.xlsx"
+UA = {"User-Agent": "IRW-Finder/1.0 (ben.domingue@gmail.com)"}
+
+COV_RENAME = {
+    "sex": "cov_gender",
+    "year": "cov_age",
+    "edu": "cov_education",
+    "marry": "cov_marital_status",
+    "cons": "cov_medical_expenses",
+    "long": "cov_disease_duration",
+    "oper": "cov_operation_history",
+    "chem": "cov_chemotherapy_history",
+    "radio": "cov_radiotherapy_history",
+    "lied": "cov_life_education",
+    "work": "cov_occupation_type",
+}
+
+
+def convert():
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    r = requests.get(SUPPL_URL, headers=UA, timeout=120)
+    r.raise_for_status()
+    zf = zipfile.ZipFile(io.BytesIO(r.content))
+    df = pd.read_excel(io.BytesIO(zf.read(MEMBER)))
+
+    df = df.rename(columns=COV_RENAME)
+    cov_cols = list(COV_RENAME.values())
+    for c in cov_cols:
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+
+    item_cols = [c for c in df.columns if c.startswith("Q")]
+
+    long = df.melt(id_vars=["id"] + cov_cols, value_vars=item_cols,
+                    var_name="item", value_name="resp")
+    long["resp"] = pd.to_numeric(long["resp"], errors="coerce")
+    long = long.dropna(subset=["resp"]).reset_index(drop=True)
+    long = long[["id", "item", "resp"] + cov_cols]
+
+    out_path = OUT_DIR / f"{OUT_NAME}.csv"
+    long.to_csv(out_path, index=False)
+    print(f"{OUT_NAME}: rows={len(long)} ids={long['id'].nunique()} "
+          f"items={long['item'].nunique()} resp={long['resp'].min():.0f}-{long['resp'].max():.0f}")
+
+
+if __name__ == "__main__":
+    convert()


### PR DESCRIPTION
## Summary
- New hard rule in SKILL.md's Step 4: any PII in a raw source file (not just id/cov_* columns) means skip the whole candidate entirely, never scrub-and-ship just the offending column(s) -- same tier as an unresolvable license. Applied this session to two PMC-connector candidates (a participant-email column on an LGB medical students' mental health study; a real date-of-birth column on a nursing-profession survey) and one PLOS candidate (the same email-column paper, found independently via PLOS batch 26).
- SKILL.md also gets an explicit "pick a discovery mode" step (PLOS / Europe-PMC-connector / repositories) up front, added alongside the new PMC connector work from earlier in this branch.
- Ships 6 papers -> 17 IRW tables from `irw_discover_pmc.py` batches 1-2, all CC BY 4.0, all QC-clean (unique ids, no PII, no isolated sentinel values, no imputation artifacts, one scale per file): `estevezlopez_2016_panas.py`, `lopezgomez_2025_mbi_ss.py` (3 tables), `xu_2025_hcq_p.py`, `lee_2024_cloninger.py` (4 tables), `altahla_2024_sci_qol.py` (2 tables), `sun_2024_ai_leasing_adoption.py` (6 tables).
- `BATCH_LOG.md` has full per-paper detail including two rejected false positives (PCIQ-F, cannabis anxiety/depression) and reasoning for each PII skip. `search_terms_log.csv` records all 30 terms run. `TODO.md` tracks what's still open (human_review CSVs pending paste, worth_retrying/human_assistance pools not yet retriaged).

## Test plan
- [x] All 17 output tables verified: unique id/item pairs, no PII, per-item response distributions checked (not just merged min/max), no non-integer/imputation artifacts, licenses confirmed CC BY 4.0 via Europe PMC's own `license` field
- [x] MBI-SS 0-6 response scale confirmed against the paper's own Methods text (0=never, not a missingness sentinel)
- [x] Biblio CSVs for both PMC batches already uploaded to Redivis and pasted into the dictionary sheet by ben-domingue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L52FJqfNHhepXzCzreQzMC