### PR TITLE
Regenerate the auto-tag vocabulary against the enforced lists

### DIFF
--- a/tags/.claude/skills/irw-auto-tag/references/vocab.md
+++ b/tags/.claude/skills/irw-auto-tag/references/vocab.md
@@ -15,12 +15,19 @@ CSV export is reachable). So the sheet's actual data-validation dropdown
 rules can't be read directly.
 
 Every list below was instead derived by **enumerating every non-empty
-value actually entered** across ~1960 rows of the live sheet (`python
-scripts/derive_vocab.py`, run 2026-07-27), which is a strong proxy: these
-columns show zero stray/off-list values, consistent with enforced dropdown
-validation. If you suspect the sheet's dropdowns have since changed (a new
-option added), re-run `derive_vocab.py` and diff its output against this
-file — don't assume this file is exhaustive forever.
+value actually entered** in the live sheet (`python scripts/derive_vocab.py`,
+last run 2026-08-29 over ~2450 rows), which is a strong proxy: these columns
+show zero stray/off-list values, consistent with enforced dropdown validation.
+If you suspect the sheet's dropdowns have since changed (a new option added),
+re-run `derive_vocab.py` and diff its output against this file — don't assume
+this file is exhaustive forever.
+
+**Two of these lists are no longer a proxy.** `Sample` and `Construct type` are
+now enforced in code: `TAG_VOCAB` in `metadata/tag_normalize.R` is the
+authoritative list, and `03_tags.R` **stops the pipeline** on any atom outside
+it rather than publishing it (issue #1720). If you need to add a value to
+either column, add it there too or the next export fails. The remaining
+columns are still enumerated proxies with nothing enforcing them.
 
 ## Age Range (single-select)
 
@@ -43,14 +50,22 @@ including whenever `Age Range` is `Adult (18+)`, `Elderly (minimum age
 
 ## Sample (multi-select, comma-separated)
 
-One option contains a literal comma — write it exactly as
-`Internet-based (Mturkers, etc)`, no extra quoting needed (the CSV writer
-in `stage_tag_row.py` quotes the whole field automatically since it
-contains a comma).
+**This column has two forms — write the sheet's, not the published one.**
+Write `Internet-based (Mturkers, etc)` exactly as listed, matching what human
+raters have always entered; `03_tags.R` renames it to `Internet-based` on
+export. Do not write `Internet-based` into the sheet: it would leave the sheet
+internally inconsistent for no gain, since the export normalizes either way.
+
+Background: that literal comma is why the value has to be quoted, and the
+inconsistent quoting that resulted spawned three separate workarounds — a
+34-line parser in `Rpkg`, a tilde-swap in `irw_site`, and nothing at all in
+`Python-pkg`, where filtering on it silently matched no tables. All three are
+gone; the rename on export is what replaced them. The sheet itself keeps the
+old form until there is a service account to change it (#1708).
 
 - `Program-based`
 - `General/non-specific`
-- `Internet-based (Mturkers, etc)`
+- `Internet-based (Mturkers, etc)` — exported as `Internet-based`
 - `Educational`
 - `Clinical`
 - `Targeted/specific`
@@ -58,6 +73,11 @@ contains a comma).
 - `Non-human`
 
 ## Construct type (multi-select, comma-separated)
+
+Order doesn't matter. `03_tags.R` sorts atoms into canonical order on export,
+so `Behavioral, Opinion/attitude` and `Opinion/attitude, Behavioral` become the
+same published string — don't spend effort hand-sorting, and don't treat a
+differently-ordered existing row as a discrepancy.
 
 - `Developmental`
 - `Affective/mental health`

--- a/tags/.claude/skills/irw-auto-tag/scripts/derive_vocab.py
+++ b/tags/.claude/skills/irw-auto-tag/scripts/derive_vocab.py
@@ -14,6 +14,14 @@ Re-run this whenever you suspect the sheet's dropdowns have changed (a new
 option added, e.g.) -- references/vocab.md is hand-maintained and won't
 update itself; diff this output against it.
 
+NOTE (2026-08-29, issue #1720): "Sample" and "Construct type" are no longer
+governed by this script alone. TAG_VOCAB in metadata/tag_normalize.R is now the
+authoritative list for those two columns, and 03_tags.R stops the pipeline on
+any atom outside it. If this script reports a value those lists don't have,
+that is a real finding -- reconcile them rather than editing vocab.md alone.
+Also note this script reads the SHEET, which still holds
+"Internet-based (Mturkers, etc)"; the export renames it to "Internet-based".
+
 Usage: python derive_vocab.py
 """
 import csv


### PR DESCRIPTION
Closes #1720 — this is its last piece.

Re-derived from the live sheet with `scripts/derive_vocab.py` (~2,450 rows, up from ~1,960 at the July run). **No column has drifted**, and the two multi-select lists match `TAG_VOCAB` exactly — so this is documentation catching up with the code, not a data fix.

Three changes beyond the re-run:

**Enforced vs. proxy.** `Sample` and `Construct type` are now authoritative — `TAG_VOCAB` in `metadata/tag_normalize.R` governs them and `03_tags.R` halts the pipeline on an unknown atom. The other columns are still enumerated proxies with nothing enforcing them, and the file now says which is which.

**The two-form situation.** The tagger writes into the *sheet*, which still holds `Internet-based (Mturkers, etc)`; the export renames it to `Internet-based`. So the instruction is to keep writing the old form — writing the new one would leave the sheet internally inconsistent for no gain, since the export normalizes either way. The sheet keeps the old form until there's a service account to change it (#1708 / 6.1).

**Order is irrelevant.** The export sorts atoms canonically, so a differently-ordered existing row isn't a discrepancy worth fixing.

`derive_vocab.py` gets a matching note: it reads the sheet rather than the published data, and any value it reports that `TAG_VOCAB` lacks is a real finding to reconcile, not something to paper over in `vocab.md`.

### Why this matters for 2.2 (#1721)

The auto-tagger was matching against a vocabulary derived by enumerating the sheet, with nothing confirming it. Two of those lists are now enforced in code, which is a precondition for scoring the tagger against those columns meaningfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KnUFZdYMGAbkVNmeCkK6gT