### PR TITLE
Rescore the auto-tagger against post-#1760 gold (2.3)

### DIFF
--- a/tags/scoring/README.md
+++ b/tags/scoring/README.md
@@ -1,11 +1,38 @@
 # Auto-tagger scoring (issue #1721, sub-action 2.2)
 
-Scores the `irw-auto-tag` skill against the human-tagged gold set, per column.
-Run 2026-08-30. Reproduce with:
+Scores the `irw-auto-tag` skill against the gold set, per column.
+Predictions were produced 2026-08-30. Reproduce with:
 
 ```bash
 python3 score.py predictions_2026-08-30.json sample_2026-08-30.json
 ```
+
+## Two scored runs, same predictions
+
+`results_2026-08-30.txt` and `results_2026-09-01.txt` are the SAME 60 blind
+predictions scored against gold before and after #1760. Nothing about the tagger
+changed between them. What changed is what it was being marked against:
+
+| column | 2026-08-30 | 2026-09-01 | why |
+|---|---|---|---|
+| `age_range` | 73.0% | **86.5%** | gold is now derived from each table's own `cov_age`; 10 of the 38 scored tables had their gold corrected |
+| `sample` | 41.7% | **44.4%** | `General/non-specific` is the frame residual now, applied to both sides |
+| others | unchanged | unchanged | |
+
+**`age_range`'s 13.5-point gain is entirely gold.** The tagger was right more
+often than the old gold said — which is the finding #1760 was opened to test,
+now measured rather than argued. Cite the 2026-09-01 numbers; the earlier ones
+scored against labels that have since been withdrawn.
+
+**`sample` barely moved, and that is informative.** The frame rule removes a
+contradiction from the gold but does not teach the tagger anything: these
+predictions were written before the rule existed. The residual errors are now
+diagnosable rather than mysterious — see `results_2026-09-01.txt`, where 8 of 20
+are the tagger claiming `Representative` for a source that never claimed it, and
+5 are it answering the SETTING facet when gold recorded the FRAME. Both are
+things `vocab.md` now states, so `sample` needs the tagger re-run against the
+current vocabulary before any shipping bar is set against it. 44.4% is a
+pre-rule number.
 
 ## Method
 

--- a/tags/scoring/README.md
+++ b/tags/scoring/README.md
@@ -24,6 +24,32 @@ often than the old gold said — which is the finding #1760 was opened to test,
 now measured rather than argued. Cite the 2026-09-01 numbers; the earlier ones
 scored against labels that have since been withdrawn.
 
+## Partial credit, per atom
+
+Exact match asks "did it name the whole answer". For a multi-select column whose
+gold answer routinely has two or three facets, that is the wrong question:
+naming two of three scores the same zero as naming something unrelated. So the
+2026-09-01 run also reports micro-averaged per-atom precision and recall.
+
+| column | exact | precision | recall | F1 |
+|---|---|---|---|---|
+| `primary_languages` | 90.9% | **100.0%** | 91.7% | 95.7% |
+| `construct_type` | 64.9% | 80.0% | 69.6% | 74.4% |
+| `child_age` | 75.0% | 80.0% | 100.0% | 88.9% |
+| `sample` | 44.4% | 52.6% | 48.8% | 50.6% |
+
+The two columns that look similar on exact match are not alike, and this is what
+separates them. `construct_type` **under-tags**: when it names a facet it is
+right 80% of the time, and it misses 30% of the facets gold holds. `sample` is
+wrong in both directions at once, which is what a missing convention looks like
+rather than a granularity disagreement.
+
+`primary_languages` never names a language that is not there; it just misses
+secondary ones. That is the least damaging failure shape available.
+
+These are reported ALONGSIDE exact match, never instead of it — a bar set on F1
+alone would pass a tagger that reliably names one facet of three.
+
 **`sample` barely moved, and that is informative.** The frame rule removes a
 contradiction from the gold but does not teach the tagger anything: these
 predictions were written before the rule existed. The residual errors are now

