### PR TITLE
itemtext: the administered-language columns are in the schema (#1777)

### DIFF
--- a/itemtext/.claude/skills/irw-auto-itemtext/SKILL.md
+++ b/itemtext/.claude/skills/irw-auto-itemtext/SKILL.md
@@ -180,13 +180,16 @@ The output claims to be what the study administered. Three rules:
   Leave the `_translated` columns out entirely for a table administered in English — do not
   emit empty columns to no purpose.
 
-  **Two things this touches beyond the CSV.** `validate_items.R` checks that required columns
-  are *present* and tolerates extras, so the gate is unaffected. But the four `_translated`
-  columns and `language` are **not yet in the public schema** at
-  itemresponsewarehouse.org/itemtext.html (mirrored in `references/itemtext_standard.md`), and
-  `upload.py` hands the CSV to Redivis, which infers fields from the file — so a table shipping
-  them adds columns to `irw_text`. Get that agreed before uploading such a table, and update the
-  public page in the same pass.
+  **Schema status: agreed, 2026-09-01.** The four `_translated` columns and `language` are
+  part of the published schema at itemresponsewarehouse.org/itemtext.html (mirrored in
+  `references/itemtext_standard.md`), so a table carrying them is uploadable without any
+  further sign-off. `validate_items.R` checks that required columns are *present* and
+  tolerates extras, so the gate is unaffected. `upload.py` hands the CSV to Redivis, which
+  infers fields from the file — the first such upload is what widens `irw_text` to hold them.
+  Whether the already-uploaded tables get backfilled is still open (irw#1777) —
+  `ALSECYPIAMH_WU_2022_SDQ` and `altahla_2024_whoqol` ship English for non-English
+  administrations, and `burkert_2019_whoqol_bref` ships German with no translation. The rule
+  above governs every new table regardless.
 
 ## Output path: CSV-direct, not Sheets-fill
 

--- a/itemtext/.claude/skills/irw-auto-itemtext/references/itemtext_standard.md
+++ b/itemtext/.claude/skills/irw-auto-itemtext/references/itemtext_standard.md
@@ -1,8 +1,8 @@
 # IRW Item Text Schema
 
 Verbatim field definitions, copied from https://itemresponsewarehouse.org/itemtext.html
-(2026-08-11, as of datapages/irw commit `3da46a86662018e6f9bf09cfd89ee4ac51c6e947`
-/ PR #97) so this skill doesn't need to re-fetch the page every run. This is the
+(2026-09-01, updated for the administered-language columns agreed in irw#1777) so this
+skill doesn't need to re-fetch the page every run. This is the
 schema of the **merged** `{table}__items.csv` — the output of joining the four
 per-table tabs (instrument, sections, items, responses) on `table` / `section_id` / `item`.
 
@@ -12,12 +12,14 @@ per-table tabs (instrument, sections, items, responses) on `table` / `section_id
 | `section_id` | Identifier for a group of items that share a common context; functions like `item_family`, annotating testlets and grouped items. |
 | `item` | Persistent identifier for the probe being used to measure — matches the core IRW dataset's `item` field exactly. |
 | `instrument` | Full, human-readable name or title for the instrument identified by `table`. |
+| `language` | Language the instrument was administered in, named plainly (`German`, `Spanish`) rather than as a code. Present when that language is not English. |
 | `instructions` | Literal text of the instructions provided to the participant for the overall instrument. |
 | `section_prompt` | Literal text of a shared prompt (e.g. a reading passage) that applies to all items within a given `section_id`. |
 | `item_text` | Literal text of the specific prompt or question associated with an `item`. |
 | `correct_response` | Scoring key for a given `item`. Blank when there is no correct answer; multiple correct answers are semicolon-separated (e.g. `A;C`). |
 | `option_text` | Literal text for a specific response option available for an item. May legitimately be missing for behavior-scored items. |
 | `resp` | Response value assigned to a specific `option_text` — must match the numeric/ordinal values already present in the live response-level IRW dataset (`irw::irw_fetch(table)$resp`). |
+| `instructions_translated`, `section_prompt_translated`, `item_text_translated`, `option_text_translated` | English translation of the correspondingly named field. Present only for instruments administered in a language other than English. |
 
 `instructions` and `section_prompt` are scoped differently: `instructions` applies to
 the entire table regardless of `section_id`; `section_prompt` applies only to the items
@@ -26,6 +28,16 @@ never be recorded in both fields. If framing or task-level text applies across t
 table, record it once in `instructions`. If it is specific to a subset of items sharing
 a `section_id` (e.g. a passage or context given before a testlet), record it in
 `section_prompt` only, even if it superficially resembles instructional language.
+
+**Administered language.** For a study administered in a language other than English,
+the four text fields hold the wording respondents actually read, verbatim, `language`
+names that language, and the English goes in the parallel `_translated` fields. `item`
+and `resp` are join keys and are never translated. For an English administration,
+`language` and the `_translated` columns are left out entirely rather than emitted
+empty. When the administered original cannot be recovered and only an English version
+exists, the English goes in the base fields, the `_translated` fields stay empty, and
+`text_source=translated_substitute` records the fallback. See SKILL.md's core model
+section 4 for the full rule.
 
 **`resp_raw`** (per the public schema page): when the scoring key can't be recovered —
 i.e. the item is on some categorical/lettered coding in the source material that doesn't
@@ -47,6 +59,11 @@ inspect a live example yourself before assuming this is exhaustive, sheets can v
 - **items** (gid=653192405): `table, section_id, item, item_text, correct_response`
 - **responses** (gid=1308795295): `table, section_id, item, option_text, resp` (or
   `raw_resp` in place of `resp` — see above)
+
+For a non-English administration each tab additionally carries the translated twin of
+its own text field — `instructions_translated` on instrument (alongside `language`),
+`section_prompt_translated` on sections, `item_text_translated` on items,
+`option_text_translated` on responses — so the merge carries them through unchanged.
 
 Merge logic (what `join.R` and `validate_items.R` do): start from `items`, then
 successively `merge(..., all.x=TRUE)` with `sections`, `instrument`, `responses` on their


### PR DESCRIPTION
Follow-up to #1778. The four `_translated` columns and `language` are now agreed for the public schema and `irw_text`, so the skill no longer holds a table back for sign-off before uploading one that carries them.

- `SKILL.md` — replaces the "not yet in the public schema, get that agreed first" paragraph with the decision, and keeps the open backfill question flagged.
- `references/itemtext_standard.md` — mirrors the field definitions from the public page, including which of the four source tabs each translated twin rides on.

Public page side: datapages/irw#108.

Still open (unchanged): whether the already-uploaded tables get backfilled — `ALSECYPIAMH_WU_2022_SDQ` and `altahla_2024_whoqol` ship English for non-English administrations, `burkert_2019_whoqol_bref` ships German with no translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jrSNLu55jNNppRns7KDw4