### PR TITLE
Name the tables that are stuck, never alert on the count (#1765, 2.5b)

### DIFF
--- a/metadata/12_stragglers.R
+++ b/metadata/12_stragglers.R
@@ -1,0 +1,131 @@
+# 12_stragglers.R
+#
+# Names the tables that are stuck (issue #1765, sub-action 2.5b).
+#
+# A table live on Redivis with no row in metadata.csv is NORMAL. 01_metadata.R
+# carries a `refresh.per.run` throttle, so at any moment some live tables have
+# not been described yet; #1704 established that a snapshot count of missing
+# metadata measures throttle position, not pipeline health. Alerting on that
+# count trains everyone to ignore the alert.
+#
+# What is NOT normal is the same table still missing several runs later. That
+# means it is stuck -- an unreleased warehouse, or 01_metadata.R failing on
+# that specific table -- and it will stay stuck indefinitely because nothing
+# distinguishes it from the throttle backlog.
+#
+# So this script alerts on a NAMED TABLE that has persisted, never on a count.
+# Doing that requires memory across runs, which is the whole reason the watch
+# file exists:
+#
+#   straggler_watch.tsv   table, first_seen, last_seen, cycles
+#
+# A table appears when it is first seen live-without-metadata, accumulates a
+# cycle per run, and is removed the moment it gets a metadata row. Anything
+# that survives more than --cycles runs (default 2, i.e. flagged on the third)
+# is reported by name.
+#
+# Unlike 09/11 this DOES call Redivis, unavoidably: the question is which live
+# tables are absent from metadata.csv, so metadata.csv cannot be the catalog.
+#
+# Usage (from metadata/, like the rest of the numbered scripts):
+#   Rscript 12_stragglers.R
+#   Rscript 12_stragglers.R --cycles 3 --watch straggler_watch.tsv
+#   Rscript 12_stragglers.R --live-from live.txt    # offline: one table per line
+
+suppressPackageStartupMessages({
+    library(readr)
+})
+
+args <- commandArgs(trailingOnly = TRUE)
+arg <- function(flag, default) {
+    i <- match(flag, args)
+    if (is.na(i) || i == length(args)) default else args[[i + 1L]]
+}
+dir       <- arg("--dir", ".")
+watch_out <- arg("--watch", file.path(dir, "straggler_watch.tsv"))
+live_from <- arg("--live-from", NA_character_)
+max_ok    <- as.integer(arg("--cycles", "2"))
+##Below this, a live-catalog fetch is assumed broken rather than believed. An
+##empty or truncated fetch would otherwise read as "every table is missing
+##metadata", flag the entire corpus, and destroy the watch file's history.
+min_live  <- as.integer(arg("--min-live", "1000"))
+
+key <- function(x) tolower(trimws(as.character(x)))
+
+meta_path <- file.path(dir, "metadata.csv")
+if (!file.exists(meta_path)) {
+    stop("metadata.csv not found in ", normalizePath(dir, mustWork = FALSE),
+         ". Run 01_metadata.R first.", call. = FALSE)
+}
+described <- key(read_csv(meta_path, show_col_types = FALSE)$table)
+
+live <- if (!is.na(live_from)) {
+    key(readLines(live_from, warn = FALSE))
+} else {
+    key(irw::irw_list_tables(source = "core")$name)
+}
+live <- live[nzchar(live)]
+
+if (length(live) < min_live) {
+    stop("live catalog returned ", length(live), " table(s); expected at least ",
+         min_live, ". Refusing to update the watch file -- a truncated fetch ",
+         "would flag the whole corpus and erase the history that makes this ",
+         "script work.", call. = FALSE)
+}
+
+missing <- sort(setdiff(live, described))
+today   <- format(Sys.Date())
+
+prev <- if (file.exists(watch_out)) {
+    read_tsv(watch_out, show_col_types = FALSE,
+             col_types = cols(.default = col_character()))
+} else {
+    data.frame(table = character(), first_seen = character(),
+               last_seen = character(), cycles = character())
+}
+
+##Resolved: on the watch last run, has a metadata row now. Dropped silently --
+##that is the system working, and reporting it would recreate the noisy count.
+resolved <- setdiff(prev$table, missing)
+
+carried <- prev[prev$table %in% missing, , drop = FALSE]
+##Built explicitly rather than with a recycled scalar for last_seen: when
+##nothing is missing -- the healthy state, and the state on the day this was
+##written -- `today` is length 1 against zero-length columns and data.frame()
+##errors on the mismatch. The empty case is the one this script spends most of
+##its life in, so it is the one that has to work.
+seen <- match(missing, carried$table)
+watch <- data.frame(
+    table      = missing,
+    first_seen = ifelse(is.na(seen), today, carried$first_seen[seen]),
+    last_seen  = rep(today, length(missing)),
+    cycles     = ifelse(is.na(seen), 1L,
+                        as.integer(carried$cycles[seen]) + 1L),
+    stringsAsFactors = FALSE
+)
+
+write_tsv(watch, watch_out)
+
+stuck <- watch[watch$cycles > max_ok, , drop = FALSE]
+stuck <- stuck[order(-stuck$cycles, stuck$table), , drop = FALSE]
+
+cat(sprintf("%s: %d live | %d described | %d awaiting metadata | %d resolved since last run\n",
+            today, length(live), length(described), length(missing), length(resolved)))
+
+if (nrow(stuck) == 0L) {
+    cat("no stragglers: nothing has been waiting more than ", max_ok,
+        " run(s)\n", sep = "")
+    quit(status = 0L)
+}
+
+##Named, with how long, because "3 tables are stuck" is not actionable and
+##"these 3 tables have been stuck since 2026-07-04" is.
+cat("\nSTRAGGLERS -- live for more than ", max_ok,
+    " run(s) with no metadata row:\n", sep = "")
+for (i in seq_len(nrow(stuck))) {
+    cat(sprintf("  %-52s %2s cycles, first seen %s\n",
+                stuck$table[i], stuck$cycles[i], stuck$first_seen[i]))
+}
+cat("\nEach is stuck for a reason -- an unreleased warehouse, or 01_metadata.R\n",
+    "failing on that table. Check 01 before assuming the throttle.\n", sep = "")
+quit(status = 1L)

--- a/metadata/straggler_watch.tsv
+++ b/metadata/straggler_watch.tsv
@@ -1,0 +1,1 @@
+table	first_seen	last_seen	cycles

--- a/metadata/tests/test_stragglers.R
+++ b/metadata/tests/test_stragglers.R
@@ -1,0 +1,94 @@
+##Tests for 12_stragglers.R (issue #1765, sub-action 2.5b).
+##
+##Runs entirely offline via --live-from, so nothing here touches Redivis.
+##Run it from the metadata/ directory:
+##
+##    Rscript tests/test_stragglers.R
+##
+##THE TEST THAT MATTERS is no_missing_tables(). The script spends most of its
+##life with nothing missing -- that is the healthy state -- and the first real
+##run against the live catalog failed there, because `last_seen = today` is a
+##length-1 scalar that cannot recycle to zero rows. A straggler detector that
+##crashes whenever there are no stragglers is worse than none: it would have
+##been switched off before it ever fired.
+
+failures <- 0L
+check <- function(cond, what) {
+    if (isTRUE(cond)) cat("  ok   -", what, "\n")
+    else { cat("  FAIL -", what, "\n"); failures <<- failures + 1L }
+}
+
+tmp <- tempfile(); dir.create(tmp)
+on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+SCRIPT <- normalizePath("12_stragglers.R")
+
+##A metadata.csv large enough to clear --min-live, plus a live list on top.
+setup <- function(described, live) {
+    d <- file.path(tmp, basename(tempfile())); dir.create(d)
+    writeLines(c("table", described), file.path(d, "metadata.csv"))
+    writeLines(live, file.path(d, "live.txt"))
+    d
+}
+run <- function(d, ...) {
+    out <- suppressWarnings(system2(
+        "Rscript", c(SCRIPT, "--dir", d, "--watch", file.path(d, "watch.tsv"),
+                     "--live-from", file.path(d, "live.txt"), ...),
+        stdout = TRUE, stderr = TRUE))
+    list(out = paste(out, collapse = "\n"),
+         status = attr(out, "status") %||% 0L)
+}
+`%||%` <- function(a, b) if (is.null(a)) b else a
+watch_rows <- function(d) {
+    f <- file.path(d, "watch.tsv")
+    if (!file.exists(f)) return(NULL)
+    read.delim(f, colClasses = "character")
+}
+
+BULK <- paste0("described_", seq_len(1200))
+
+cat("\nthe healthy state\n")
+d <- setup(BULK, BULK)
+r <- run(d)
+check(r$status == 0L, "no missing tables: exits 0")
+check(grepl("no stragglers", r$out), "no missing tables: reports no stragglers")
+check(!is.null(watch_rows(d)) && nrow(watch_rows(d)) == 0L,
+      "no missing tables: writes an empty watch file rather than crashing")
+
+cat("\naccumulation and the threshold\n")
+d <- setup(BULK, c(BULK, "stuck_one", "stuck_two"))
+r1 <- run(d); r2 <- run(d)
+check(r1$status == 0L && r2$status == 0L,
+      "a table missing for 2 runs is not yet reported (that is the throttle)")
+r3 <- run(d)
+check(r3$status == 1L, "a table missing for a 3rd run exits non-zero")
+check(grepl("stuck_one", r3$out) && grepl("stuck_two", r3$out),
+      "stragglers are named, not counted")
+check(grepl("first seen", r3$out), "each straggler reports how long it has waited")
+check(nrow(watch_rows(d)) == 2L, "the watch file carries both tables")
+
+cat("\nresolution\n")
+writeLines(c("table", BULK, "stuck_one"), file.path(d, "metadata.csv"))
+r <- run(d)
+check(grepl("1 resolved", r$out), "a table that gains a metadata row is counted as resolved")
+w <- watch_rows(d)
+check(nrow(w) == 1L && w$table == "stuck_two",
+      "a resolved table is dropped from the watch, silently")
+
+cat("\nguards\n")
+d2 <- setup(BULK, c(BULK, "STUCK_ONE"))
+writeLines(c("table", BULK, "stuck_one"), file.path(d2, "metadata.csv"))
+r <- run(d2)
+check(grepl("0 awaiting metadata", r$out),
+      "a live table matching its metadata row only by case is not a straggler")
+
+before <- watch_rows(d)
+writeLines(head(BULK, 5), file.path(d, "live.txt"))
+r <- run(d)
+check(r$status != 0L && grepl("Refusing to update", r$out),
+      "a truncated live catalog is refused, not believed")
+check(identical(watch_rows(d), before),
+      "a truncated live catalog leaves the watch file untouched")
+
+cat("\n")
+if (failures > 0L) { cat(failures, "FAILURE(S)\n"); quit(status = 1L) }
+cat("all tests passed\n")


### PR DESCRIPTION
Last sub-action of #1765 (item 2.5). 2.5a was #1766, 2.5c was #1767.

## Why an alert on a count would be useless

A table live on Redivis with no `metadata.csv` row is **normal**. `01_metadata.R` throttles via `refresh.per.run`, so some live tables are always undescribed. #1704 established that a snapshot count of missing metadata measures *throttle position*, not pipeline health — and an alert that fires on normal conditions gets ignored, then switched off.

What is not normal is the *same table* still missing several runs later. That is stuck — an unreleased warehouse, or `01_metadata.R` failing on that specific table — and right now nothing distinguishes it from the throttle backlog, so it stays stuck indefinitely.

## What this does

`12_stragglers.R` alerts on a **named table** that has persisted. That requires memory across runs, which is what `straggler_watch.tsv` is for:

- a table appears when first seen live-without-metadata
- gains a cycle each run
- is dropped, silently, the moment it gets a metadata row
- anything surviving more than `--cycles` runs (default 2) is **named**, with how long it has waited, and the script exits 1

```
STRAGGLERS -- live for more than 2 run(s) with no metadata row:
  stuck_one                    3 cycles, first seen 2026-08-31
```

"3 tables are stuck" is not actionable. "These tables have been stuck since 4 July" is.

Unlike `09_hero_status.R` and `11_status.R`, this **does** call Redivis — unavoidably, since the question is which live tables are absent from `metadata.csv`, so `metadata.csv` cannot be the catalog.

## Seeded state

```
2026-08-31: 4134 live | 4134 described | 0 awaiting metadata | 0 resolved
```

The watch file starts empty. That is the expected state — #1765 found the metadata gap has closed — and it is precisely why this was worth building now: **it will be quiet, so its first alarm will mean something.**

## The bug worth reading

The first run against the real catalog **crashed**, in the healthy state, with no missing tables: `last_seen = today` is a length-1 scalar that cannot recycle to zero rows. My fixtures all had stragglers in them, so none of them covered it.

The script spends most of its life with nothing to report. A straggler detector that dies whenever there are no stragglers would have been switched off long before it ever fired. That case is now the first test in the file, and is labelled as the one that matters.

## Tests

`tests/test_stragglers.R`, entirely offline via `--live-from`:

| | |
|---|---|
| healthy state — exits 0, empty watch, no crash | ✅ |
| missing 2 runs → silent; 3rd run → exit 1 | ✅ |
| stragglers named, with age | ✅ |
| resolved table dropped from watch, silently | ✅ |
| case-only match is not a straggler | ✅ |
| truncated live catalog refused, watch untouched | ✅ |

That last guard matters: an empty or partial fetch would otherwise read as "every table is missing metadata", flag the entire corpus, and erase the history the script depends on.

With this, #1765 is complete — 2.5a, 2.5b and 2.5c all landed.