### PR TITLE
Publish corpus-state numbers from one place, with a history (#1765, 2.5c)

### DIFF
--- a/metadata/11_status.R
+++ b/metadata/11_status.R
@@ -1,0 +1,147 @@
+# 11_status.R
+#
+# Publishes the IRW's corpus-state numbers from one place, so they stop
+# being quoted from memory (issue #1765, sub-action 2.5c).
+#
+# The problem this solves: the Year 3 roadmap (#1702) reports tag coverage
+# as 61.7% and the corpus as ~3,650 tables. Two days later the corpus was
+# 4,134 tables and coverage was 55.3% -- it had FALLEN six points, because
+# the denominator grew by 484 while tagged tables grew by 35. Nobody
+# noticed, because the only way to know the number was to recompute it by
+# hand, and the figure in the write-up looked authoritative.
+#
+# So this emits two files, and the second one is the point:
+#
+#   status.json          the current numbers, machine-readable
+#   status_history.tsv   one appended row per run, so the TREND is visible
+#
+# A single snapshot goes stale silently. A history makes "coverage fell six
+# points" a thing you can see rather than a thing you have to discover.
+#
+# Both are deliberately TRACKED in git. metadata/**/*.csv is gitignored
+# because the pipeline CSVs are large regenerable outputs, but these two are
+# small and their whole value is being readable over time and in review --
+# hence .tsv rather than .csv for the history, which is the only reason for
+# that extension.
+#
+# Reads the local CSVs that 01/03/08 already produce. No Redivis calls, same
+# contract as 09_hero_status.R -- run the pipeline first or these numbers
+# describe whatever is on disk.
+#
+# Usage (from metadata/, like the rest of the numbered scripts):
+#   Rscript 11_status.R
+#   Rscript 11_status.R --dir . --json status.json --history status_history.tsv
+
+suppressPackageStartupMessages({
+    library(readr)
+    library(jsonlite)
+})
+
+args <- commandArgs(trailingOnly = TRUE)
+arg <- function(flag, default) {
+    i <- match(flag, args)
+    if (is.na(i) || i == length(args)) default else args[[i + 1L]]
+}
+dir      <- arg("--dir", ".")
+json_out <- arg("--json", file.path(dir, "status.json"))
+hist_out <- arg("--history", file.path(dir, "status_history.tsv"))
+
+read_or_stop <- function(name) {
+    p <- file.path(dir, name)
+    if (!file.exists(p)) {
+        stop(name, " not found in ", normalizePath(dir, mustWork = FALSE),
+             ". Run the pipeline first -- this script reports what is on ",
+             "disk and must not invent a number for a file it cannot read.",
+             call. = FALSE)
+    }
+    read_csv(p, show_col_types = FALSE)
+}
+
+##Every join here is case-insensitive on purpose. 308 tag rows differ from
+##their metadata row only by case, and a case-sensitive join silently drops
+##all of them -- which is how tag coverage once read 53% instead of 62%.
+key <- function(x) tolower(trimws(as.character(x)))
+
+metadata <- read_or_stop("metadata.csv")
+tags     <- read_or_stop("tags.csv")
+itemtext <- tryCatch(read_or_stop("itemtext_metadata.csv"), error = function(e) NULL)
+
+live <- key(metadata$table)
+n    <- length(live)
+if (n == 0L) stop("metadata.csv has no rows; refusing to publish a status file.")
+
+covered <- function(other) if (is.null(other)) NA_integer_ else sum(live %in% key(other))
+pct     <- function(k) if (is.na(k)) NA_real_ else round(100 * k / n, 1)
+
+n_tags <- covered(tags$table)
+n_text <- covered(if (is.null(itemtext)) NULL else itemtext$table)
+
+##Per-warehouse, because the aggregate hides where the gap actually is: the
+##roadmap named w3/w4 as the undertagged shards, and by 2026-08-31 w5 was
+##worse than either at 7.8% across 206 tables.
+shard <- ifelse(is.na(metadata$dataset) | metadata$dataset == "",
+                "unknown", as.character(metadata$dataset))
+by_shard <- lapply(split(seq_len(n), shard), function(idx) {
+    list(n_tables = length(idx),
+         tagged   = sum(live[idx] %in% key(tags$table)),
+         pct      = round(100 * sum(live[idx] %in% key(tags$table)) / length(idx), 1))
+})
+
+status <- list(
+    generated   = format(Sys.time(), "%Y-%m-%dT%H:%M:%S%z"),
+    source      = "metadata/11_status.R -- local pipeline CSVs, no Redivis calls",
+    n_tables    = n,
+    coverage    = list(
+        tags     = list(n = n_tags, pct = pct(n_tags)),
+        itemtext = list(n = n_text, pct = pct(n_text))
+    ),
+    tags_by_shard = by_shard,
+    ##Orphan rows should be 0 from #1766 onward: 03_tags.R now drops tag rows
+    ##for tables that are not live. A non-zero value here means that guard
+    ##did not run, or ran against a stale metadata.csv.
+    orphan_tag_rows = sum(!(key(tags$table) %in% live))
+)
+
+write_json(status, json_out, auto_unbox = TRUE, pretty = TRUE, digits = NA)
+
+row <- data.frame(
+    date            = format(Sys.Date()),
+    n_tables        = n,
+    tagged          = n_tags,
+    tagged_pct      = pct(n_tags),
+    itemtext        = n_text,
+    itemtext_pct    = pct(n_text),
+    orphan_tag_rows = status$orphan_tag_rows
+)
+##Append, never rewrite: the history is the deliverable, and one bad run
+##must not be able to erase what earlier runs recorded. Re-running on a day
+##when nothing moved is a no-op rather than a duplicate row -- the pipeline
+##gets run repeatedly while debugging, and a history padded with identical
+##rows is harder to read the trend out of.
+unchanged <- FALSE
+if (file.exists(hist_out)) {
+    ##Read as character throughout. Type inference would parse `date` as a
+    ##Date, and unlist() then strips the class and compares the underlying
+    ##day count against the formatted string -- so the guard never fires.
+    prev <- suppressWarnings(read_tsv(hist_out, show_col_types = FALSE,
+                                      col_types = cols(.default = col_character())))
+    if (nrow(prev) > 0L) {
+        last <- prev[nrow(prev), , drop = FALSE]
+        cmp  <- intersect(names(last), names(row))
+        as_chr <- function(d) vapply(d, function(x) as.character(x), character(1))
+        unchanged <- identical(as_chr(last[cmp]), as_chr(row[cmp]))
+    }
+}
+if (unchanged) {
+    cat("history unchanged since the last run; not appending a duplicate row\n")
+} else {
+    write_tsv(row, hist_out, append = file.exists(hist_out),
+              col_names = !file.exists(hist_out))
+}
+
+cat(sprintf("%s: %d tables | tags %d (%.1f%%) | itemtext %d (%.1f%%) | orphan tag rows %d\n",
+            row$date, n, n_tags, pct(n_tags), n_text, pct(n_text),
+            status$orphan_tag_rows))
+cat("wrote ", json_out,
+    if (unchanged) paste0("; ", hist_out, " unchanged")
+    else paste0("; appended to ", hist_out), "\n", sep = "")

--- a/metadata/status.json
+++ b/metadata/status.json
@@ -1,0 +1,48 @@
+{
+  "generated": "2026-08-31T20:28:48-0700",
+  "source": "metadata/11_status.R -- local pipeline CSVs, no Redivis calls",
+  "n_tables": 4134,
+  "coverage": {
+    "tags": {
+      "n": 2286,
+      "pct": 55.3
+    },
+    "itemtext": {
+      "n": 558,
+      "pct": 13.5
+    }
+  },
+  "tags_by_shard": {
+    "item_response_warehouse": {
+      "n_tables": 988,
+      "tagged": 987,
+      "pct": 99.9
+    },
+    "item_response_warehouse_2": {
+      "n_tables": 975,
+      "tagged": 755,
+      "pct": 77.4
+    },
+    "item_response_warehouse_3": {
+      "n_tables": 983,
+      "tagged": 268,
+      "pct": 27.3
+    },
+    "item_response_warehouse_4": {
+      "n_tables": 981,
+      "tagged": 260,
+      "pct": 26.5
+    },
+    "item_response_warehouse_5": {
+      "n_tables": 206,
+      "tagged": 16,
+      "pct": 7.8
+    },
+    "item_response_warehouse_6": {
+      "n_tables": 1,
+      "tagged": 0,
+      "pct": 0
+    }
+  },
+  "orphan_tag_rows": 194
+}

--- a/metadata/status_history.tsv
+++ b/metadata/status_history.tsv
@@ -1,0 +1,2 @@
+date	n_tables	tagged	tagged_pct	itemtext	itemtext_pct	orphan_tag_rows
+2026-08-31	4134	2286	55.3	558	13.5	194


### PR DESCRIPTION
Second sub-action of #1765 (item 2.5). 2.5a was #1766.

## Why

#1702 reports tag coverage as **61.7%** and the corpus as **~3,650 tables**. Two days later the corpus is **4,134** and coverage is **55.3%** — it has *fallen six points*, because the denominator grew by 484 while tagged tables grew by 35.

Nobody noticed, and that is the actual problem: the only way to know the number was to recompute it by hand, while the figure in the write-up looked authoritative.

## What

`metadata/11_status.R`, a sibling of `09_hero_status.R` — reads the local pipeline CSVs, makes no Redivis calls, emits two files:

| file | contents |
|---|---|
| `status.json` | current numbers, machine-readable, including per-shard |
| `status_history.tsv` | one appended row per run |

**The history is the point.** A snapshot goes stale silently; a history makes "coverage fell six points" something you can see rather than something you have to discover.

Both are tracked in git. `metadata/**/*.csv` is gitignored because the pipeline CSVs are large regenerable outputs — these two are small and their value *is* being readable over time and in review, which is the only reason the history is `.tsv` rather than `.csv`.

## Baseline seeded today

```
2026-08-31: 4134 tables | tags 2286 (55.3%) | itemtext 558 (13.5%) | orphan tag rows 194
```

Per-shard, because the aggregate hides where the gap is:

| shard | tagged | | roadmap said |
|---|---|---|---|
| w1 | 987/988 | 99.9% | 99.6% |
| w2 | 755/975 | 77.4% | 77.4% |
| w3 | 268/983 | 27.3% | 27.2% |
| w4 | 260/981 | **26.5%** | 34.7% — fell 8 points |
| w5 | 16/206 | **7.8%** | not mentioned |
| w6 | 0/1 | 0% | "none" |

**The undertagged shard is no longer w3/w4.** w5 is worse than either. Anywhere the write-up says "w3 and w4 are the undertagged ones" is now wrong.

`orphan tag rows: 194` should go to **0** on the next pipeline run now that #1766 has landed. A non-zero value after that means the guard did not run, or ran against a stale `metadata.csv` — so this doubles as a regression check on 2.5a.

## Details worth a look in review

- **Every join is case-insensitive.** 308 tag rows differ from their metadata row only by case; a case-sensitive join silently drops all of them, which is how tag coverage once read 53% instead of 62%.
- **Re-running on an unchanged day is a no-op**, not a duplicate row. That guard needed two fixes I would not have caught without testing it three times in a row: `read_tsv` infers `date` as a `Date` and `unlist()` strips the class, so the comparison ran against the underlying day count (20696); and `format()` truncated 55.3 to `"55"`. Reading the history as character and comparing with `as.character()` fixes both.
- **A missing input is an error, not a zero.** The script refuses to publish rather than invent a number for a file it cannot read.

Remaining on #1765: **2.5b**, straggler detection on a named table.