### PR TITLE
Stop publishing tags for tables the IRW no longer serves (#1765, 2.5a)

### DIFF
--- a/metadata/03_tags.R
+++ b/metadata/03_tags.R
@@ -162,6 +162,23 @@ get_tags <- function(db) {
                      " (", sum(superseded), " superseded by the sheet)"))
     }
 
+    ##Drop tags for tables the IRW no longer publishes. 194 of the 2,480 rows
+    ##in tags.csv name a table that is not live on Redivis -- retired or
+    ##renamed -- and none of them is merely awaiting a metadata row (#1765).
+    ##They are published anyway, so the table overstates coverage, and
+    ##Rpkg's .irw_filter_rows_to_live_tables() then removes them again on read.
+    ##That filter is correct but silent, so the published CSV and irw_tags()
+    ##disagree by ~8% for reasons no user can see. Dropping here makes the
+    ##published table mean what it says and leaves the R-package filter with
+    ##nothing to do.
+    ##
+    ##metadata.csv is the liveness oracle rather than a Redivis call: 01
+    ##runs before 03, and it is currently row-for-row identical to the live
+    ##catalog (4,134 = 4,134, zero drift either way, #1765). Matching is
+    ##case-insensitive -- 308 tag rows differ from their metadata row only by
+    ##case, and a case-sensitive join would silently discard every one.
+    tag <- drop_retired_tables(tag, db)
+
     ##Normalise the multi-select columns before writing. Fails loudly on any
     ##atom outside the controlled vocabulary rather than publishing it -- the
     ##union happens above precisely so auto rows face the same check.
@@ -171,10 +188,44 @@ get_tags <- function(db) {
     invisible(tag)
 }
 
