### PR TITLE
itemtext: verify the two skip verdicts of the 2026-08-29 batch (#1770)

### DIFF
--- a/automated_finding/.claude/skills/irw-automated-finding/SKILL.md
+++ b/automated_finding/.claude/skills/irw-automated-finding/SKILL.md
@@ -372,6 +372,16 @@ When you skip, say **where the text actually is** in the `data/<table>.py`
 header and in the `BATCH_LOG.md` entry, so a later pass starts from an answer
 instead of re-deriving one. That is the whole cost of skipping — one sentence.
 
+**Say which label levels you checked, not just what you concluded.** A skip
+verdict is the one output here that nothing downstream re-tests: no gate runs
+on a table that was never attempted, so the prose in the header is the whole
+record. `estevez_2021_*` (#1770) was skipped on "no variable labels and no
+value labels for any item"; the file carried value labels for all 82 shipped
+items, and the verdict had been written from the variable-label level alone.
+Name both levels — "no variable labels; value labels present but only on the
+covariates", "both levels empty" — so the next reader can tell a checked
+absence from an unchecked one.
+
 Two carve-outs: **never extract item text for `enem*` tables** (Ben handles
 those separately), and a table skipped for PII/license/N<100 has its item text
 skipped with it.

--- a/automated_finding/BATCH_LOG.md
+++ b/automated_finding/BATCH_LOG.md
@@ -13397,6 +13397,19 @@ Worked top-down through the unworked tail (102 of the 110 backlog leads had no
   mean(IAM40, IAM42, IAM43). Recorded in the script header for a later item
   text pass. Item text not shipped -- no labels, no codebook.
 
+  > **Correction, 2026-09-01 (#1770).** "No variable labels at all" and "no
+  > labels, no codebook" are wrong; the entry is left as written and corrected
+  > here. The .sav was reopened independently (md5 matches the Zenodo
+  > checksum): no *variable* label on any item column, true -- but **86 of 99
+  > columns carry value labels, including all 82 shipped items**, plus
+  > `GENERO`, `CURSO` and all thirteen `CENTRO` school names. So the block
+  > split still had to be done on prefixes, but the anchors were extractable
+  > all along. `option_text` for all 8 tables has now been built and gated
+  > (validate_items.R 8/8 PASS, audit_batch.R 8 WARN "100% blank item_text",
+  > expected with the stems still in the paper); held pending the call in
+  > #1770 on whether option-only item text ships. Also corrected there:
+  > the study covers **13** schools, not 7.
+
 - **`zenodo.13855427` -- Chen (2024), Chinese fitness coaches. 16 tables /
   57,095 responses.** Sixteen prefix blocks, deliberately not renamed: `TS` is
   confirmed thrill seeking by its one stray variable label and JE/DS/SC/TS read
@@ -13406,6 +13419,13 @@ Worked top-down through the unworked tail (102 of the 110 backlog leads had no
   block-mean columns the deposit also ships each have a maximum of exactly 7.0,
   which is only reachable if the items run to 7. Asserted in the script before
   those columns are dropped, so no table was split on an observed maximum.
+
+  > **Correction, 2026-09-01 (#1770).** The skip verdict was rechecked against
+  > the same .sav and **stands** -- no shipped item carries a variable or a
+  > value label. Two details were wrong: the file has five variable labels,
+  > not one (`TS1` plus the four covariate columns, which carry the
+  > questionnaire's own numbered questions), and `TS1`'s label is the
+  > truncated "thrillseeking 需求刺激，se". Details in the script header.
 
 - **`zenodo.15168213` -- Torok et al. (2025), "Trust, Awareness, and Risk
   Perception in the Online Environment", n=1,003 Hungarian CATI survey.

--- a/data/chen_2024_fitness_coach_creativity.py
+++ b/data/chen_2024_fitness_coach_creativity.py
@@ -5,10 +5,20 @@ Source: https://zenodo.org/records/13855427
 DOI: 10.5281/zenodo.13855427
 Data: 2024929健身教练数据(Peerj).sav
 License: CC BY 4.0
-Item text: not shipped -- the .sav has no value labels and only one stray
-    variable label (`TS1` = "thrillseeking 需求刺激"). The wording is in the
-    PeerJ article this deposit backs, which is open access; a later pass with
-    the paper in hand could recover all 74 stems.
+Item text: not shipped -- verdict independently rechecked 2026-09-01 under
+    #1770, against the same file (md5 32ce50d9e7a0f8f0f5cf4030be866620,
+    matching the Zenodo checksum), and it stands: **no shipped item carries a
+    variable label or a value label**, so there is nothing here to extract.
+    The wording is in the PeerJ article this deposit backs, which is open
+    access; a later pass with the paper in hand could recover all 74 stems.
+    Two details of the original claim were wrong and are corrected here:
+    the file has **five** variable labels, not one, and `TS1`'s reads
+    "thrillseeking 需求刺激，se" (a truncated fragment) rather than the tidy
+    string quoted before. The other four are on the covariate columns and are
+    the questionnaire's own numbered questions: `Gender` "1. 您的性别：",
+    `Age` "2. 您的年龄段（单位：岁）", `Seniority` "7. 工作年限",
+    `Monthly` "8. 月收入（人民币）". Value labels really are absent for every
+    one of the 99 columns, so the band boundaries noted below stay unpublished.
 
 732 fitness coaches, every item on a 1-7 agreement format.
 

--- a/data/estevez_2021_homework_motivation.py
+++ b/data/estevez_2021_homework_motivation.py
@@ -5,14 +5,31 @@ Source: https://zenodo.org/records/5156068
 DOI: 10.5281/zenodo.5156068
 Data: BASE_DATOS_PERFILES.sav
 License: CC BY 4.0
-Item text: not shipped -- the .sav carries no variable labels and no value
-    labels for any item, and the deposit has no codebook. The wording is in the
-    paper's instrument appendix (Estevez, Valle, Rodriguez, Pineiro, Vieites,
-    Gonzalez-Suarez & Rodriguez-Llorente); only the four Z-score columns carry
-    any label at all.
+Item text: partially available; not shipped in this batch. **The original
+    claim in this header was wrong and is corrected here** -- reopened and
+    checked independently 2026-09-01 under #1770, against the same file
+    (md5 003fc7cc425aed1d9c65545dd88b1042, matching the Zenodo checksum).
+    * Variable labels: the item stems really are absent -- no item column
+      carries one, and the wording is in the paper's instrument appendix
+      (Estevez, Valle, Rodriguez, Pineiro, Vieites, Gonzalez-Suarez &
+      Rodriguez-Llorente). But only **two** columns in the file carry a
+      variable label at all, `Zperceived.competence` and
+      `Zintrinsic.motivation` -- not "the four Z-score columns"; the file has
+      two Z-score columns.
+    * Value labels: "no value labels for any item" is false. 86 of the 99
+      columns carry them, **including all 82 shipped items** -- 77 on one
+      shared 1-5 set (TOTALMENTE FALSO .. TOTALMENTE CIERTO) and the five
+      homework-block items on item-specific 5-point sets of their own.
+    So this is a real `option_text` extraction with `item_text` blank, not a
+    dead end. Built and gated 2026-09-01 (validate_items.R 8/8 PASS on item
+    and resp sets; audit_batch.R 8 WARN "100% of rows have blank item_text",
+    which is the expected shape here). Held rather than uploaded pending the
+    call in #1770 on whether option-only item text ships.
 
-863 primary school students (ages 9-13) across 7 schools, all items on a
-1-5 format.
+863 primary school students (ages 9-13) across 13 schools, all items on a
+1-5 format. (**Corrected 2026-09-01, #1770**: "7 schools" and "CENTRO, 1-7"
+below were both wrong -- `CENTRO` runs 1-13, all thirteen codes are observed
+in the shipped tables, and the .sav's value labels name each school.)
 
 Tables written
 --------------
@@ -37,7 +54,12 @@ Coding notes
   at 4, all five are on the same 1-5 format, and the three named columns are
   the homework amount/time/time-use items the paper's abstract describes.
   That is a structural inference from the numbering, recorded here rather than
-  hidden.
+  hidden. **Corroborated 2026-09-01 (#1770):** those three columns carry
+  item-specific value labels that name exactly those three quantities --
+  `Cantid.deb` NINGUNO..TODOS (how much homework), `Tiemp.deb` MENOS DE 30
+  MINUTOS..MAS DE 2 HORAS (how long), `Aprov.tiem.deb` LO DESAPROVECHO
+  TOTALMENTE..LO APROVECHO TOTALMENTE (how well the time was used). The
+  inference stands on the source's own labels, not only on the numbering.
 * **`ALUMNO` is not a usable id**: 863 rows carry 862 distinct values, and the
   two rows sharing `ALUMNO=4` differ on age and on nearly every response, so
   they are two students with a collided code rather than one student twice.
@@ -53,9 +75,14 @@ Coding notes
   mean(IAM35..IAM39_recod); negative feelings = mean(IAM40, IAM42, IAM43).
   IAM is shipped as one 43-item table because the remaining 28 items are not
   assigned to any named subscale by anything in the deposit.
-* Covariates: `cov_school` (CENTRO, 1-7), `cov_age` (EDAD, 9-13),
-  `cov_gender` (GENERO, 1/2 -- the deposit does not say which is which),
-  `cov_grade` (CURSO, 1/2).
+* Covariates: `cov_school` (CENTRO, 1-13), `cov_age` (EDAD, 9-13),
+  `cov_gender` (GENERO, 1/2), `cov_grade` (CURSO, 1/2). **All three coded
+  covariates are decoded by the .sav's value labels** (found 2026-09-01,
+  #1770 -- the deposit *does* say which is which, contrary to what this note
+  claimed): GENERO 1=hombre, 2=mujer; CURSO 1=5ºEP, 2=6ºEP; CENTRO 1-13 named
+  (Cruceiro de Canido, Isaac Peral, Centieiras, Ponte de Xuvia, Piñeiros, Ceip
+  San Marcos (Abegondo), Recimil, CEIP Vales Villamarin, Ceip Ponzos, Ceip
+  Esteiro, Ceip Couceiro Freijomil, CPR Santiago Apóstol, CPR Jorge Juan).
 """
 
 import os

--- a/itemtext/fixes/issue_1770_estevez_options/README.md
+++ b/itemtext/fixes/issue_1770_estevez_options/README.md
@@ -1,0 +1,40 @@
+# #1770 — verifying the two skip verdicts of the 2026-08-29 batch
+
+The first live run of item text at processing time (Step 3.5) skipped 24 tables
+on two factual claims about their source `.sav` files. Neither claim had been
+checked. This directory holds the check and what came out of it.
+
+`verify_labels.py` reopens both files, confirms each against its Zenodo md5,
+and dumps `meta.column_names_to_labels` and `meta.variable_value_labels`.
+
+## Result
+
+| | claim | verdict |
+|---|---|---|
+| `chen_2024_fitness_coach_creativity` (16 tables) | "no value labels and only one stray variable label (`TS1`)" | **skip stands** — no shipped item has either kind of label. Two details wrong: five variable labels, not one (`TS1` + the four covariates, which carry the questionnaire's own numbered questions), and `TS1`'s reads `thrillseeking 需求刺激，se`. |
+| `estevez_2021_homework_motivation` (8 tables) | "no variable labels and no value labels for any item … only the four Z-score columns carry any label at all" | **overturned on the value-label half.** 86 of 99 columns carry value labels, including **all 82 shipped items**. Variable labels: two, not four, and both on Z-score columns — so the *stems* are genuinely absent and remain in the paper's instrument appendix. |
+
+Also corrected in the `estevez` script header from the same dump: the study
+covers **13** schools, not 7 (`CENTRO` runs 1–13, all observed), and `GENERO`,
+`CURSO` and every `CENTRO` code are named by the file's own value labels — the
+header had said the deposit does not say which gender code is which.
+
+## What is here
+
+`build_items.py` writes one `<table>__items.csv` per estevez table: the value
+labels as `option_text`, `item_text` blank (the stems are a second hop, into
+the paper), `section_id = <table>_1`. 77 items share one 1–5 anchor set
+(TOTALMENTE FALSO … TOTALMENTE CIERTO); the five homework-block items carry
+item-specific sets, which independently corroborate the structural inference
+the script header flagged about `Cantid.deb` / `Tiemp.deb` / `Aprov.tiem.deb`.
+
+Gates, run 2026-09-01 against the regenerated response CSVs:
+
+- `normalize_nulls.R` — 8/8 normalized
+- `validate_items.R --resp-csv` — **8/8 PASS**, item sets and resp sets match exactly
+- `audit_batch.R --resp-dir` — 8 WARN, all of them `100% of rows have blank item_text`
+
+**Not uploaded.** Shipping `option_text` with no `item_text` where the stems
+exist but are one hop away is a precedent call, not a mechanical one — it is
+the open question on #1770. The CSVs here are gated and ready if the answer is
+yes; a later pass with the paper in hand can fill `item_text` and re-merge.

--- a/itemtext/fixes/issue_1770_estevez_options/build_items.py
+++ b/itemtext/fixes/issue_1770_estevez_options/build_items.py
@@ -1,0 +1,39 @@
+import csv, os
+import pandas as pd, pyreadstat
+
+SRC = "/tmp/zenodo_5156068_BASE_DATOS_PERFILES.sav"
+AF = "/home/ben/Dropbox/projects/irw/src/automated_finding"
+RESP = os.path.join(AF, "irw_output")
+OUT = os.path.join(AF, "itemtext_output")
+os.makedirs(OUT, exist_ok=True)
+
+_, meta = pyreadstat.read_sav(SRC, metadataonly=True)
+vvl = meta.variable_value_labels
+
+TABLES = [f"estevez_2021_{s}" for s in
+          ["homework_engagement", "motiv", "gest", "inter", "actitu",
+           "feepr", "feepad", "math_attitudes"]]
+
+FIELDS = ["table", "section_id", "item", "instrument", "instructions",
+          "section_prompt", "item_text", "correct_response", "option_text",
+          "resp"]
+
+for t in TABLES:
+    d = pd.read_csv(os.path.join(RESP, f"{t}.csv"))
+    items = list(dict.fromkeys(d["item"]))
+    obs = sorted(set(d["resp"]))
+    rows = []
+    for it in items:
+        assert it in vvl, (t, it)
+        for resp, text in sorted(vvl[it].items()):
+            rows.append({"table": t, "section_id": f"{t}_1", "item": it,
+                         "instrument": "", "instructions": "",
+                         "section_prompt": "", "item_text": "",
+                         "correct_response": "", "option_text": text,
+                         "resp": int(resp)})
+    labset = sorted({int(k) for it in items for k in vvl[it]})
+    print(f"{t}: {len(items)} items, resp observed={obs}, labelled={labset}, rows={len(rows)}")
+    with open(os.path.join(OUT, f"{t}__items.csv"), "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=FIELDS)
+        w.writeheader()
+        w.writerows(rows)

--- a/itemtext/fixes/issue_1770_estevez_options/estevez_2021_actitu__items.csv
+++ b/itemtext/fixes/issue_1770_estevez_options/estevez_2021_actitu__items.csv
@@ -1,0 +1,21 @@
+"table","section_id","item","instrument","instructions","section_prompt","item_text","correct_response","option_text","resp"
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU1",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU1",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU1",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU1",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU1",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU2",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU2",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU2",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU2",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU2",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU3",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU3",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU3",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU3",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU3",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU4",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU4",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU4",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU4",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_actitu","estevez_2021_actitu_1","ACTITU4",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5

--- a/itemtext/fixes/issue_1770_estevez_options/estevez_2021_feepad__items.csv
+++ b/itemtext/fixes/issue_1770_estevez_options/estevez_2021_feepad__items.csv
@@ -1,0 +1,26 @@
+"table","section_id","item","instrument","instructions","section_prompt","item_text","correct_response","option_text","resp"
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD1",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD1",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD1",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD1",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD1",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD2",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD2",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD2",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD2",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD2",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD3",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD3",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD3",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD3",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD3",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD4",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD4",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD4",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD4",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD4",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD5",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD5",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD5",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD5",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_feepad","estevez_2021_feepad_1","FEEPAD5",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5

--- a/itemtext/fixes/issue_1770_estevez_options/estevez_2021_feepr__items.csv
+++ b/itemtext/fixes/issue_1770_estevez_options/estevez_2021_feepr__items.csv
@@ -1,0 +1,31 @@
+"table","section_id","item","instrument","instructions","section_prompt","item_text","correct_response","option_text","resp"
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR1",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR1",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR1",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR1",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR1",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR2",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR2",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR2",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR2",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR2",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR3",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR3",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR3",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR3",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR3",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR4",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR4",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR4",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR4",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR4",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR5",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR5",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR5",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR5",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR5",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR6",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR6",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR6",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR6",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_feepr","estevez_2021_feepr_1","FEEPR6",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5

--- a/itemtext/fixes/issue_1770_estevez_options/estevez_2021_gest__items.csv
+++ b/itemtext/fixes/issue_1770_estevez_options/estevez_2021_gest__items.csv
@@ -1,0 +1,21 @@
+"table","section_id","item","instrument","instructions","section_prompt","item_text","correct_response","option_text","resp"
+"estevez_2021_gest","estevez_2021_gest_1","GEST1",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_gest","estevez_2021_gest_1","GEST1",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_gest","estevez_2021_gest_1","GEST1",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_gest","estevez_2021_gest_1","GEST1",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_gest","estevez_2021_gest_1","GEST1",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_gest","estevez_2021_gest_1","GEST2",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_gest","estevez_2021_gest_1","GEST2",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_gest","estevez_2021_gest_1","GEST2",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_gest","estevez_2021_gest_1","GEST2",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_gest","estevez_2021_gest_1","GEST2",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_gest","estevez_2021_gest_1","GEST3",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_gest","estevez_2021_gest_1","GEST3",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_gest","estevez_2021_gest_1","GEST3",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_gest","estevez_2021_gest_1","GEST3",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_gest","estevez_2021_gest_1","GEST3",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_gest","estevez_2021_gest_1","GEST4",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_gest","estevez_2021_gest_1","GEST4",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_gest","estevez_2021_gest_1","GEST4",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_gest","estevez_2021_gest_1","GEST4",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_gest","estevez_2021_gest_1","GEST4",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5

--- a/itemtext/fixes/issue_1770_estevez_options/estevez_2021_homework_engagement__items.csv
+++ b/itemtext/fixes/issue_1770_estevez_options/estevez_2021_homework_engagement__items.csv
@@ -1,0 +1,26 @@
+"table","section_id","item","instrument","instructions","section_prompt","item_text","correct_response","option_text","resp"
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","Cantid.deb",NA,NA,NA,NA,NA,"NINGUNO",1
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","Cantid.deb",NA,NA,NA,NA,NA,"ALGUNOS",2
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","Cantid.deb",NA,NA,NA,NA,NA,"LA MITAD",3
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","Cantid.deb",NA,NA,NA,NA,NA,"CASI TODOS",4
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","Cantid.deb",NA,NA,NA,NA,NA,"TODOS",5
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","Tiemp.deb",NA,NA,NA,NA,NA,"MENOS DE 30 MINUTOS",1
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","Tiemp.deb",NA,NA,NA,NA,NA,"DE 30 A UNA HORA",2
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","Tiemp.deb",NA,NA,NA,NA,NA,"DE UNA HORA A HORA Y MEDIA",3
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","Tiemp.deb",NA,NA,NA,NA,NA,"DE HORA Y MEDIA A DOS HORAS",4
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","Tiemp.deb",NA,NA,NA,NA,NA,"MAS DE 2 HORAS",5
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","Aprov.tiem.deb",NA,NA,NA,NA,NA,"LO DESAPROVECHO TOTALMENTE",1
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","Aprov.tiem.deb",NA,NA,NA,NA,NA,"LO DESAPROVECHO MAS DE LO QUE DEBIERA",2
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","Aprov.tiem.deb",NA,NA,NA,NA,NA,"REGULAR",3
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","Aprov.tiem.deb",NA,NA,NA,NA,NA,"LO APROVECHO BASTANTE",4
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","Aprov.tiem.deb",NA,NA,NA,NA,NA,"LO APROVECHO TOTALMENTE",5
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","EDE4",NA,NA,NA,NA,NA,"NO SIRVEN PARA NADA",1
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","EDE4",NA,NA,NA,NA,NA,"SON POCO ÚTILES",2
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","EDE4",NA,NA,NA,NA,NA,"SON ALGO ÚTILES",3
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","EDE4",NA,NA,NA,NA,NA,"SON BASTANTE ÚTILES",4
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","EDE4",NA,NA,NA,NA,NA,"SON MUY ÚTILES",5
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","EDE5",NA,NA,NA,NA,NA,"MUY MALO",1
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","EDE5",NA,NA,NA,NA,NA,"TIRANDO A MALO",2
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","EDE5",NA,NA,NA,NA,NA,"REGULAR",3
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","EDE5",NA,NA,NA,NA,NA,"BUENO",4
+"estevez_2021_homework_engagement","estevez_2021_homework_engagement_1","EDE5",NA,NA,NA,NA,NA,"MUY BUENO",5

--- a/itemtext/fixes/issue_1770_estevez_options/estevez_2021_inter__items.csv
+++ b/itemtext/fixes/issue_1770_estevez_options/estevez_2021_inter__items.csv
@@ -1,0 +1,16 @@
+"table","section_id","item","instrument","instructions","section_prompt","item_text","correct_response","option_text","resp"
+"estevez_2021_inter","estevez_2021_inter_1","INTER1",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_inter","estevez_2021_inter_1","INTER1",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_inter","estevez_2021_inter_1","INTER1",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_inter","estevez_2021_inter_1","INTER1",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_inter","estevez_2021_inter_1","INTER1",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_inter","estevez_2021_inter_1","INTER2",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_inter","estevez_2021_inter_1","INTER2",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_inter","estevez_2021_inter_1","INTER2",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_inter","estevez_2021_inter_1","INTER2",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_inter","estevez_2021_inter_1","INTER2",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_inter","estevez_2021_inter_1","INTER3",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_inter","estevez_2021_inter_1","INTER3",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_inter","estevez_2021_inter_1","INTER3",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_inter","estevez_2021_inter_1","INTER3",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_inter","estevez_2021_inter_1","INTER3",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5

--- a/itemtext/fixes/issue_1770_estevez_options/estevez_2021_math_attitudes__items.csv
+++ b/itemtext/fixes/issue_1770_estevez_options/estevez_2021_math_attitudes__items.csv
@@ -1,0 +1,216 @@
+"table","section_id","item","instrument","instructions","section_prompt","item_text","correct_response","option_text","resp"
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM1",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM1",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM1",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM1",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM1",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM2",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM2",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM2",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM2",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM2",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM3",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM3",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM3",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM3",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM3",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM4",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM4",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM4",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM4",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM4",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM5",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM5",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM5",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM5",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM5",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM6",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM6",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM6",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM6",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM6",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM7",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM7",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM7",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM7",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM7",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM8",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM8",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM8",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM8",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM8",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM9",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM9",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM9",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM9",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM9",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM10",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM10",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM10",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM10",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM10",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM11",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM11",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM11",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM11",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM11",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM12",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM12",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM12",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM12",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM12",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM13",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM13",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM13",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM13",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM13",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM14",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM14",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM14",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM14",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM14",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM15",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM15",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM15",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM15",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM15",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM16",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM16",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM16",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM16",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM16",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM17",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM17",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM17",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM17",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM17",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM18",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM18",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM18",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM18",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM18",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM19",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM19",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM19",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM19",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM19",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM20",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM20",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM20",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM20",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM20",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM21",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM21",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM21",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM21",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM21",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM22",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM22",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM22",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM22",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM22",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM23",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM23",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM23",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM23",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM23",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM24",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM24",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM24",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM24",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM24",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM25",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM25",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM25",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM25",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM25",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM26",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM26",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM26",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM26",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM26",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM27",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM27",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM27",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM27",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM27",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM28",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM28",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM28",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM28",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM28",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM29",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM29",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM29",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM29",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM29",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM30",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM30",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM30",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM30",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM30",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM31",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM31",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM31",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM31",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM31",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM32",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM32",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM32",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM32",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM32",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM33",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM33",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM33",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM33",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM33",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM34",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM34",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM34",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM34",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM34",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM35",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM35",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM35",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM35",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM35",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM36",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM36",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM36",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM36",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM36",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM37",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM37",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM37",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM37",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM37",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM38",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM38",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM38",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM38",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM38",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM39",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM39",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM39",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM39",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM39",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM40",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM40",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM40",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM40",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM40",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM41",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM41",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM41",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM41",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM41",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM42",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM42",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM42",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM42",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM42",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM43",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM43",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM43",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM43",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_math_attitudes","estevez_2021_math_attitudes_1","IAM43",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5

--- a/itemtext/fixes/issue_1770_estevez_options/estevez_2021_motiv__items.csv
+++ b/itemtext/fixes/issue_1770_estevez_options/estevez_2021_motiv__items.csv
@@ -1,0 +1,61 @@
+"table","section_id","item","instrument","instructions","section_prompt","item_text","correct_response","option_text","resp"
+"estevez_2021_motiv","estevez_2021_motiv_1","MOITV1",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_motiv","estevez_2021_motiv_1","MOITV1",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_motiv","estevez_2021_motiv_1","MOITV1",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_motiv","estevez_2021_motiv_1","MOITV1",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_motiv","estevez_2021_motiv_1","MOITV1",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_motiv","estevez_2021_motiv_1","MOYIV2",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_motiv","estevez_2021_motiv_1","MOYIV2",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_motiv","estevez_2021_motiv_1","MOYIV2",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_motiv","estevez_2021_motiv_1","MOYIV2",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_motiv","estevez_2021_motiv_1","MOYIV2",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV3",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV3",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV3",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV3",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV3",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV4",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV4",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV4",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV4",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV4",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV5",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV5",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV5",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV5",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV5",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_motiv","estevez_2021_motiv_1","MOITV6",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_motiv","estevez_2021_motiv_1","MOITV6",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_motiv","estevez_2021_motiv_1","MOITV6",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_motiv","estevez_2021_motiv_1","MOITV6",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_motiv","estevez_2021_motiv_1","MOITV6",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV7",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV7",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV7",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV7",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV7",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_motiv","estevez_2021_motiv_1","MOITV8",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_motiv","estevez_2021_motiv_1","MOITV8",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_motiv","estevez_2021_motiv_1","MOITV8",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_motiv","estevez_2021_motiv_1","MOITV8",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_motiv","estevez_2021_motiv_1","MOITV8",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV9",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV9",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV9",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV9",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV9",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV10",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV10",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV10",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV10",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV10",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV11",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV11",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV11",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV11",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV11",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV12",NA,NA,NA,NA,NA,"TOTALMENTE FALSO",1
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV12",NA,NA,NA,NA,NA,"BASTANTE FALSO",2
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV12",NA,NA,NA,NA,NA,"MAS O MENOS CIERTO",3
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV12",NA,NA,NA,NA,NA,"BASTANTE CIERTO",4
+"estevez_2021_motiv","estevez_2021_motiv_1","MOTIV12",NA,NA,NA,NA,NA,"TOTALMENTE CIERTO",5

--- a/itemtext/fixes/issue_1770_estevez_options/verify_labels.py
+++ b/itemtext/fixes/issue_1770_estevez_options/verify_labels.py
@@ -1,0 +1,43 @@
+import hashlib, json, sys, urllib.request
+import pyreadstat
+
+CASES = [
+    ("estevez_2021", "5156068", "BASE_DATOS_PERFILES.sav",
+     "/tmp/zenodo_5156068_BASE_DATOS_PERFILES.sav"),
+    ("chen_2024", "13855427", "2024929健身教练数据(Peerj).sav",
+     "/tmp/zenodo_13855427.sav"),
+]
+
+for name, rec, fname, path in CASES:
+    print("=" * 70)
+    print(name, "|", path)
+    raw = open(path, "rb").read()
+    md5 = hashlib.md5(raw).hexdigest()
+    try:
+        import requests
+        api = requests.get(f"https://zenodo.org/api/records/{rec}", timeout=60).json()
+        entry = [f for f in api["files"] if f["key"] == fname]
+        remote = entry[0]["checksum"] if entry else "FILE KEY NOT FOUND: " + str([f["key"] for f in api["files"]])
+    except Exception as e:
+        remote = f"UNAVAILABLE ({type(e).__name__}: {e})"
+    print(f"  local md5   : {md5}  ({len(raw)} bytes)")
+    print(f"  zenodo cksum: {remote}")
+    print(f"  MATCH       : {remote.endswith(md5)}")
+
+    df, meta = pyreadstat.read_sav(path)
+    print(f"  columns: {len(meta.column_names)}   rows: {len(df)}")
+    varlab = {k: v for k, v in meta.column_names_to_labels.items()
+              if v is not None and str(v).strip() != ""}
+    print(f"  --- non-empty VARIABLE labels: {len(varlab)}")
+    for k, v in varlab.items():
+        print(f"      {k!r}: {v!r}")
+    vvl = meta.variable_value_labels
+    print(f"  --- columns with VALUE labels: {len(vvl)}")
+    for k, v in vvl.items():
+        print(f"      {k!r}: {v!r}")
+    print(f"  --- value_labels sets defined in file: {len(meta.value_labels)}")
+    for k, v in meta.value_labels.items():
+        print(f"      {k!r}: {v!r}")
+    other = {k: getattr(meta, k, None) for k in
+             ("notes", "file_label", "table_name")}
+    print("  --- other:", other)


### PR DESCRIPTION
Closes the one first-run check that was never performed (#1770), rolls up to #1709 (item 7).

Both `.sav` files reopened independently of the scripts that wrote the verdicts, each confirmed against its Zenodo md5 first.

| | the claim | verdict |
|---|---|---|
| `chen_2024_fitness_coach_creativity` (16 tables) | "no value labels and only one stray variable label (`TS1`)" | **stands** — no shipped item carries either kind of label. Two details wrong: five variable labels, not one (`TS1` + the four covariates, which carry the questionnaire's own numbered questions), and `TS1`'s label is the truncated `thrillseeking 需求刺激，se`. |
| `estevez_2021_homework_motivation` (8 tables) | "no variable labels and no value labels for any item … only the four Z-score columns carry any label at all" | **overturned on the value-label half.** 86 of 99 columns carry value labels, **including all 82 shipped items**. Variable labels: two, not four. The stems really are absent — they are in the paper's instrument appendix — so `item_text` stays blank, but `option_text` was extractable all along. |

This is the exact failure mode `irw-auto-itemtext`'s own Step 4 already names: *"'the .sav has no item text' when only the variable labels lacked it."*

`option_text` for the 8 estevez tables is built and gated in `itemtext/fixes/issue_1770_estevez_options/` — `normalize_nulls.R` 8/8, `validate_items.R --resp-csv` **8/8 PASS** on item and resp sets, `audit_batch.R --resp-dir` 8 WARN, all of them `100% of rows have blank item_text`.

**Not uploaded, deliberately.** Shipping `option_text` with no `item_text` where the stems exist but are one hop away is a precedent call rather than a mechanical one — that question is left open on #1770.

Two shipped facts also fell out of the same dump and are corrected in the estevez header: the study covers **13** schools, not 7 (`CENTRO` runs 1–13, all observed), and `GENERO` / `CURSO` / all thirteen `CENTRO` codes are named by the file's own value labels — the header said the deposit does not say which gender code is which. If the dictionary description carries the "7 schools" figure it needs the same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUTbCySD4RLJrG7HGBMSz9