--- a/tags/scoring/results_2026-09-01.txt
+++ b/tags/scoring/results_2026-09-01.txt
@@ -1,0 +1,86 @@
+tables: 60 attempted | 38 tagged | 22 abstained (37% of the sample had no usable source)
+
+column                gold   ans   ok  accuracy  coverage   yield
+----------------------------------------------------------------
+age_range               38    37   32     86.5%     97.4%   84.2%
+child_age                7     4    3     75.0%     57.1%   42.9%
+sample                  38    36   16     44.4%     94.7%   42.1%
+construct_type          37    37   24     64.9%    100.0%   64.9%
+measurement_tool        38    38   33     86.8%    100.0%   86.8%
+item_format             38    22   20     90.9%     57.9%   52.6%
+primary_languages       36    33   30     90.9%     91.7%   83.3%
+
+child_age, with NA read as the answer 'not a child-focused study':
+  correctly left blank when gold is NA : 30
+  wrongly filled when gold is NA       : 1
+
+per-warehouse (all columns pooled, tagged tables only):
+  item_response_warehouse       6 tagged,  9 abstained   21/ 40 =  52.5%
+  item_response_warehouse_2     8 tagged,  7 abstained   28/ 49 =  57.1%
+  item_response_warehouse_3    15 tagged,  0 abstained   74/ 88 =  84.1%
+  item_response_warehouse_4     9 tagged,  6 abstained   35/ 55 =  63.6%
+
+multi-select columns -- how they miss, not just whether:
+  column                  n    exact  subset  super  overlap  disjoint   >=1 atom
+  child_age               4    75.0%       0      1        0      0.0%     100.0%
+  sample                 36    44.4%       2      0        0     50.0%      50.0%
+  construct_type         37    64.9%       5      2        0     16.2%      83.8%
+  primary_languages      33    90.9%       3      0        0      0.0%     100.0%
+  A subset or superset is a granularity disagreement on a genuinely
+  multi-faceted answer; a disjoint miss is a different answer entirely.
+
+confusions (gold -> predicted):
+  age_range:
+      2x  Mixed  ->  Adult (18+)
+      2x  Mixed  ->  Child (<18y)
+      1x  Adult (18+)  ->  Mixed
+  child_age:
+      1x  Adolescent (12-18y)  ->  Adolescent (12-18y), Child (6-12y)
+  sample:
+      5x  General/non-specific  ->  Representative
+      3x  Targeted/specific  ->  Representative
+      3x  General/non-specific  ->  Educational
+      2x  Targeted/specific  ->  Educational
+      1x  Educational  ->  Targeted/specific
+      1x  Educational  ->  Clinical
+  construct_type:
+      2x  Opinion/attitude  ->  Behavioral, Opinion/attitude
+      2x  Affective/mental health, Opinion/attitude  ->  Opinion/attitude
+      1x  Affective/mental health, Cognitive/educational, Developmental  ->  Affective/mental health, Developmental
+      1x  Affective/mental health  ->  Behavioral
+      1x  Affective/mental health, Opinion/attitude  ->  Physical health/functioning
+      1x  Affective/mental health, Cognitive/educational, Developmental  ->  Cognitive/educational
+  measurement_tool:
+      4x  Survey/questionnaire  ->  Test
+      1x  Observational rating  ->  Survey/questionnaire
+  item_format:
+      1x  Likert Scale/selected response  ->  Mixed
+      1x  Mixed  ->  Likert Scale/selected response
+  primary_languages:
+      1x  eng, spa  ->  eng
+      1x  chi, eng  ->  chi
+      1x  eng, por  ->  por
+
+abstained:
+  aspirations_sonmez_2022                              fetch_failed   item_response_warehouse
+  gilbert_meta_40                                      fetch_failed   item_response_warehouse
+  ecuador_2011_safety_crime                            fetch_failed   item_response_warehouse_2
+  cfc_balaji_2019                                      fetch_failed   item_response_warehouse
+  oxfordcovid_xue_2024_brs                             paywall        item_response_warehouse
+  gahps_korner_2021                                    fetch_failed   item_response_warehouse_2
+  c19prc_uk_mcbride_2021_socialdistance                fetch_failed   item_response_warehouse_4
+  dwyer_2025_genomics_pb                               paywall        item_response_warehouse
+  pass20_klosowska_2025_pass_hospital                  paywall        item_response_warehouse
+  gmc_kay_2025                                         paywall        item_response_warehouse_2
+  spain_2023_identity_authenticity                     no_source      item_response_warehouse_4
+  enem_2022_1mil_cn                                    fetch_failed   item_response_warehouse
+  heise_2024_mental_falsesign                          paywall        item_response_warehouse_2
+  abdullah_2024_hbbloat_pbc                            paywall        item_response_warehouse_4
+  spain_2023_identity_territorial                      no_source      item_response_warehouse_4
+  pisa2009_math                                        fetch_failed   item_response_warehouse
+  jeilani_2024_personal_growth                         fetch_failed   item_response_warehouse_2
+  sun_2025_morality_study1_fairnesshexaco              paywall        item_response_warehouse_2
+  c19prc_uk_mcbride_2021_polarization_brexit           fetch_failed   item_response_warehouse_4
+  pisa2022_read                                        paywall        item_response_warehouse
+  jeilani_2024_self_efficacy                           fetch_failed   item_response_warehouse_2
+  c19prc_uk_mcbride_2021_protective_behaviours         paywall        item_response_warehouse_4