+##Rows whose table is absent from the live catalog. Returns `tag` unchanged,
+##loudly, if the oracle is missing or implausibly small -- a truncated
+##metadata.csv must never be able to delete the tag corpus.
+drop_retired_tables <- function(tag, db, min_oracle_rows = 1000) {
+    if (is.null(db$file.live)) return(tag)          ##nom has its own catalog
+    if (!file.exists(db$file.live)) {
+        warning(db$name, ": ", db$file.live, " not found; publishing ",
+                nrow(tag), " tag rows without a liveness check. Run ",
+                "01_metadata.R first.", call. = FALSE)
+        return(tag)
+    }
+    live <- readr::read_csv(db$file.live, show_col_types = FALSE)
+    if (!"table" %in% names(live) || nrow(live) < min_oracle_rows) {
+        warning(db$name, ": ", db$file.live, " has ", nrow(live),
+                " row(s); too few to trust as a liveness oracle (expected at ",
+                "least ", min_oracle_rows, "). Skipping the retired-table ",
+                "check rather than risk dropping live tags.", call. = FALSE)
+        return(tag)
+    }
+    retired <- !(tolower(tag$table) %in% tolower(live$table))
+    if (any(retired)) {
+        ##Keep them on disk. These rows are real human annotation work, and a
+        ##retired table can come back under the same name.
+        out <- file.path(dirname(db$file.out),
+                         paste0("retired_", basename(db$file.out)))
+        readr::write_csv(tag[retired, , drop = FALSE], out)
+        print(paste0(db$name, ": dropped ", sum(retired),
+                     " tag row(s) for tables no longer live -> ", out))
+        tag <- tag[!retired, , drop = FALSE]
+    }
+    tag
+}
+
 dbs <- list(
     core = list(name = "core",
                 url = 'https://docs.google.com/spreadsheets/d/1V3ef0sa7HKtJJd2cgqRAkEdfbpGWDD1JIyQa6HwVK7g/edit?gid=126134123#gid=126134123',
                 file.auto = "../tags/tags_auto.csv",
+                file.live = "metadata.csv",
                 file.out = "tags.csv"),
     ##`nom` has no file.auto on purpose. tags/nominal_tags_staging.csv looks like
     ##an auto file -- same 13 columns -- but it is an empty scaffold: every Rater

--- a/metadata/tests/test_tags_union.R
+++ b/metadata/tests/test_tags_union.R
@@ -175,6 +175,68 @@ repo_files <- function() {
 }
 repo_files()
 
+
+##--------------------------------------------- retired tables (#1765, 2.5a) ---
+##drop_retired_tables() removes tags for tables the IRW no longer publishes.
+##The failure modes matter more than the happy path: a missing or truncated
+##metadata.csv must never be able to delete the tag corpus, and the match must
+##be case-insensitive because 308 tag rows differ from their metadata row only
+##by case.
+
+with_oracle <- function(tables, f) {
+    d <- tempfile(); dir.create(d)
+    live <- file.path(d, "metadata.csv")
+    readr::write_csv(data.frame(table = tables), live)
+    on.exit(unlink(d, recursive = TRUE), add = TRUE)
+    f(live)
+}
+
+tag3 <- data.frame(table = c("alive_one", "RETIRED_one", "alive_two"),
+                   `age range` = c("Adult (18+)", "Mixed", "Mixed"),
+                   check.names = FALSE)
+
+##Happy path: the retired row goes, the live ones stay.
+with_oracle(c(paste0("filler", 1:1200), "alive_one", "alive_two"), function(live) {
+    db <- list(name = "t", file.live = live, file.out = file.path(tempdir(), "tags.csv"))
+    out <- drop_retired_tables(tag3, db)
+    check(nrow(out) == 2 && !("RETIRED_one" %in% out$table),
+          "drop_retired_tables removes a tag row whose table is not live")
+    side <- file.path(tempdir(), "retired_tags.csv")
+    check(file.exists(side) && nrow(readr::read_csv(side, show_col_types = FALSE)) == 1,
+          "dropped rows are written to retired_tags.csv, not discarded")
+})
+
+##Case-insensitivity: 308 real rows depend on this.
+with_oracle(c(paste0("filler", 1:1200), "ALIVE_ONE", "alive_two"), function(live) {
+    db <- list(name = "t", file.live = live, file.out = file.path(tempdir(), "tags2.csv"))
+    out <- drop_retired_tables(tag3, db)
+    check("alive_one" %in% out$table,
+          "a tag row matching its metadata row only by case is kept, not dropped")
+})
+
+##A truncated oracle must not be able to wipe the corpus.
+with_oracle(c("alive_one"), function(live) {
+    db <- list(name = "t", file.live = live, file.out = file.path(tempdir(), "tags3.csv"))
+    out <- suppressWarnings(drop_retired_tables(tag3, db))
+    check(nrow(out) == nrow(tag3),
+          "an implausibly small metadata.csv is refused as an oracle, nothing dropped")
+})
+
+##A missing oracle is a warning, not a silent purge and not a hard stop.
+local({
+    db <- list(name = "t", file.live = file.path(tempdir(), "does_not_exist.csv"),
+               file.out = file.path(tempdir(), "tags4.csv"))
+    out <- suppressWarnings(drop_retired_tables(tag3, db))
+    check(nrow(out) == nrow(tag3),
+          "a missing metadata.csv publishes everything rather than dropping it")
+})
+
+##nom has no file.live and must be left entirely alone.
+local({
+    out <- drop_retired_tables(tag3, list(name = "nom", file.out = "nominal_tags.csv"))
+    check(identical(out, tag3), "a db with no file.live is untouched (nom)")
+})
+
 cat("\n")
 if (failures > 0L) { cat(failures, "FAILURE(S)\n"); quit(status = 1L) }
 cat("all tests passed\n")


### PR DESCRIPTION
First sub-action of #1765 (item 2.5).

## The problem

194 of the 2,480 rows in `tags.csv` name a table that is not live on Redivis. I checked all of them against the live catalog: **0 are live**. They are not a metadata backlog — they are retired or renamed tables whose tags describe nothing.

They get published anyway. `Rpkg/R/redivis-metadata.R:262` then strips them on read via `.irw_filter_rows_to_live_tables()`, which is why `irw_tags()` returns **2,286** rows against a published **2,480**. That filter is correct but silent, so:

- the published table and the R package disagree by ~8% for reasons no user can see
- any coverage figure computed from the published CSV is inflated
- `audit_tables.R` counts those tables as tagged, so they can never resurface as needing tags

## The fix

Drop them at the export boundary in `03_tags.R`. After this, the published table is 2,286 rows — exactly what `irw_tags()` already returns, now by construction rather than by a silent downstream filter.

```
before: 2480   after: 2286   dropped: 194
```

**`metadata.csv` is the liveness oracle**, not a Redivis call: 01 runs before 03, and it is currently row-for-row identical to the live catalog (4,134 = 4,134, zero drift either way). **The match is case-insensitive** — 308 tag rows differ from their metadata row only by case, and a case-sensitive join would discard every one of them.

**Dropped rows go to `metadata/retired_tags.csv`**, not to nothing. They are real human annotation work and a retired table can come back under the same name. Same shape as the sentinel-drop precedent in #1723: stop at the export boundary, keep the evidence.

## Guards

An oracle that fails open is worse than no oracle, so:

| condition | behaviour | tested |
|---|---|---|
| `metadata.csv` missing | warn, publish everything | ✅ |
| `metadata.csv` under 1,000 rows | refuse as implausible, drop nothing | ✅ |
| source has no `file.live` (`nom`) | untouched | ✅ |
| table matches only by case | kept | ✅ |
| happy path | dropped, and written to the side file | ✅ |

## Unrelated fix included

`test_tags_union.R` printed its summary and set exit status **before** its final block of tests ran, so a failure there would not have failed the suite. Summary moved to the end. All tests pass, existing ones included.