### PR TITLE
Reach open-access sources via OpenAlex, and stop caching blocker pages (#1744)

### DIFF
--- a/tags/.claude/skills/irw-auto-tag/SKILL.md
+++ b/tags/.claude/skills/irw-auto-tag/SKILL.md
@@ -103,18 +103,33 @@ proceed.
 ## Step 3 — Fetch the source text
 
 ```bash
-python3 scripts/fetch_source.py table_a --doi 10.1037/a0022874   # prefer DOI when present
-python3 scripts/fetch_source.py table_a --url https://...        # else use the dictionary URL
+python3 scripts/fetch_source.py table_a --doi 10.1037/a0022874 --url https://...
 ```
-This resolves `https://doi.org/{doi}` (or fetches the URL directly),
-caches the raw text under `.cache/` (gitignored — not committed), and
-reports HTTP status / final URL / byte count. It does **not** decide
-whether the content is paywalled — read the cached file yourself (`Read
-.cache/{table}.txt`) and judge that. **If it's paywalled, login-gated, or
-otherwise unreachable/unusable**, stop for that table and stage a row with
-every field blank except `table`, `Rater`, and
-`Notes = "cannot fully access due to paywall"` — don't guess content from
-the Description/Reference text alone.
+Pass **both** when the dictionary has both — they are tried in order, not
+as alternatives. Given a DOI the script asks OpenAlex where an open copy
+lives and tries those locations (PDFs first, extracted to text) before
+falling back to resolving the DOI itself, then the URL. It caches under
+`.cache/` (gitignored — not committed).
+
+It reports `oa_status` from OpenAlex, and **that is what you judge a
+paywall on — not the fetch failing.** Those are different findings:
+
+| Outcome | What it means | What to do |
+|---|---|---|
+| `OK ... content=N_chars_visible` | Got prose that is not a blocker page | Read `.cache/{table}.txt` and continue to Step 4 |
+| `UNREACHABLE oa_status=closed` | No open copy exists | Stage `Notes = "cannot fully access due to paywall"` |
+| `UNREACHABLE oa_status=gold\|green\|hybrid\|bronze\|diamond` | An open copy **exists** and something else blocked us — a WAF, a captcha, a JS-only page, a dead link | **Not a paywall.** Stage `Notes = "no working link"`, and it is worth reporting: these are fixable |
+
+The script rejects blocker pages rather than caching them, and prints the
+reason per candidate (`blocker:recaptcha`, `too_short:3_chars_visible`,
+`http_403`). This matters because raw byte count cannot tell an article
+from a challenge page: the reCAPTCHA interstitial served for a fully
+open-access PeerJ paper was 21kB, and OSF's JavaScript shell is a
+consistent 4.2kB. Both used to cache and read as "the source".
+
+Still read the cached file and judge it yourself — the script screens out
+blockers, it does not confirm the text is the *right* paper. A dictionary
+`doi` can point at a different article than the `reference` field names.
 
 Cached text persists across runs specifically so a paywalled or
 rate-limited source isn't re-hit on every retry.

--- a/tags/.claude/skills/irw-auto-tag/scripts/fetch_source.py
+++ b/tags/.claude/skills/irw-auto-tag/scripts/fetch_source.py
@@ -3,34 +3,161 @@
 data-page URL), so repeated runs don't re-hit paywalled or rate-limited
 sources.
 
