### PR TITLE
Report how the multi-select tag columns miss, not just whether (#1721)

### DIFF
--- a/tags/scoring/README.md
+++ b/tags/scoring/README.md
@@ -57,6 +57,36 @@ prediction against NA is correct rather than an abstention.
 | `age_range` | 73.0% | 97.4% | 71.1% |
 | `construct_type` | 64.9% | 100% | 64.9% |
 | `sample` | **41.7%** | 94.7% | 39.5% |
+
+### Set equality hides which way a multi-select column fails
+
+`sample` and `construct_type` are scored on set equality, so predicting two of a
+construct's three facets scores the same zero as naming an unrelated one. Those
+two columns have similar exact-match rates and are not alike:
+
+| column | n | exact | subset | superset | disjoint | shares >=1 atom |
+|---|---|---|---|---|---|---|
+| `primary_languages` | 33 | 90.9% | 3 | 0 | 0.0% | **100%** |
+| `construct_type` | 37 | 64.9% | 5 | 2 | 16.2% | **83.8%** |
+| `sample` | 36 | 41.7% | 3 | 0 | **50.0%** | 50.0% |
+
+`construct_type` mostly disagrees about *granularity*: `preschool_sel_akt` gold
+is `{Affective/mental health, Cognitive/educational, Developmental}` and the
+tagger returned two of those three. `sample` mostly picks a *different category*:
+
+    gold Targeted/specific     ->  pred Representative
+    gold General/non-specific  ->  pred Representative
+    gold Educational           ->  pred Targeted/specific
+
+Is a national probability survey `General/non-specific` or `Representative`?
+`vocab.md` lists the nine atoms and defines none of them. 2.1 (#1720) made these
+vocabularies enforced but not defined, which is the same root cause as #1760.
+So `sample`'s 41.7% is not a measure of model capability -- it measures asking a
+model to match a convention nobody has written down.
+
+Consequence for 2.3 (#1722): these two columns should not share a verdict. One
+needs its vocabulary defined; the other mostly needs a scoring rule that credits
+a partial match. Regenerate this table with `score.py`.
 | `child_age` | 75.0% | 66.7% | 50.0% (n=6) |
 
 ## What the numbers say

--- a/tags/scoring/score.py
+++ b/tags/scoring/score.py
@@ -19,6 +19,15 @@ punish the behaviour we asked for. Three numbers per column instead:
 child_age is reported separately as well: gold is NA for ~80% of rows because the
 column only applies to child-focused studies, so there NA is a real answer
 meaning "not applicable" and a blank prediction against it is correct.
+
+Set equality is strict, and for the multi-select columns it hides a distinction
+that matters: predicting two of a construct's three facets scores the same zero
+as naming an unrelated one. So those columns also get a breakdown of HOW they
+miss -- subset, superset, partial overlap, or disjoint. sample and
+construct_type report near-identical exact-match rates and are not alike:
+construct_type mostly disagrees about granularity, while sample mostly picks a
+different category outright, because its atoms overlap and vocab.md defines
+none of them (see #1760).
 """
 import csv, json, sys, html, collections
 
@@ -49,6 +58,20 @@ def norm(v, multi):
     if not atoms:
         return None
     return tuple(sorted(set(atoms)))
+
+
+def _miss_kind(gv, pv):
+    """How a multi-select prediction relates to gold -- not just right/wrong."""
+    g, p = set(gv), set(pv)
+    if g == p:
+        return "exact"
+    if p < g:
+        return "subset"      # right atoms, missed some
+    if p > g:
+        return "superset"    # right atoms, added some
+    if g & p:
+        return "overlap"     # partly right
+    return "disjoint"        # nothing in common
 
 
 def run(pred_path, sample_path):
@@ -97,6 +120,8 @@ def run(pred_path, sample_path):
             else:
                 s["wrong"] += 1
                 confusion[pkey][(", ".join(gv), ", ".join(pv))] += 1
+            if multi:
+                s[_miss_kind(gv, pv)] += 1
     return stats, confusion, per_ws, abst, preds
 
 
@@ -128,6 +153,22 @@ if __name__ == "__main__":
         if c["gold"]:
             print(f"  {ws:28s} {c['tables']:2d} tagged, {c['abstained']:2d} abstained  "
                   f"{c['correct']:3d}/{c['gold']:3d} = {100*c['correct']/c['gold']:5.1f}%")
+
+    multi = [c for c in COLS if c[2]]
+    print("\nmulti-select columns -- how they miss, not just whether:")
+    print(f"  {'column':20s} {'n':>4s} {'exact':>8s} {'subset':>7s} {'super':>6s} "
+          f"{'overlap':>8s} {'disjoint':>9s}  {'>=1 atom':>9s}")
+    for pkey, _, _ in multi:
+        s = stats[pkey]
+        n = sum(s[k] for k in ("exact", "subset", "superset", "overlap", "disjoint"))
+        if not n:
+            continue
+        shared = n - s["disjoint"]
+        print(f"  {pkey:20s} {n:4d} {f(s['exact'],n):>8s} {s['subset']:7d} "
+              f"{s['superset']:6d} {s['overlap']:8d} {f(s['disjoint'],n):>9s}  "
+              f"{f(shared,n):>9s}")
+    print("  A subset or superset is a granularity disagreement on a genuinely")
+    print("  multi-faceted answer; a disjoint miss is a different answer entirely.")
 
     print("\nconfusions (gold -> predicted):")
     for pkey, _, _ in COLS:


### PR DESCRIPTION
Follow-up to #1721, which is closed — recording a correction to how its six numbers should be read, so it is in the artifact rather than only in a comment.

`sample` and `construct_type` were scored on **set equality**. That collapses two different failures into one number: predicting two of a construct's three facets scores the same zero as naming an unrelated category.

`score.py` now decomposes multi-select misses:

| column | n | exact | subset | superset | disjoint | shares ≥1 atom |
|---|---|---|---|---|---|---|
| `primary_languages` | 33 | 90.9% | 3 | 0 | 0.0% | **100%** |
| `construct_type` | 37 | 64.9% | 5 | 2 | 16.2% | **83.8%** |
| `sample` | 36 | 41.7% | 3 | 0 | **50.0%** | 50.0% |

**`construct_type` disagrees about granularity** — `preschool_sel_akt` gold is `{Affective/mental health, Cognitive/educational, Developmental}`, tagger returned two of the three. 64.9% understates it.

**`sample` picks a different category**, and definitionally so:

```
gold Targeted/specific     ->  pred Representative
gold General/non-specific  ->  pred Representative
gold Educational           ->  pred Targeted/specific
```

Is a national probability survey `General/non-specific` or `Representative`? `vocab.md` lists the nine atoms and defines none of them.

### The general point

2.1 (#1720) made these vocabularies **enforced** but never **defined** — the same root cause as the referent question in #1760. So `sample`'s 41.7% is not a measure of model capability; it measures asking a model to match a convention nobody has written down.

**Consequence for 2.3 (#1722):** #1721's suggested bar puts `sample` and `construct_type` together in "do not ship". They should not share a verdict — one needs its vocabulary defined, the other mostly needs a scoring rule that credits partial matches.