### PR TITLE
First pipeline run with the #1760 rules in force

### DIFF
--- a/metadata/status.json
+++ b/metadata/status.json
@@ -1,20 +1,20 @@
 {
-  "generated": "2026-09-01T10:29:09-0700",
+  "generated": "2026-09-01T10:52:08-0700",
   "source": "metadata/11_status.R -- local pipeline CSVs, no Redivis calls",
   "n_tables": 4134,
   "coverage": {
     "tags": {
-      "n": 2286,
-      "pct": 55.3
+      "n": 3061,
+      "pct": 74
     },
     "tags_by_column": {
       "age range": {
-        "n": 2243,
-        "pct": 54.3
+        "n": 3023,
+        "pct": 73.1
       },
       "child age (for child-focused studies)": {
-        "n": 445,
-        "pct": 10.8
+        "n": 702,
+        "pct": 17
       },
       "sample": {
         "n": 2229,
@@ -54,23 +54,23 @@
     },
     "item_response_warehouse_2": {
       "n_tables": 975,
-      "tagged": 755,
-      "pct": 77.4
+      "tagged": 858,
+      "pct": 88
     },
     "item_response_warehouse_3": {
       "n_tables": 983,
-      "tagged": 268,
-      "pct": 27.3
+      "tagged": 569,
+      "pct": 57.9
     },
     "item_response_warehouse_4": {
       "n_tables": 981,
-      "tagged": 260,
-      "pct": 26.5
+      "tagged": 559,
+      "pct": 57
     },
     "item_response_warehouse_5": {
       "n_tables": 206,
-      "tagged": 16,
-      "pct": 7.8
+      "tagged": 88,
+      "pct": 42.7
     },
     "item_response_warehouse_6": {
       "n_tables": 1,
@@ -78,5 +78,5 @@
       "pct": 0
     }
   },
-  "orphan_tag_rows": 194
+  "orphan_tag_rows": 0
 }

--- a/metadata/status_history.tsv
+++ b/metadata/status_history.tsv
@@ -1,3 +1,4 @@
 date	n_tables	tagged	tagged_pct	age_range	construct_type	itemtext	itemtext_pct	orphan_tag_rows
 2026-08-31	4134	2286	55.3	NA	NA	558	13.5	194
 2026-09-01	4134	2286	55.3	2243	2254	558	13.5	194
+2026-09-01	4134	3061	74	3023	2254	558	13.5	0


### PR DESCRIPTION
The first pipeline run with the #1760 rules in force. Two tracked files: `status.json` and `status_history.tsv`. The regenerated `tags.csv` is gitignored, as always.

`03_tags.R` did exactly what the dry run said it would:

```
core: derived age tags -- 387 overridden, 628 confirmed, 4 Non-human preserved, 775 new row(s)
core: dropped 194 tag row(s) for tables no longer live
```

`tags.csv` 2,480 → **3,061** rows. `Mixed` 700 → 469, `Adult (18+)` 1,260 → 2,045, `Elderly` 43 → 66, `Child (<18y)` 416 → 428.

**Coverage, and why the per-column split matters:**

| | before | after |
|---|---|---|
| has a tag row | 55.3% | **74.0%** |
| `age range` filled | 54.3% | **73.1%** |
| `sample` filled | 53.9% | 53.9% |
| `construct type` filled | 54.5% | 54.5% |

The headline moves 19 points because 775 tables gained a derived `age range`; nothing else moved, and the per-column figures are what say so. Per shard: w5 7.8% → 42.7%, w4 26.5% → 57.0%, w3 27.3% → 57.9%.

`orphan_tag_rows` reads **0** for the first time — #1766's guard firing as designed. It had read 194 since that PR merged, because the status file predated any run with the guard in place. That resolves the watch item.

**Not yet live on Redivis.** `upload_meta.py` writes into `datapages/irw_meta` version `next`, and there is no draft version right now (`NotFoundError: datapages.irw_meta:next`). No script in the repo creates one, so I have left that to you — see my note on the issue. The local `tags.csv` is regenerated and ready to upload the moment a draft exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUTbCySD4RLJrG7HGBMSz9
