### PR TITLE
Abort the itemtext gates on a failed live fetch (#1736)

### DIFF
--- a/itemtext/.claude/skills/irw-auto-itemtext/SKILL.md
+++ b/itemtext/.claude/skills/irw-auto-itemtext/SKILL.md
@@ -183,6 +183,26 @@ is excluded and check with them before doing anything.
 
 ## Before doing anything
 
+0. **Check the `irw` package version — these scripts require `irw >= 1.0.1`.**
+
+   ```bash
+   Rscript -e 'v <- packageVersion("irw"); cat(as.character(v), if (v < "1.0.1") "-- TOO OLD, upgrade\n" else "-- ok\n")'
+   ```
+
+   Upgrade with `Rscript -e 'remotes::install_github("itemresponsewarehouse/Rpkg")'`.
+
+   Two hard dependencies on 1.0.1, and both fail confusingly on 1.0.0:
+   - `irw_fetch()` in 1.0.0 knows only warehouse shards 1–2 (1965 of 4052 tables). Any
+     table in shards 3–6 reports "does not exist in the IRW database" — a table that is
+     in fact live. The gates then have nothing to compare against.
+   - `audit_batch.R` calls `irw::irw_table_sets()`, added in 1.0.1 (Rpkg#121). On 1.0.0 it
+     dies with `'irw_table_sets' is not an exported object`, for every table.
+
+   `get_resp()` in `scripts/fetch_resp.R` now aborts on an empty live fetch and names this
+   as the likely cause, so you should not have to diagnose it from scratch — but check the
+   version first anyway, because `audit_batch.R` fails before any guard can help.
+   See ben-domingue/irw#1736.
+
 1. Read `references/itemtext_standard.md` for the schema and the per-tab column layout.
 2. Check whether a `{table}__items.csv` already exists locally in `itemtext/itemtables/`
    for the table in question — if so, don't reprocess without being told to redo it.
@@ -784,6 +804,15 @@ The last two are the mapping-side gates: `verify_batch.R` re-runs each table's o
 `verify_<table>.R`, and `lint_verification.R` checks that no row claims more than its
 evidence supports. A FAIL or NO VERDICT means the round's own claim did not reproduce —
 read the output before staging that table.
+
+**`lint_verification.R` reads a batch directory via `<batch_dir>/verification_merged.csv`**
+— a per-batch extract of that round's `mapping_verification.csv` rows. Batches 006–011 each
+carry one; write one for your round too, or lint by passing the central
+`itemtext/mapping_verification.csv` path instead. This is not optional bookkeeping: a batch
+directory with no `verification_merged.csv` used to be skipped with a bare message, so an
+unverified round passed this gate by being invisible rather than by being checked. It is now
+reported as an ERROR naming the batch, but the file still has to exist for the round's rows
+to actually be linted.
 
 **Re-run the first two after ANY later edit to a CSV**, including a one-line fix made with a
 script. Python's `csv` writer and R's `write.csv` disagree about absent values — a

--- a/itemtext/.claude/skills/irw-auto-itemtext/scripts/fetch_resp.R
+++ b/itemtext/.claude/skills/irw-auto-itemtext/scripts/fetch_resp.R
@@ -25,11 +25,41 @@ coerce_resp <- function(x) {
     suppressWarnings(as.numeric(s))
 }
 
+# A failed live fetch must not be handed back to a caller that will treat it as
+# data. irw_fetch() signals "table not found" with a message() and
+# invisible(NULL) rather than stop() -- deliberate upstream (fetch.R: quota,
+# timeout and transport errors ARE re-raised; only not-found is softened), but
+# the caller has to honour it. Unguarded, R's set semantics turn the absence
+# into a confident accusation: setdiff(x, NULL) returns all of x, so "no ground
+# truth" and "ground truth disagrees with every code" are indistinguishable in
+# validate_items.R's output, and the obvious response to it is to damage a
+# correct CSV. See ben-domingue/irw#1736.
+.stop_no_live_data <- function(table) {
+    v <- tryCatch(as.character(utils::packageVersion("irw")),
+                  error = function(e) "not installed")
+    stop("irw_fetch(", shQuote(table), ") returned no rows, so there is no ground truth to\n",
+         "  compare against. NOTHING was checked -- this is a missing dependency, not a\n",
+         "  finding about the CSV. Do not 'fix' the CSV in response to this.\n",
+         "  Likely causes:\n",
+         if (isTRUE(try(utils::packageVersion("irw") < "1.0.1", silent = TRUE)))
+             paste0("    1. THE LIKELY ONE: the installed irw package (", v, ") is too old to see the\n",
+                    "       warehouse shard this table lives in; these scripts need >= 1.0.1.\n",
+                    "       Fix: Rscript -e 'remotes::install_github(\"itemresponsewarehouse/Rpkg\")'\n")
+         else
+             paste0("    1. (ruled out) irw ", v, " is recent enough to see every warehouse shard.\n"),
+         "    2. The table name is misspelled.\n",
+         "    3. A Redivis version pin is active and this table postdates the pinned release\n",
+         "       (irw_get_version() reports pins; irw_reset_version() clears them).\n",
+         call. = FALSE)
+}
+
 # The response data as a data.frame with `item` (character) and `resp`.
 # resp_csv: path to a staged IRW response CSV, or NA for live.
 get_resp <- function(table, resp_csv = NA) {
     if (is.na(resp_csv) || !nzchar(resp_csv)) {
-        return(irw::irw_fetch(table))
+        d <- irw::irw_fetch(table)
+        if (is.null(d) || !nrow(d)) .stop_no_live_data(table)
+        return(d)
     }
     if (!file.exists(resp_csv)) {
         stop("response CSV not found: ", resp_csv)

--- a/itemtext/.claude/skills/irw-auto-itemtext/scripts/lint_verification.R
+++ b/itemtext/.claude/skills/irw-auto-itemtext/scripts/lint_verification.R
@@ -38,16 +38,32 @@ HEDGE <- paste0(
     "(remain|remains|are|is) unconfirmed|",
     "only pins|pins only|verifies .* not ")
 
+# Batches requested but skipped for want of a verification file. A skip used to
+# be a bare message(), which meant an unverified batch passed this gate by being
+# INVISIBLE rather than by being checked -- and linted alongside a batch that did
+# have a file, the run still reported success. Collected and reported as ERROR
+# flags below instead. See ben-domingue/irw#1736.
+skipped <- character(0)
+
 read_one <- function(a) {
     p <- if (dir.exists(a)) file.path(a, "verification_merged.csv") else a
-    if (!file.exists(p)) { message("skipping ", a, " -- no verification file"); return(NULL) }
+    if (!file.exists(p)) {
+        skipped <<- c(skipped, a)
+        message("skipping ", a, " -- no verification file")
+        return(NULL)
+    }
     d <- read.csv(p, stringsAsFactors = FALSE)
     d$..src <- p
     d$..dir <- if (dir.exists(a)) a else NA_character_
     d
 }
 v <- do.call(rbind, Filter(Negate(is.null), lapply(sub("/$", "", args), read_one)))
-if (is.null(v) || !nrow(v)) stop("nothing to lint")
+if (is.null(v) || !nrow(v))
+    stop("nothing to lint -- no verification rows were found in: ",
+         paste(sub("/$", "", args), collapse = ", "),
+         "\n  A batch directory is linted via its verification_merged.csv; batches that record",
+         "\n  their rows only in the central itemtext/mapping_verification.csv must be linted by",
+         "\n  passing that file's path instead. Nothing was checked.", call. = FALSE)
 
 flags <- list()
 add <- function(sev, table, msg) flags[[length(flags) + 1]] <<- list(sev = sev, table = table, msg = msg)
@@ -83,6 +99,10 @@ for (d in unique(na.omit(v$..dir))) {
     for (t in setdiff(csvs, v$table[v$..dir %in% d]))
         add("ERROR", t, sprintf("ships a CSV in %s but has no verification row", d))
 }
+
+for (a in skipped)
+    add("ERROR", basename(sub("/$", "", a)),
+        sprintf("requested for linting but has no verification_merged.csv -- %s was NOT checked", a))
 
 if (!length(flags)) {
     cat(sprintf("lint_verification: %d rows, no problems found\n", nrow(v)))

--- a/itemtext/.claude/skills/irw-auto-itemtext/scripts/mapping_structure.R
+++ b/itemtext/.claude/skills/irw-auto-itemtext/scripts/mapping_structure.R
@@ -29,7 +29,17 @@ if (length(args) < 1) stop("Usage: Rscript mapping_structure.R <table> [group1 g
 table <- args[1]
 groups <- if (length(args) > 1) strsplit(args[-1], ",") else list()
 
+# Resolve the shared fetch helper next to this script, however it was invoked
+# (same idiom as validate_items.R/audit_batch.R).
+script_dir <- {
+    a <- commandArgs(trailingOnly = FALSE)
+    f <- sub("^--file=", "", a[grep("^--file=", a)])
+    if (length(f)) dirname(normalizePath(f[1])) else "."
+}
+source(file.path(script_dir, "fetch_resp.R"))
+
 df <- irw::irw_fetch(table)
+if (is.null(df) || !nrow(df)) .stop_no_live_data(table)
 df$resp <- suppressWarnings(as.numeric(df$resp))
 df$id <- as.character(df$id)
 df$item <- as.character(df$item)

--- a/itemtext/.claude/skills/irw-auto-itemtext/scripts/table_context.R
+++ b/itemtext/.claude/skills/irw-auto-itemtext/scripts/table_context.R
@@ -17,7 +17,17 @@ table_lower <- tolower(table)
 library(gsheet)
 
 cat("=== Ground truth from irw::irw_fetch(\"", table, "\") ===\n", sep = "")
+# Resolve the shared fetch helper next to this script, however it was invoked
+# (same idiom as validate_items.R/audit_batch.R).
+script_dir <- {
+    a <- commandArgs(trailingOnly = FALSE)
+    f <- sub("^--file=", "", a[grep("^--file=", a)])
+    if (length(f)) dirname(normalizePath(f[1])) else "."
+}
+source(file.path(script_dir, "fetch_resp.R"))
+
 df <- irw::irw_fetch(table)
+if (is.null(df) || !nrow(df)) .stop_no_live_data(table)
 items <- sort(unique(df$item))
 resps <- sort(unique(df$resp))
 cat("N items:", length(items), "\n")


### PR DESCRIPTION
Closes #1736.

**Rebased onto the `--resp-csv` refactor**, which changed where this fix belongs. The line I originally patched (`df <- irw::irw_fetch(table)` in `validate_items.R`) no longer exists — it is now `df <- get_resp(table, resp_csv)`. `get_resp()` returns `irw::irw_fetch(table)` for the live route with no guard, so the bug survived the refactor intact, but it is now in a **shared** helper. Guarding there is better than my original three-site patch.

## What was wrong

`irw_fetch()` signals "table not found" with `message()` + `invisible(NULL)` rather than `stop()`. That is deliberate upstream — `Rpkg` `fetch.R:98` re-raises quota, timeout and transport errors and softens only not-found, which protects the multi-table fetch loop — but the caller has to honour it, and the `NULL` return is undocumented (`@return` says "a tibble").

Unguarded, R's set semantics turn the absence into a confident accusation:

```r
unique(NULL$item)    # NULL
setdiff(csv, NULL)   # the ENTIRE csv vector
```

So "no ground truth" and "ground truth disagrees with every code" print identically, and `validate_items.R` printed the wording of the second:

```
FAIL: item sets differ.
  In items csv but not in response data (5): jobsat, jobsats, jobsatss, jobsatsss, jobsatssss
```

That CSV was correct. The obvious response to that output is to edit the CSV to match an empty set, i.e. to damage correct work.

## The fix

| file | change |
|---|---|
| `fetch_resp.R` | guard in `get_resp()`'s live branch — covers `validate_items.R` |
| `table_context.R`, `mapping_structure.R` | guard; these call `irw_fetch()` directly |
| `lint_verification.R` | skipped batch becomes an `ERROR` flag |
| `SKILL.md` | `irw >= 1.0.1` prerequisite; document `verification_merged.csv` |

`audit_batch.R` needs no guard — it goes through `irw_table_sets()` and already fails loudly.

**The message is the substance, not the `stop()`.** It leads with *"NOTHING was checked — this is a missing dependency, not a finding about the CSV. Do not 'fix' the CSV in response to this"*, then self-diagnoses against the installed version, since a stale package was the original trigger:

```
  Likely causes:
    1. (ruled out) irw 1.0.1 is recent enough to see every warehouse shard.
    2. The table name is misspelled.
    3. A Redivis version pin is active and this table postdates the pinned release
```

On 1.0.0 line 1 instead reads `THE LIKELY ONE` with the `install_github` command. `!nrow(df)` also covers a table that exists but is empty, which produced the same false FAIL.

**`lint_verification.R`** — `batch_011 + batch_012` previously reported `0 ERROR` and success while skipping `batch_012` entirely. Now:

```
[ERROR] batch_012
    requested for linting but has no verification_merged.csv -- itemtables/batch_012 was NOT checked
```

Exit codes deliberately unchanged: `verify_batch.R` does not exit non-zero on FAIL either, so print-findings-exit-0 is the convention here and changing one script would be inconsistent. Flagged below instead.

## Verified

All five files parse. Guards fire on an unresolvable table (exit 1) and are silent on the happy path. Critically, **the `--resp-csv` route still works** — tested against a staged local CSV, `PASS` on both routes:

```
Response data source: live (irw::irw_fetch)            -> PASS/PASS
Response data source: local CSV .../resp_local.csv     -> PASS/PASS
```

`table_context.R` now aborts where it used to print `N items: 0` while silently broken.

## Related, not fixed here

- **These gate scripts exit 0 even on real `ERROR`/`FAIL` flags** (`lint_verification.R`, `verify_batch.R`). Nothing chained on them can fail. Left alone as a deliberate-looking convention; changing it is a separate decision.
- **Upstream:** documenting the `NULL` return in `irw_fetch()`'s `@return` would stop the next caller making the same assumption. Worth an `itemresponsewarehouse/Rpkg` issue.
- **On the CRLF note from #1696:** you checked and found line endings survived #1737 — correct, but that is because I restored CRLF by hand before committing, not because the round-trip is safe. `read.csv` → `write.csv` on `mapping_verification.csv` or `provenance.csv` (both CRLF, from Python `csv.writer`'s default) still flips every line. The hazard is real; it just did not reach `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