--- a/tags/scoring/results_2026-09-01.txt
+++ b/tags/scoring/results_2026-09-01.txt
@@ -29,6 +29,16 @@ multi-select columns -- how they miss, not just whether:
   A subset or superset is a granularity disagreement on a genuinely
   multi-faceted answer; a disjoint miss is a different answer entirely.
 
+multi-select, per-atom (micro-averaged) -- partial credit:
+  column                  tp    fp    fn  precision   recall      F1
+  child_age                4     1     0      80.0%   100.0%   88.9%
+  sample                  20    18    21      52.6%    48.8%   50.6%
+  construct_type          32     8    14      80.0%    69.6%   74.4%
+  primary_languages       33     0     3     100.0%    91.7%   95.7%
+  Precision below recall means over-tagging; recall below precision
+  means it names too few facets. They fail differently, and a single
+  exact-match number cannot tell you which.
+
 confusions (gold -> predicted):
   age_range:
       2x  Mixed  ->  Adult (18+)

--- a/tags/scoring/score.py
+++ b/tags/scoring/score.py
@@ -43,8 +43,26 @@ RENAME = {"Internet-based (Mturkers, etc)": "Internet-based",
           "Internet-based (Mturkers": "Internet-based"}
 DROP = {"etc)"}
 
+##`sample`'s frame facet, decided in #1760 on 2026-09-01 and enforced on export
+##by metadata/tag_normalize.R. Gold has been through that rule since the
+##2026-09-01 run; predictions were written before it existed, so they get it
+##here. Without this, a prediction of "General/non-specific, Representative"
+##scores as wrong against a gold of "Representative" for a disagreement the
+##convention has since defined away -- which would measure the tagger against a
+##question nobody could answer at the time.
+FRAME_RESIDUAL = "General/non-specific"
+FRAME_SPECIFIC = {"Representative", "Targeted/specific"}
 
-def norm(v, multi):
+
+def apply_frame_residual(atoms, column):
+    if column != "sample" or FRAME_RESIDUAL not in atoms:
+        return atoms
+    if not (FRAME_SPECIFIC & set(atoms)):
+        return atoms
+    return [a for a in atoms if a != FRAME_RESIDUAL]
+
+
+def norm(v, multi, column=None):
     """Canonicalise a cell to a comparable frozen set, or None when empty/NA."""
     if v is None:
         return None
@@ -55,6 +73,7 @@ def norm(v, multi):
         v = v.replace(a, b)
     atoms = [a.strip() for a in v.split(",")]
     atoms = [a for a in atoms if a and a not in DROP]
+    atoms = apply_frame_residual(atoms, column)
     if not atoms:
         return None
     return tuple(sorted(set(atoms)))
@@ -96,7 +115,8 @@ def run(pred_path, sample_path):
             continue
         per_ws[ws]["tables"] += 1
         for pkey, gcol, multi in COLS:
-            gv, pv = norm(g.get(gcol), multi), norm(pr.get(pkey), multi)
+            gv, pv = (norm(g.get(gcol), multi, pkey),
+                      norm(pr.get(pkey), multi, pkey))
             s = stats[pkey]
             if pkey == "child_age":
                 if gv is None and pv is None:

--- a/tags/scoring/score.py
+++ b/tags/scoring/score.py
@@ -93,12 +93,19 @@ def _miss_kind(gv, pv):
     return "disjoint"        # nothing in common
 
 
+def atom_prf(gv, pv):
+    """Per-atom true/false positives and negatives for one multi-select cell."""
+    g, p = set(gv), set(pv)
+    return len(g & p), len(p - g), len(g - p)
+
+
 def run(pred_path, sample_path):
     gold = {r["table"].strip().lower(): r for r in csv.DictReader(open(GOLD))}
     preds = json.load(open(pred_path))
     sample = {x["table"]: x["warehouse"] for x in json.load(open(sample_path))}
 
     stats = {p: collections.Counter() for p, _, _ in COLS}
+    atoms = {p: collections.Counter() for p, _, _ in COLS}
     confusion = {p: collections.Counter() for p, _, _ in COLS}
     per_ws = collections.defaultdict(collections.Counter)
     abst = []
@@ -142,11 +149,15 @@ def run(pred_path, sample_path):
                 confusion[pkey][(", ".join(gv), ", ".join(pv))] += 1
             if multi:
                 s[_miss_kind(gv, pv)] += 1
-    return stats, confusion, per_ws, abst, preds
+                tp, fp, fn = atom_prf(gv, pv)
+                atoms[pkey]["tp"] += tp
+                atoms[pkey]["fp"] += fp
+                atoms[pkey]["fn"] += fn
+    return stats, confusion, per_ws, abst, preds, atoms
 
 
 if __name__ == "__main__":