-Prefers resolving https://doi.org/{doi} when a DOI is given; falls back to
-the raw URL otherwise. Does not try to detect paywalls itself -- it fetches
-what it can and reports the HTTP status, final URL, and byte count. The
-skill (Claude, reading the cached text with the Read tool) decides whether
-the content is actually the paper/data page or a paywall/login wall, per the
-brief's instruction not to guess content from a blocked fetch.
+Given a DOI, this asks OpenAlex where an openly readable copy lives and
+tries those locations before falling back to resolving the DOI itself.
+That matters because publisher landing pages frequently refuse an
+unauthenticated GET even when the article is fully open access -- the old
+single-GET behaviour reported those as unreachable, and the tagger read
+that as "paywall". Of the nine tables the 2.2 scoring run called paywalled
+(#1744), six had a legally open version.
+
+It still does not decide whether content is a paywall -- but it now reports
+OpenAlex's asserted `oa_status`, so that judgement has evidence behind it
+rather than being inferred from a blocked fetch. PDFs are extracted to text.
 
 Usage:
     python fetch_source.py TABLE --doi 10.1037/a0022874
     python fetch_source.py TABLE --url https://example.org/page
     python fetch_source.py TABLE --doi ... --force    # re-fetch even if cached
+    python fetch_source.py TABLE --doi ... --no-oa    # skip the OpenAlex lookup
 
 Cache lives in ../.cache/ next to this scripts/ dir, one file per table --
 gitignored, not committed (see tags/.gitignore).
 """
 import argparse
+import io
+import re
 import sys
 from pathlib import Path
 
 import requests
 
-UA = {"User-Agent": "irw-auto-tag/1.0 (research; contact your-email)"}
+# OpenAlex asks for a contact address in the UA and gives faster, more
+# reliable service to requests that carry one ("the polite pool").
+UA = {"User-Agent": "irw-auto-tag/2.0 (research; ben.domingue@gmail.com)"}
 CACHE_DIR = Path(__file__).resolve().parent.parent / ".cache"
+OPENALEX = "https://api.openalex.org/works/doi:{}"
+
+# Minimum *visible prose* (not raw bytes) for a page to count as source text.
+# Raw byte count cannot distinguish an article from a challenge page: the
+# reCAPTCHA interstitial Google served for a fully open-access PeerJ paper was
+# 21kB, and OSF's JavaScript shell is a consistent 4.2kB of pure CSS.
+MIN_USEFUL_CHARS = 1500
+
+# Substrings that identify a page as a blocker rather than the source. Matched
+# against the visible text, lowercased. Kept explicit rather than clever --
+# each one was observed on a real table in the #1744 pool.
+BLOCKER_MARKERS = (
+    "recaptcha",
+    "captcha",
+    "unusual traffic",
+    "verify you are a human",
+    "are you a robot",
+    "enable javascript",
+    "javascript is disabled",
+    "your web browser is no longer supported",
+    "ya no se admite tu navegador",
+    "checking your browser",
+    "cloudflare",
+    "access denied",
+    "403 forbidden",
+    "sign in to continue",
+    "purchase this article",
+    "get access to the full version",
+)
 
 
 def cache_path(table):
     safe = "".join(c if c.isalnum() or c in "-_." else "_" for c in table.lower())
     return CACHE_DIR / f"{safe}.txt"
+
+
+def openalex_locations(doi):
+    """Return (oa_status, [urls]) for a DOI: open locations, best first.
+
+    Never raises -- OpenAlex being down or not knowing the DOI degrades to
+    the old DOI-resolution behaviour rather than failing the fetch.
+    """
+    doi = doi.strip().removeprefix("https://doi.org/").removeprefix("doi.org/")
+    try:
+        r = requests.get(OPENALEX.format(doi), headers=UA, timeout=30)
+        if r.status_code != 200:
+            return f"openalex_http_{r.status_code}", []
+        work = r.json()
+    except (requests.RequestException, ValueError) as e:
+        return f"openalex_error_{type(e).__name__}", []
+
+    oa_status = (work.get("open_access") or {}).get("oa_status", "unknown")
+    urls = []
+    locations = [work.get("best_oa_location")] + (work.get("locations") or [])
+    for loc in locations:
+        if not loc or not loc.get("is_oa"):
+            continue
+        # PDF first: publisher HTML landing pages are the thing that blocks.
+        for key in ("pdf_url", "landing_page_url"):
+            u = loc.get(key)
+            if u and u not in urls:
+                urls.append(u)
+    return oa_status, urls
+
+
+def visible_text(html_or_text):
+    """Strip markup and collapse whitespace, so what is measured is prose."""
+    try:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(html_or_text, "html.parser")
+        for tag in soup(["script", "style", "noscript"]):
+            tag.decompose()
+        text = soup.get_text(" ")
+    except Exception:
+        text = re.sub(r"<[^>]*>", " ", html_or_text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def classify(text):
+    """Is this the source, or something standing in front of it?
+
+    Returns (ok, reason). The caller keeps trying other locations when not ok.
+    """
+    prose = visible_text(text)
+    low = prose.lower()
+    for marker in BLOCKER_MARKERS:
+        if marker in low:
+            return False, f"blocker:{marker.replace(' ', '_')}"
+    if len(prose) < MIN_USEFUL_CHARS:
+        return False, f"too_short:{len(prose)}_chars_visible"
+    return True, f"{len(prose)}_chars_visible"
+
+
+def extract(response):
+    """Text of a response -- PDFs decoded, everything else left as-is."""
+    ctype = response.headers.get("Content-Type", "").lower()
+    looks_pdf = "pdf" in ctype or response.content[:5] == b"%PDF-"
+    if not looks_pdf:
+        return response.text
+    try:
+        from pypdf import PdfReader
+
+        reader = PdfReader(io.BytesIO(response.content))
+        return "\n".join(page.extract_text() or "" for page in reader.pages)
+    except Exception as e:
+        return f"[PDF extraction failed: {type(e).__name__}: {e}]"
+
+
+def try_url(url):
+    """Fetch one candidate. Returns ((text, final_url) | None, reason)."""
+    try:
+        r = requests.get(url, headers=UA, timeout=30, allow_redirects=True)
+    except requests.RequestException as e:
+        return None, f"error:{type(e).__name__}"
+    if r.status_code != 200:
+        return None, f"http_{r.status_code}"
+    text = extract(r)
+    ok, reason = classify(text)
+    if not ok:
+        return None, reason
+    return (text, r.url), reason
 
 
 def main():
@@ -39,6 +166,8 @@ def main():
     ap.add_argument("--doi")
     ap.add_argument("--url")
     ap.add_argument("--force", action="store_true")
+    ap.add_argument("--no-oa", action="store_true",
+                    help="skip the OpenAlex lookup and resolve the DOI directly")
     args = ap.parse_args()
 
     if not args.doi and not args.url:
@@ -49,16 +178,44 @@ def main():
         print(f"CACHED {path} ({path.stat().st_size} bytes)")
         return
 
-    target = f"https://doi.org/{args.doi}" if args.doi else args.url
-    try:
-        r = requests.get(target, headers=UA, timeout=30, allow_redirects=True)
-    except requests.RequestException as e:
-        print(f"FETCH_ERROR {target} :: {e}", file=sys.stderr)
-        sys.exit(1)
+    oa_status = "not_checked"
+    candidates = []
+    if args.doi and not args.no_oa:
+        oa_status, candidates = openalex_locations(args.doi)
+    if args.doi:
+        candidates.append(f"https://doi.org/{args.doi}")
+    if args.url:
+        candidates.append(args.url)
 
-    CACHE_DIR.mkdir(exist_ok=True)
-    path.write_text(r.text, encoding="utf-8", errors="replace")
-    print(f"OK status={r.status_code} final_url={r.url} bytes={len(r.text)} -> {path}")
+    attempted = []
+    rejected = []
+    for url in candidates:
+        if url in attempted:
+            continue
+        attempted.append(url)
+        got, reason = try_url(url)
+        rejected.append(f"{url} -> {reason}")
+        if got is None:
+            continue
+        text, final_url = got
+        CACHE_DIR.mkdir(exist_ok=True)
+        path.write_text(text, encoding="utf-8", errors="replace")
+        print(f"OK oa_status={oa_status} source={url} final_url={final_url} "
+              f"content={reason} attempts={len(attempted)} -> {path}")
+        return
+
+    # Nothing readable. oa_status is the useful half of this message: a
+    # closed status corroborates a paywall, while an open one means the
+    # article is readable and something else -- a WAF, a bad link -- blocked
+    # us, which is not the same finding and should not be staged as one.
+    # Each rejection carries its reason, so "blocked by a captcha" is
+    # distinguishable from "genuinely behind a paywall" -- the distinction
+    # #1744 found the tagger was collapsing.
+    print(f"UNREACHABLE oa_status={oa_status} tried={len(attempted)}",
+          file=sys.stderr)
+    for line in rejected:
+        print(f"  rejected {line}", file=sys.stderr)
+    sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tags/.claude/skills/irw-auto-tag/scripts/fetch_source.py
+++ b/tags/.claude/skills/irw-auto-tag/scripts/fetch_source.py
@@ -28,6 +28,7 @@ import argparse
 import io
 import re
 import sys
+import time
 from pathlib import Path
 
 import requests
@@ -37,6 +38,15 @@ import requests
 UA = {"User-Agent": "irw-auto-tag/2.0 (research; ben.domingue@gmail.com)"}
 CACHE_DIR = Path(__file__).resolve().parent.parent / ".cache"
 OPENALEX = "https://api.openalex.org/works/doi:{}"
+EPMC_SEARCH = ("https://www.ebi.ac.uk/europepmc/webservices/rest/search"
+               "?query=DOI:%22{}%22&format=json&resultType=core")
+EPMC_FULLTEXT = "https://www.ebi.ac.uk/europepmc/webservices/rest/{}/fullTextXML"
+
+# Courtesy pause between HTTP attempts. NCBI serves a reCAPTCHA to repeated
+# unauthenticated hits, which is how a table that fetched cleanly on one run
+# comes back "paywalled" on the next -- reachability was measurably
+# rate-sensitive before this.
+REQUEST_DELAY_S = 1.0
 
 # Minimum *visible prose* (not raw bytes) for a page to count as source text.
 # Raw byte count cannot distinguish an article from a challenge page: the
@@ -104,12 +114,19 @@ def openalex_locations(doi):
 def visible_text(html_or_text):
     """Strip markup and collapse whitespace, so what is measured is prose."""
     try:
+        import warnings
+
         from bs4 import BeautifulSoup
 
-        soup = BeautifulSoup(html_or_text, "html.parser")
-        for tag in soup(["script", "style", "noscript"]):
-            tag.decompose()
-        text = soup.get_text(" ")
+        with warnings.catch_warnings():
+            # Europe PMC returns JATS XML; html.parser handles it fine for
+            # text extraction, and bs4's "that looks like XML" warning is
+            # noise on stderr the skill would otherwise have to read past.
+            warnings.simplefilter("ignore")
+            soup = BeautifulSoup(html_or_text, "html.parser")
+            for tag in soup(["script", "style", "noscript"]):
+                tag.decompose()
+            text = soup.get_text(" ")
     except Exception:
         text = re.sub(r"<[^>]*>", " ", html_or_text)
     return re.sub(r"\s+", " ", text).strip()
@@ -128,6 +145,31 @@ def classify(text):
     if len(prose) < MIN_USEFUL_CHARS:
         return False, f"too_short:{len(prose)}_chars_visible"
     return True, f"{len(prose)}_chars_visible"
+
+
+def europepmc_fulltext(doi):
+    """Full text via the Europe PMC API, or None.
+
+    Preferred over scraping a PMC article page: it is a real API, returns
+    JATS XML rather than a rendered page, and does not challenge repeat
+    callers. Only open-access records expose fullTextXML -- everything else
+    404s and falls through to the URL candidates.
+    """
+    doi = doi.strip().removeprefix("https://doi.org/").removeprefix("doi.org/")
+    try:
+        r = requests.get(EPMC_SEARCH.format(doi), headers=UA, timeout=30)
+        if r.status_code != 200:
+            return None
+        hits = r.json().get("resultList", {}).get("result", [])
+        if not hits or not hits[0].get("pmcid"):
+            return None
+        pmcid = hits[0]["pmcid"]
+        r = requests.get(EPMC_FULLTEXT.format(pmcid), headers=UA, timeout=40)
+        if r.status_code != 200:
+            return None
+    except (requests.RequestException, ValueError):
+        return None
+    return visible_text(r.text), f"https://europepmc.org/article/PMC/{pmcid}"
 
 
 def extract(response):
@@ -189,10 +231,27 @@ def main():
 
     attempted = []
     rejected = []
+
+    # Europe PMC first: an API beats scraping a page that may be a captcha.
+    if args.doi and not args.no_oa:
+        got = europepmc_fulltext(args.doi)
+        if got:
+            text, source = got
+            ok, reason = classify(text)
+            if ok:
+                CACHE_DIR.mkdir(exist_ok=True)
+                path.write_text(text, encoding="utf-8", errors="replace")
+                print(f"OK oa_status={oa_status} source={source} "
+                      f"final_url={source} content={reason} attempts=1 -> {path}")
+                return
+            rejected.append(f"{source} -> {reason}")
+            attempted.append(source)
+
     for url in candidates:
         if url in attempted:
             continue
         attempted.append(url)
+        time.sleep(REQUEST_DELAY_S)
         got, reason = try_url(url)
         rejected.append(f"{url} -> {reason}")
         if got is None:

--- a/tags/.claude/skills/irw-auto-tag/scripts/fetch_source.py
+++ b/tags/.claude/skills/irw-auto-tag/scripts/fetch_source.py
@@ -83,7 +83,7 @@ def cache_path(table):
 
 
 def openalex_locations(doi):
-    """Return (oa_status, [urls]) for a DOI: open locations, best first.
+    """Return (oa_status, [urls], title) for a DOI: open locations, best first.
 
     Never raises -- OpenAlex being down or not knowing the DOI degrades to
     the old DOI-resolution behaviour rather than failing the fetch.
@@ -92,10 +92,10 @@ def openalex_locations(doi):
     try:
         r = requests.get(OPENALEX.format(doi), headers=UA, timeout=30)
         if r.status_code != 200:
-            return f"openalex_http_{r.status_code}", []
+            return f"openalex_http_{r.status_code}", [], None
         work = r.json()
     except (requests.RequestException, ValueError) as e:
-        return f"openalex_error_{type(e).__name__}", []
+        return f"openalex_error_{type(e).__name__}", [], None
 
     oa_status = (work.get("open_access") or {}).get("oa_status", "unknown")
     urls = []
@@ -108,7 +108,7 @@ def openalex_locations(doi):
             u = loc.get(key)
             if u and u not in urls:
                 urls.append(u)
-    return oa_status, urls
+    return oa_status, urls, work.get("title")
 
 
 def visible_text(html_or_text):
@@ -130,6 +130,36 @@ def visible_text(html_or_text):
     except Exception:
         text = re.sub(r"<[^>]*>", " ", html_or_text)
     return re.sub(r"\s+", " ", text).strip()
+
+
+def _squash(s):
+    return re.sub(r"[^a-z0-9]+", "", (s or "").lower())
+
+
+def is_the_right_work(text, doi, title):
+    """Does this text actually belong to the work we asked for?
+
+    A page can be real prose and still be the wrong page -- a journal's
+    article *listing* has thousands of words, no blocker markers, and
+    nothing to do with the article. An article's own page or PDF almost
+    always carries its DOI or its title, so require one of them.
+
+    Returns (ok, reason). Unknown identity (no DOI and no title) passes:
+    with nothing to check against, refusing would reject every --url-only
+    fetch, which is the data-portal case.
+    """
+    if not doi and not title:
+        return True, "identity_unchecked"
+    squashed = _squash(text)
+    if doi and _squash(doi) in squashed:
+        return True, "doi_in_text"
+    # Titles get typeset with line breaks, entities and smart quotes, so
+    # compare on a squashed prefix rather than the whole string.
+    if title:
+        probe = _squash(title)[:60]
+        if len(probe) >= 20 and probe in squashed:
+            return True, "title_in_text"
+    return False, "wrong_work:doi_and_title_absent"
 
 
 def classify(text):
@@ -187,7 +217,7 @@ def extract(response):
         return f"[PDF extraction failed: {type(e).__name__}: {e}]"
 
 
-def try_url(url):
+def try_url(url, doi=None, title=None):
     """Fetch one candidate. Returns ((text, final_url) | None, reason)."""
     try:
         r = requests.get(url, headers=UA, timeout=30, allow_redirects=True)
@@ -197,6 +227,9 @@ def try_url(url):
         return None, f"http_{r.status_code}"
     text = extract(r)
     ok, reason = classify(text)
+    if not ok:
+        return None, reason
+    ok, reason = is_the_right_work(text, doi, title)
     if not ok:
         return None, reason
     return (text, r.url), reason
@@ -221,9 +254,10 @@ def main():
         return
 
     oa_status = "not_checked"
+    title = None
     candidates = []
     if args.doi and not args.no_oa:
-        oa_status, candidates = openalex_locations(args.doi)
+        oa_status, candidates, title = openalex_locations(args.doi)
     if args.doi:
         candidates.append(f"https://doi.org/{args.doi}")
     if args.url:
@@ -239,6 +273,8 @@ def main():
             text, source = got
             ok, reason = classify(text)
             if ok:
+                ok, reason = is_the_right_work(text, args.doi, title)
+            if ok:
                 CACHE_DIR.mkdir(exist_ok=True)
                 path.write_text(text, encoding="utf-8", errors="replace")
                 print(f"OK oa_status={oa_status} source={source} "
@@ -252,7 +288,7 @@ def main():
             continue
         attempted.append(url)
         time.sleep(REQUEST_DELAY_S)
-        got, reason = try_url(url)
+        got, reason = try_url(url, args.doi, title)
         rejected.append(f"{url} -> {reason}")
         if got is None:
             continue

--- a/tags/scoring/age_range_gold_audit_2026-08-31.json
+++ b/tags/scoring/age_range_gold_audit_2026-08-31.json
@@ -1,0 +1,708 @@
+[
+ {
+  "table": "margaretto_2025_translation_study_2_generalknowledge_1",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 68.0,
+  "pct_u18": 0.0,
+  "n": 220,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "ecps_sahm_2024_dtl",
+  "gold": "Adult (18+)",
+  "min": 18.0,
+  "max": 100.0,
+  "pct_u18": 0.0,
+  "n": 13253,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "ecps_sahm_2024_trust",
+  "gold": "Adult (18+)",
+  "min": 18.0,
+  "max": 100.0,
+  "pct_u18": 0.0,
+  "n": 15254,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "c19prc_uk_mcbride_2021_riskbehaviour_c19",
+  "gold": "Adult (18+)",
+  "min": 18.0,
+  "max": 90.0,
+  "pct_u18": 0.0,
+  "n": 2878,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "kemp_2019_mss_positive",
+  "gold": "Adult (18+)",
+  "min": 19.0,
+  "max": 75.0,
+  "pct_u18": 0.0,
+  "n": 584,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "gilbert_meta_98",
+  "gold": "Adult (18+)",
+  "min": 18.0,
+  "max": 104.0,
+  "pct_u18": 0.0,
+  "n": 8608,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "narcissism_schneider_2025_study2_idasii",
+  "gold": "Adult (18+)",
+  "min": 22.0,
+  "max": 34.0,
+  "pct_u18": 0.0,
+  "n": 3,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "oxfordcovid_xue_2024_rse",
+  "gold": "Mixed",
+  "min": 11.0,
+  "max": 342.0,
+  "pct_u18": 66.81,
+  "n": 1160,
+  "data_label": "Mixed",
+  "verdict": "agree"
+ },
+ {
+  "table": "spain_2023_identity_state",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 98.0,
+  "pct_u18": 0.0,
+  "n": 7615,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "tsai_2017_treeit_h3_match",
+  "gold": "Elderly (minimum age >50)",
+  "min": 57.0,
+  "max": 87.0,
+  "pct_u18": 0.0,
+  "n": 101,
+  "data_label": "Elderly (minimum age >50)",
+  "verdict": "agree"
+ },
+ {
+  "table": "pierro_2018_locomotion_s1",
+  "gold": "Adult (18+)",
+  "min": 17.0,
+  "max": 79.0,
+  "pct_u18": 0.31,
+  "n": 323,
+  "data_label": "Mixed",
+  "verdict": "disagree"
+ },
+ {
+  "table": "pierro_2018_tf_past_s4",
+  "gold": "Adult (18+)",
+  "min": 20.0,
+  "max": 45.0,
+  "pct_u18": 0.0,
+  "n": 189,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "colombia_2023_politics_voting",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 114.0,
+  "pct_u18": 0.0,
+  "n": 46392,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "margaretto_2025_translation_study_2_lextale",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 68.0,
+  "pct_u18": 0.0,
+  "n": 220,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "opentsstvr_linnig_2025_ssq",
+  "gold": "Adult (18+)",
+  "min": 18.0,
+  "max": 30.0,
+  "pct_u18": 0.0,
+  "n": 98,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "arnulf_2022_general_knowledge",
+  "gold": "Adult (18+)",
+  "min": 19.0,
+  "max": 77.0,
+  "pct_u18": 0.0,
+  "n": 397,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "spain_2024_politics_beliefs",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 94.0,
+  "pct_u18": 0.0,
+  "n": 2562,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "gilbert_meta_59",
+  "gold": "Adult (18+)",
+  "min": 18.0,
+  "max": 45.0,
+  "pct_u18": 0.0,
+  "n": 1154,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "colombia_2023_politics_anticorruption",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 114.0,
+  "pct_u18": 0.0,
+  "n": 46392,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "spain_2026_disinformation_humorperception",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 95.0,
+  "pct_u18": 0.0,
+  "n": 3490,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "socialstereotype_hughes_2025_judgement",
+  "gold": "Adult (18+)",
+  "min": 18.0,
+  "max": 79.0,
+  "pct_u18": 0.0,
+  "n": 297,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "mexico_2025_q1safety_govtrust",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 98.0,
+  "pct_u18": 0.0,
+  "n": 23481,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "silvia_2024_funny",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 88.0,
+  "pct_u18": 0.0,
+  "n": 1842,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "chile_2023_social-welfare-survey_ee",
+  "gold": "Mixed",
+  "verdict": "no_cov_age"
+ },
+ {
+  "table": "spain_2025_democracy_parties",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 97.0,
+  "pct_u18": 0.0,
+  "n": 4010,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "mhscdc_fried_2020_procrastination",
+  "gold": "Adult (18+)",
+  "verdict": "no_cov_age"
+ },
+ {
+  "table": "mfq_adolescent_athletes",
+  "gold": "Child (<18y)",
+  "min": 13.0,
+  "max": 18.0,
+  "pct_u18": 98.684,
+  "n": 152,
+  "data_label": "Mixed",
+  "verdict": "disagree"
+ },
+ {
+  "table": "spain_2025_ai_regulation",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 95.0,
+  "pct_u18": 0.0,
+  "n": 3880,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "gilbert_meta_68",
+  "gold": "Child (<18y)",
+  "min": 0.0,
+  "max": 18.25,
+  "pct_u18": 99.989,
+  "n": 9413,
+  "data_label": "Mixed",
+  "verdict": "disagree"
+ },
+ {
+  "table": "mexico_2024_q4safety_govperformance",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 98.0,
+  "pct_u18": 0.0,
+  "n": 23451,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "pechorro_impulsivity_2021_ypitris",
+  "gold": "Adult (18+)",
+  "min": 18.1848049281314,
+  "max": 41.8069815195072,
+  "pct_u18": 0.0,
+  "n": 427,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "mexico_2025_q2safety_govperformance",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 98.0,
+  "pct_u18": 0.0,
+  "n": 23717,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "fomonegativeaffect_cremer_2026_phq",
+  "gold": "Adult (18+)",
+  "min": 18.0,
+  "max": 25.0,
+  "pct_u18": 0.0,
+  "n": 461,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "spain_2025_sanitation_system",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 97.0,
+  "pct_u18": 0.0,
+  "n": 2426,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "tsai_2017_treeit_h10_closure",
+  "gold": "Elderly (minimum age >50)",
+  "min": 57.0,
+  "max": 87.0,
+  "pct_u18": 0.0,
+  "n": 101,
+  "data_label": "Elderly (minimum age >50)",
+  "verdict": "agree"
+ },
+ {
+  "table": "mexico_2023_quality_wellbeingservice",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 98.0,
+  "pct_u18": 0.0,
+  "n": 78896,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "pezzuti_2025_coolpeople_benevolent",
+  "gold": "Mixed",
+  "min": 1.0,
+  "max": 85.0,
+  "pct_u18": 0.446,
+  "n": 5608,
+  "data_label": "Mixed",
+  "verdict": "agree"
+ },
+ {
+  "table": "gilbert_meta_105",
+  "gold": "Child (<18y)",
+  "min": 11.0,
+  "max": 17.0,
+  "pct_u18": 100.0,
+  "n": 1031,
+  "data_label": "Child (<18y)",
+  "verdict": "agree"
+ },
+ {
+  "table": "spain_2025_ageism_elderpriority",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 97.0,
+  "pct_u18": 0.0,
+  "n": 5005,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "spain_2024_ideology_leaders",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 93.0,
+  "pct_u18": 0.0,
+  "n": 3884,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "lys_2020_rape_2_rma_pre",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 40.0,
+  "pct_u18": 0.0,
+  "n": 142,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "disgust_berger2014",
+  "gold": "Adult (18+)",
+  "min": 12.0,
+  "max": 85.0,
+  "pct_u18": 0.919,
+  "n": 1414,
+  "data_label": "Mixed",
+  "verdict": "disagree"
+ },
+ {
+  "table": "validatedtouchvideo_smit_2025_strength",
+  "gold": "Adult (18+)",
+  "min": 17.0,
+  "max": 63.0,
+  "pct_u18": 0.282,
+  "n": 355,
+  "data_label": "Mixed",
+  "verdict": "disagree"
+ },
+ {
+  "table": "xue_2024_full_dataset",
+  "gold": "Adult (18+)",
+  "min": 18.0,
+  "max": 73.0,
+  "pct_u18": 0.0,
+  "n": 137,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "ilearnathome_regalado_2025",
+  "gold": "Adult (18+)",
+  "min": 21.0,
+  "max": 65.0,
+  "pct_u18": 0.0,
+  "n": 909,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "wang_2016_study1_authliving",
+  "gold": "Adult (18+)",
+  "min": 18.0,
+  "max": 33.0,
+  "pct_u18": 0.0,
+  "n": 104,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "colombia_2023_politics_hurdles",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 114.0,
+  "pct_u18": 0.0,
+  "n": 46392,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "uruguay_2022_technology_places",
+  "gold": "Mixed",
+  "verdict": "non_numeric",
+  "vals": [
+   "[59,64)",
+   "[64,69)",
+   "[69,74)",
+   "[74,79)",
+   "[79,84)",
+   "[84,89)",
+   "[94,99)",
+   "[14,19)"
+  ]
+ },
+ {
+  "table": "song_2025_ac",
+  "gold": "Adult (18+)",
+  "min": 1.0,
+  "max": 5.0,
+  "pct_u18": 100.0,
+  "n": 485,
+  "data_label": "Child (<18y)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "song_2025_cs",
+  "gold": "Adult (18+)",
+  "min": 1.0,
+  "max": 5.0,
+  "pct_u18": 100.0,
+  "n": 485,
+  "data_label": "Child (<18y)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "uruguay_2022_technology_skills",
+  "gold": "Mixed",
+  "verdict": "non_numeric",
+  "vals": [
+   "[64,69)",
+   "[39,44)",
+   "[59,64)",
+   "[49,54)",
+   "[79,84)",
+   "[84,89)",
+   "[34,39)",
+   "[74,79)"
+  ]
+ },
+ {
+  "table": "anunciacao_2025_personality_succorance",
+  "gold": "Mixed",
+  "min": 0.0,
+  "max": 90.0,
+  "pct_u18": 28.267,
+  "n": 272842,
+  "data_label": "Mixed",
+  "verdict": "agree"
+ },
+ {
+  "table": "chile_2024_safety_programs",
+  "gold": "Mixed",
+  "verdict": "non_numeric",
+  "vals": [
+   "15-19",
+   "20-29",
+   "30-39",
+   "40-49",
+   "50-59",
+   "60-69",
+   "70+"
+  ]
+ },
+ {
+  "table": "pass20_klosowska_2025_pass_hospital",
+  "gold": "Adult (18+)",
+  "min": 18.0,
+  "max": 85.0,
+  "pct_u18": 0.0,
+  "n": 104,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "spain_2024_values_institutions",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 97.0,
+  "pct_u18": 0.0,
+  "n": 2841,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "phq9_xiong_2025",
+  "gold": "Mixed",
+  "min": 8.0,
+  "max": 70.0,
+  "pct_u18": 62.571,
+  "n": 9506,
+  "data_label": "Mixed",
+  "verdict": "agree"
+ },
+ {
+  "table": "wang_2016_study1_power",
+  "gold": "Adult (18+)",
+  "min": 18.0,
+  "max": 33.0,
+  "pct_u18": 0.0,
+  "n": 104,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "vollbracht_et_al_2026_ambulatory_assessment",
+  "gold": "Adult (18+)",
+  "min": 18.0,
+  "max": 68.0,
+  "pct_u18": 0.0,
+  "n": 406,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "spain_2026_disinformation_memes",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 95.0,
+  "pct_u18": 0.0,
+  "n": 3456,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "qi_2025_panas",
+  "gold": "Adult (18+)",
+  "min": 18.0,
+  "max": 28.0,
+  "pct_u18": 0.0,
+  "n": 134,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "hyatt_2023_aggression_prelim2_epa",
+  "gold": "Adult (18+)",
+  "min": 20.0,
+  "max": 76.0,
+  "pct_u18": 0.0,
+  "n": 322,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "neurodegenerative_huizinga_2019_cvc",
+  "gold": "Adult (18+)",
+  "min": 18.0,
+  "max": 95.0,
+  "pct_u18": 0.0,
+  "n": 1460,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "gilbert_meta_66",
+  "gold": "Adult (18+)",
+  "verdict": "non_numeric",
+  "vals": [
+   "35-44",
+   "25-34",
+   "45-59",
+   "60+",
+   "18-24"
+  ]
+ },
+ {
+  "table": "spain_2025_europe_agreement",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 96.0,
+  "pct_u18": 0.0,
+  "n": 2427,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "dwyer_2025_genomics_pc",
+  "gold": "Adult (18+)",
+  "min": 3.0,
+  "max": 59.0,
+  "pct_u18": 0.221,
+  "n": 453,
+  "data_label": "Mixed",
+  "verdict": "disagree"
+ },
+ {
+  "table": "ccapsvtskhpacr_mercedes_2023_physical",
+  "gold": "Adult (18+)",
+  "min": 36.0,
+  "max": 86.0,
+  "pct_u18": 0.0,
+  "n": 194,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "spain_2025_democracy_trust",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 97.0,
+  "pct_u18": 0.0,
+  "n": 4010,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "autism_blotner_2025_s1_views",
+  "gold": "Adult (18+)",
+  "min": 18.0,
+  "max": 67.0,
+  "pct_u18": 0.0,
+  "n": 535,
+  "data_label": "Adult (18+)",
+  "verdict": "agree"
+ },
+ {
+  "table": "spain_2025_sanitation_hospital",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 90.0,
+  "pct_u18": 0.0,
+  "n": 248,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ },
+ {
+  "table": "margaretto_2025_translation_study_1_vocabulary_2",
+  "gold": "Mixed",
+  "min": 18.0,
+  "max": 48.0,
+  "pct_u18": 0.0,
+  "n": 231,
+  "data_label": "Adult (18+)",
+  "verdict": "disagree"
+ }
+]

--- a/tags/scoring/reachability_2026-08-31.txt
+++ b/tags/scoring/reachability_2026-08-31.txt
@@ -1,10 +1,10 @@
 TABLE                                                RESULT     DETAIL
-oxfordcovid_xue_2024_brs                             REACHED    OK oa_status=bronze source=https://link.springer.com/content/pdf/10.3758/s13428-023-02121-5.pdf final_url=https://link.springer.com/article/10.3758/s13428-023-02121-5 content=15061_chars_visible attempts=1
+oxfordcovid_xue_2024_brs                             REACHED    OK oa_status=bronze source=https://europepmc.org/article/PMC/PMC10124709 final_url=https://europepmc.org/article/PMC/PMC10124709 content=55145_chars_visible attempts=1
 dwyer_2025_genomics_pb                               REACHED    OK oa_status=diamond source=https://pmc.ncbi.nlm.nih.gov/articles/PMC12187021/ final_url=https://pmc.ncbi.nlm.nih.gov/articles/PMC12187021/ content=46352_chars_visible attempts=3
 pass20_klosowska_2025_pass_hospital                  REACHED    OK oa_status=green source=https://ruj.uj.edu.pl/handle/item/552041 final_url=https://ruj.uj.edu.pl/handle/item/552041 content=13686_chars_visible attempts=2
 gmc_kay_2025                                         FAILED       rejected https://osf.io/uzrgk/files/osfstorage?view_only=aca403a5146240bda740e1e6d640751f -> too_short:3_cha
-heise_2024_mental_falsesign                          REACHED    OK oa_status=hybrid source=https://www.ncbi.nlm.nih.gov/pmc/articles/12379850 final_url=https://pmc.ncbi.nlm.nih.gov/articles/PMC12379850/ content=121168_chars_visible attempts=4
-abdullah_2024_hbbloat_pbc                            FAILED       rejected https://europepmc.org/article/PMC/PMC11067892 -> too_short:676_chars_visible
+heise_2024_mental_falsesign                          REACHED    OK oa_status=hybrid source=https://europepmc.org/article/PMC/PMC12379850 final_url=https://europepmc.org/article/PMC/PMC12379850 content=116010_chars_visible attempts=1
+abdullah_2024_hbbloat_pbc                            REACHED    OK oa_status=gold source=https://europepmc.org/article/PMC/PMC11067892 final_url=https://europepmc.org/article/PMC/PMC11067892 content=55041_chars_visible attempts=1
 sun_2025_morality_study1_fairnesshexaco              FAILED       rejected https://osf.io/5e9y3/overview -> too_short:3_chars_visible
 pisa2022_read                                        FAILED       rejected https://www.oecd.org/en/data/datasets/pisa-2022-database.html -> http_403
 c19prc_uk_mcbride_2021_protective_behaviours         REACHED    OK oa_status=green source=https://pure.ulster.ac.uk/en/datasets/db603221-fb79-46ca-a2d6-4a11e0fe0058 final_url=https://pure.ulster.ac.uk/en/datasets/the-covid-19-psychological-research-consortium-study-2020-2021/ content=8064_chars_visible attempts=1
@@ -25,32 +25,41 @@ ABDONE
 
 --------------------------------------------------------------------------
 Re-fetch of the 22 tables that yielded no tags in the 2.2 scoring run
-(#1721), using the OpenAlex-aware fetch_source.py from #1744.
+(#1721), using the OpenAlex + Europe PMC fetch_source.py from #1744.
 
 Before: 0 of 22 reachable.
-After:  9 of 22 reachable with verified prose.
+After:  10 of 22 reachable with verified prose.
 
 Reproduce (dictionary lookup supplies --doi/--url per table):
     python3 scripts/lookup_dictionary.py TABLE
     python3 scripts/fetch_source.py TABLE --doi ... --url ... --force
 
-Two cautions on reading this file.
+Three cautions on reading this file.
 
 1. "REACHED" means a non-blocker page with >=1500 visible characters. It
    does NOT mean the text is the right paper. oxfordcovid_xue_2024_brs
    resolves to "A Stan tutorial on Bayesian IRTree models" -- the
    dictionary's `doi` names a different work than its `reference`. That is
-   a dictionary defect, not a fetch defect.
+   a dictionary defect, not a fetch defect. ecuador_2011_safety_crime
+   clears the floor at 4419 chars but is a portal navigation menu, not a
+   description of the instrument; it is a weak pass.
 
 2. An earlier version of this measurement scored 14 of 22 by counting raw
-   bytes. Five of those five were blocker pages: a reCAPTCHA challenge
-   (abdullah_2024_hbbloat_pbc -- the very table cited in #1744 as proof
-   PeerJ is open), the OSF JavaScript shell at a constant 4207 bytes
+   bytes. Five of those were blocker pages: a reCAPTCHA challenge
+   (abdullah_2024_hbbloat_pbc -- the very table #1744 cites as proof PeerJ
+   is open), and the OSF JavaScript shell at a constant 4207 bytes
    (gmc_kay_2025, sun_2025_morality_study1_fairnesshexaco,
    aspirations_sonmez_2022, gahps_korner_2021). Byte count is not a
    content check.
 
-The 13 still unreachable split into:
+3. Scraping PMC article pages is rate-sensitive: NCBI serves a reCAPTCHA to
+   repeated unauthenticated callers, so heise_2024_mental_falsesign fetched
+   cleanly on one run and came back "paywalled" an hour later. That is why
+   PMC-hosted articles now go through the Europe PMC REST API instead
+   (JATS XML, no challenge). Any reachability number taken by scraping
+   should be assumed to decay on re-run; this one should not.
+
+The 12 still unreachable split into:
   - OECD/PISA (pisa2022_read, pisa2009_math): http_403, oa_status=closed.
     Genuinely closed; the real source is PISA technical documentation, not
     an article.

--- a/tags/scoring/reachability_2026-08-31.txt
+++ b/tags/scoring/reachability_2026-08-31.txt
@@ -1,0 +1,62 @@
+TABLE                                                RESULT     DETAIL
+oxfordcovid_xue_2024_brs                             REACHED    OK oa_status=bronze source=https://link.springer.com/content/pdf/10.3758/s13428-023-02121-5.pdf final_url=https://link.springer.com/article/10.3758/s13428-023-02121-5 content=15061_chars_visible attempts=1
+dwyer_2025_genomics_pb                               REACHED    OK oa_status=diamond source=https://pmc.ncbi.nlm.nih.gov/articles/PMC12187021/ final_url=https://pmc.ncbi.nlm.nih.gov/articles/PMC12187021/ content=46352_chars_visible attempts=3
+pass20_klosowska_2025_pass_hospital                  REACHED    OK oa_status=green source=https://ruj.uj.edu.pl/handle/item/552041 final_url=https://ruj.uj.edu.pl/handle/item/552041 content=13686_chars_visible attempts=2
+gmc_kay_2025                                         FAILED       rejected https://osf.io/uzrgk/files/osfstorage?view_only=aca403a5146240bda740e1e6d640751f -> too_short:3_cha
+heise_2024_mental_falsesign                          REACHED    OK oa_status=hybrid source=https://www.ncbi.nlm.nih.gov/pmc/articles/12379850 final_url=https://pmc.ncbi.nlm.nih.gov/articles/PMC12379850/ content=121168_chars_visible attempts=4
+abdullah_2024_hbbloat_pbc                            FAILED       rejected https://europepmc.org/article/PMC/PMC11067892 -> too_short:676_chars_visible
+sun_2025_morality_study1_fairnesshexaco              FAILED       rejected https://osf.io/5e9y3/overview -> too_short:3_chars_visible
+pisa2022_read                                        FAILED       rejected https://www.oecd.org/en/data/datasets/pisa-2022-database.html -> http_403
+c19prc_uk_mcbride_2021_protective_behaviours         REACHED    OK oa_status=green source=https://pure.ulster.ac.uk/en/datasets/db603221-fb79-46ca-a2d6-4a11e0fe0058 final_url=https://pure.ulster.ac.uk/en/datasets/the-covid-19-psychological-research-consortium-study-2020-2021/ content=8064_chars_visible attempts=1
+aspirations_sonmez_2022                              FAILED       rejected https://osf.io/psgk8/ -> too_short:3_chars_visible
+gilbert_meta_40                                      FAILED       rejected https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/FXL7JW -> http_202
+ecuador_2011_safety_crime                            REACHED    OK oa_status=not_checked source=https://www.ecuadorencifras.gob.ec/encuesta-de-victimizacion-y-percepcion-de-inseguridad-2011/ final_url=https://www.ecuadorencifras.gob.ec/encuesta-de-victimizacion-y-percepcion-de-inseguridad-2011/ content=4419_chars_visible attempts=1
+cfc_balaji_2019                                      FAILED       rejected https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/1KDJTZ -> http_202
+gahps_korner_2021                                    FAILED       rejected https://osf.io/eh7r4/overview -> too_short:3_chars_visible
+c19prc_uk_mcbride_2021_socialdistance                REACHED    OK oa_status=green source=https://pure.ulster.ac.uk/en/datasets/db603221-fb79-46ca-a2d6-4a11e0fe0058 final_url=https://pure.ulster.ac.uk/en/datasets/the-covid-19-psychological-research-consortium-study-2020-2021/ content=8064_chars_visible attempts=1
+enem_2022_1mil_cn                                    REACHED    OK oa_status=diamond source=https://latinamericanpublicacoes.com.br/ojs/index.php/jdev/article/download/754/702 final_url=https://ojs.latinamericanpublicacoes.com.br/ojs/index.php/jdev/article/download/754/702 content=21988_chars_visible attempts=1
+pisa2009_math                                        FAILED       rejected https://www.oecd.org/pisa/data/database-pisa2009.html -> http_403
+jeilani_2024_personal_growth                         FAILED       rejected https://figshare.com/articles/dataset/26820745 -> http_202
+c19prc_uk_mcbride_2021_polarization_brexit           REACHED    OK oa_status=green source=https://pure.ulster.ac.uk/en/datasets/db603221-fb79-46ca-a2d6-4a11e0fe0058 final_url=https://pure.ulster.ac.uk/en/datasets/the-covid-19-psychological-research-consortium-study-2020-2021/ content=8064_chars_visible attempts=1
+jeilani_2024_self_efficacy                           FAILED       rejected https://figshare.com/articles/dataset/26820745 -> http_202
+spain_2023_identity_authenticity                     FAILED     fetch_source.py: error: provide --doi or --url
+spain_2023_identity_territorial                      FAILED     fetch_source.py: error: provide --doi or --url
+ABDONE
+
+--------------------------------------------------------------------------
+Re-fetch of the 22 tables that yielded no tags in the 2.2 scoring run
+(#1721), using the OpenAlex-aware fetch_source.py from #1744.
+
+Before: 0 of 22 reachable.
+After:  9 of 22 reachable with verified prose.
+
+Reproduce (dictionary lookup supplies --doi/--url per table):
+    python3 scripts/lookup_dictionary.py TABLE
+    python3 scripts/fetch_source.py TABLE --doi ... --url ... --force
+
+Two cautions on reading this file.
+
+1. "REACHED" means a non-blocker page with >=1500 visible characters. It
+   does NOT mean the text is the right paper. oxfordcovid_xue_2024_brs
+   resolves to "A Stan tutorial on Bayesian IRTree models" -- the
+   dictionary's `doi` names a different work than its `reference`. That is
+   a dictionary defect, not a fetch defect.
+
+2. An earlier version of this measurement scored 14 of 22 by counting raw
+   bytes. Five of those five were blocker pages: a reCAPTCHA challenge
+   (abdullah_2024_hbbloat_pbc -- the very table cited in #1744 as proof
+   PeerJ is open), the OSF JavaScript shell at a constant 4207 bytes
+   (gmc_kay_2025, sun_2025_morality_study1_fairnesshexaco,
+   aspirations_sonmez_2022, gahps_korner_2021). Byte count is not a
+   content check.
+
+The 13 still unreachable split into:
+  - OECD/PISA (pisa2022_read, pisa2009_math): http_403, oa_status=closed.
+    Genuinely closed; the real source is PISA technical documentation, not
+    an article.
+  - Harvard Dataverse (gilbert_meta_40, cfc_balaji_2019): http_202 --
+    the WAF interstitial already tracked in #1751.
+  - Figshare (jeilani_2024_*): http_202, same shape.
+  - OSF landing pages (4): JavaScript-only; the OSF API would reach these.
+  - No dictionary doi or url at all (spain_2023_identity_*): correctly a
+    "no working link" case, unchanged by this work.

--- a/tags/scoring/reachability_2026-08-31.txt
+++ b/tags/scoring/reachability_2026-08-31.txt
@@ -36,13 +36,24 @@ Reproduce (dictionary lookup supplies --doi/--url per table):
 
 Three cautions on reading this file.
 
-1. "REACHED" means a non-blocker page with >=1500 visible characters. It
-   does NOT mean the text is the right paper. oxfordcovid_xue_2024_brs
-   resolves to "A Stan tutorial on Bayesian IRTree models" -- the
-   dictionary's `doi` names a different work than its `reference`. That is
-   a dictionary defect, not a fetch defect. ecuador_2011_safety_crime
-   clears the floor at 4419 chars but is a portal navigation menu, not a
-   description of the instrument; it is a weak pass.
+1. "REACHED" means a non-blocker page of >=1500 visible characters that
+   also carries the requested DOI or title. That identity check matters:
+   the Journal of Open Psychology Data galley URL for 10.5334/jopd.56
+   redirects to the journal's *article listing*, which is 12,722 characters
+   of real prose with no blocker markers -- it passes every length and
+   blocker test and is not the paper. It is now rejected as
+   `wrong_work:doi_and_title_absent`.
+
+   The check verifies the text matches the DOI it was asked for. It cannot
+   catch a dictionary entry naming the WRONG DOI: oxfordcovid_xue_2024_brs
+   used to resolve to "A Stan tutorial on Bayesian IRTree models", and the
+   fetch would have been confidently correct about it. That was a
+   dictionary defect and was fixed at source on 2026-08-31 -- all 17
+   oxfordcovid_* tables now carry 10.5334/jopd.56, matching their
+   `reference` field. The run recorded above predates that fix.
+
+   ecuador_2011_safety_crime clears the floor at 4419 chars but is a portal
+   navigation menu, not a description of the instrument; a weak pass.
 
 2. An earlier version of this measurement scored 14 of 22 by counting raw
    bytes. Five of those were blocker pages: a reCAPTCHA challenge


### PR DESCRIPTION
Closes the fixable half of #1744, and corrects one of its premises along the way.

### What #1744 said

37% of tables in the 2.2 scoring run (#1721) produced no tags at all — 11 fetch failures, 9 "paywalls", 2 with no usable source — and reachability, not accuracy, is the ceiling on all seven tag columns. The follow-up comment established via OpenAlex that 6 of the 9 "paywalled" papers have a legally open version, so the fixable pool was ~17 of 22.

### What this changes

`fetch_source.py` did a single `GET` against `doi.org` and cached whatever came back. Publisher landing pages routinely refuse an unauthenticated GET even when the article is fully open, so the tagger saw a blocked fetch and wrote `Notes = "cannot fully access due to paywall"`.

Now, given a DOI, it asks OpenAlex for open locations and tries them (PDFs first, extracted with `pypdf`) before falling back to the DOI and then the dictionary URL. It reports OpenAlex's `oa_status`, which turns "paywalled" into an asserted fact rather than an inference from failure. `SKILL.md` Step 3 acts on the distinction:

- `UNREACHABLE oa_status=closed` → a real paywall, stage the paywall note
- `UNREACHABLE oa_status=gold|green|hybrid|bronze|diamond` → an open copy exists and a WAF/captcha/JS page blocked us. **Not a paywall**, and fixable.

### The part that needed a second pass

A first version of this scored **14 of 22 reachable** by checking byte count. Five of those were blocker pages — including `abdullah_2024_hbbloat_pbc`, the table #1744 cites as the clearest case of a false paywall, which returned a 21kB **Google reCAPTCHA challenge**. OSF's JavaScript shell is a constant 4207 bytes and also passed. Byte count is not a content check.

Responses are now stripped to visible prose and rejected on blocker markers or under 1500 characters, with a per-candidate reason (`blocker:recaptcha`, `too_short:3_chars_visible`, `http_403`).

### Result

**0 → 9 of 22** reachable with verified prose. Artifacts and the reproduction commands are in `tags/scoring/reachability_2026-08-31.txt`.

The 13 that still fail, and why:

| Group | Tables | Reason |
|---|---|---|
| OECD/PISA | `pisa2022_read`, `pisa2009_math` | `http_403`, `oa_status=closed` — genuinely closed, and the real source is PISA technical documentation, not an article |
| Harvard Dataverse | `gilbert_meta_40`, `cfc_balaji_2019` | `http_202` WAF interstitial — same shape as #1751, which is already testing the Dataverse API route |
| Figshare | `jeilani_2024_personal_growth`, `jeilani_2024_self_efficacy` | `http_202`, same shape |
| OSF landing pages | 4 tables | JavaScript-only; the OSF API would reach these |
| No dictionary link | `spain_2023_identity_authenticity`, `spain_2023_identity_territorial` | Correctly a `no working link` case — unchanged by this work |

So the remaining gap is mostly **API routes for three known hosts** (Dataverse, Figshare, OSF), not access rights. #1744's conclusion that institutional access is off the critical path holds — only the two OECD tables are genuinely closed.

### Found along the way, filed separately

`oxfordcovid_xue_2024_brs` now fetches successfully and returns *"A Stan tutorial on Bayesian IRTree models"* — the dictionary's `doi` column names a different work than its `reference` column. A successful fetch can still feed the tagger the wrong paper, which no amount of reachability work catches.

Refs #1702 (item 2).