-    stats, confusion, per_ws, abst, preds = run(sys.argv[1], sys.argv[2])
+    stats, confusion, per_ws, abst, preds, atoms = run(sys.argv[1], sys.argv[2])
     tagged = sum(1 for p in preds if p.get("status") == "tagged")
     pct = 100 * len(abst) / len(preds) if preds else 0
     print(f"tables: {len(preds)} attempted | {tagged} tagged | {len(abst)} abstained "
@@ -189,6 +200,34 @@ if __name__ == "__main__":
               f"{f(shared,n):>9s}")
     print("  A subset or superset is a granularity disagreement on a genuinely")
     print("  multi-faceted answer; a disjoint miss is a different answer entirely.")
+
+    ##Partial credit, per ATOM rather than per cell (#1722). Exact match asks
+    ##"did it name the whole answer", which is the right question for a
+    ##single-select column and the wrong one where the gold answer routinely has
+    ##two or three facets: naming two of three scores the same zero as naming
+    ##something unrelated. Micro-averaged over atoms:
+    ##
+    ##  precision = of the atoms it named, how many were right   (over-tagging)
+    ##  recall    = of the atoms gold holds, how many it found   (under-tagging)
+    ##
+    ##Reported ALONGSIDE exact match, never instead of it. A bar set on F1 alone
+    ##would pass a tagger that reliably names one facet of three.
+    print("\nmulti-select, per-atom (micro-averaged) -- partial credit:")
+    print(f"  {'column':20s} {'tp':>5s} {'fp':>5s} {'fn':>5s} "
+          f"{'precision':>10s} {'recall':>8s} {'F1':>7s}")
+    for pkey, _, _ in multi:
+        a = atoms[pkey]
+        tp, fp, fn = a["tp"], a["fp"], a["fn"]
+        if not (tp + fp + fn):
+            continue
+        prec = tp / (tp + fp) if tp + fp else 0.0
+        rec = tp / (tp + fn) if tp + fn else 0.0
+        f1 = 2 * prec * rec / (prec + rec) if prec + rec else 0.0
+        print(f"  {pkey:20s} {tp:5d} {fp:5d} {fn:5d} "
+              f"{100*prec:9.1f}% {100*rec:7.1f}% {100*f1:6.1f}%")
+    print("  Precision below recall means over-tagging; recall below precision")
+    print("  means it names too few facets. They fail differently, and a single")
+    print("  exact-match number cannot tell you which.")
 
     print("\nconfusions (gold -> predicted):")
     for pkey, _, _ in COLS:


### PR DESCRIPTION
Scores the **same 60 blind predictions** from 2026-08-30 against the gold set as it stands after the #1760 rules ran. The tagger did not change; what it is being marked against did.

| column | 2026-08-30 | 2026-09-01 | coverage | yield |
|---|---|---|---|---|
| `age_range` | 73.0% | **86.5%** | 97.4% | 84.2% |
| `sample` | 41.7% | **44.4%** | 94.7% | 42.1% |
| `construct_type` | 64.9% | 64.9% | 100% | 64.9% |
| `measurement_tool` | 86.8% | 86.8% | 100% | 86.8% |
| `item_format` | 90.9% | 90.9% | 57.9% | 52.6% |
| `primary_languages` | 90.9% | 90.9% | 91.7% | 83.3% |

**`age_range`'s 13.5-point gain is entirely gold.** 10 of the 38 scored tables had their label corrected by the derivation — 8 of them `Mixed` → `Adult (18+)`. This is #1760's thesis measured rather than argued: the tagger was right more often than the old gold said. Its remaining five errors are the honest ones (2 `Mixed` → `Adult`, 2 `Mixed` → `Child`, 1 `Adult` → `Mixed`).

**`sample` barely moved, and that is the useful part.** `score.py` now applies the frame-residual rule to both sides, since gold goes through it on export and these predictions predate it. Removing the contradiction from gold does not teach the tagger anything — but it makes the residual errors diagnosable instead of mysterious. Of the 20 wrong:

- **8 are `Representative` claimed for a source that never claimed it** (5 gold `General/non-specific`, 3 gold `Targeted/specific`). `vocab.md` now says the claim must be the source's.
- **5 are the tagger answering the *setting* facet where gold recorded the *frame*** (`General/non-specific` → `Educational`, `Targeted/specific` → `Educational`). `vocab.md` now says these are two different questions.

Both failure modes are things the vocabulary states today and did not state then. **44.4% is a pre-rule number and cannot set a shipping bar.** `sample` needs the tagger re-run against the current `vocab.md` before it can be held to anything — which needs blind subagents, so it is not something I should kick off unasked.

Changes: the frame rule in `score.py` (applied to both sides, documented at the constant), `results_2026-09-01.txt`, and a README section explaining why two result files exist for one set of predictions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUTbCySD4RLJrG7HGBMSz9
