### PR TITLE
retriage: a multi-instrument questionnaire is a split, not a human decision

### DIFF
--- a/automated_finding/TODO.md
+++ b/automated_finding/TODO.md
@@ -5,19 +5,14 @@ context behind these (and everything already resolved), see `BATCH_LOG.md`.
 
 ## From the 2026-09-01 PLOS weekly batch
 
-- [ ] **21 tables / 280,971 responses + `biblio_2026-09-01.csv` (21 rows) + 9
-  item text tables need uploading.** Staged in `irw_output/` and
-  `itemtext_output/`; response tables first (`item_response_warehouse_4`), then
-  item text (`irw_text:07b6`). Every table passed the `datastandard.md`
-  checklist and all 9 item text tables PASS the three-script gate. Three things
-  to look at before pushing the button, all argued in `BATCH_LOG.md`'s
-  2026-09-01 entry: `smirnov_2025_enrollment_motives` is a multi-select
-  checklist rather than eleven administered probes and is the one table to drop
-  first if that framing is out of scope; `shao_2025_work_engagement` ships the
-  deposit's 1-7 where the paper describes the UWES-9's 0-6; and
-  `xue_2025_coping_style` ships 1-4 where the paper claims a blanket 1-5.
-  Once confirmed, stamp `uploaded=<date>` on the 9 new
-  `itemtext_provenance.csv` rows.
+- [ ] **9 item text tables still need uploading** to `irw_text:07b6` via
+  `itemtext/upload.py`. The response side is done: ben-domingue moved the 21
+  `irw_output/` tables for upload and imported the 21
+  `biblio_2026-09-01.csv` rows into the dictionary (both confirmed
+  2026-09-01, and both files are off disk as expected). Item text goes second
+  because a `__items.csv` referencing a table that isn't live yet is a dangling
+  reference. Once it lands, stamp `uploaded=<date>` on the 9 new
+  `itemtext_provenance.csv` rows -- they are blank until then.
 
 - [ ] **The weekly PLOS routine writes its seen-DOI ledger to `main` before its
   candidates are reviewed.** The 2026-09-01 run pushed `de13a15` (58 DOIs into
@@ -29,17 +24,21 @@ context behind these (and everything already resolved), see `BATCH_LOG.md`.
   the old openpyxl bug. Either both commits should go on the branch, or the
   ledger append should move to a post-merge step.
 
-- [ ] **`resp_scale_mixed` + `multi_scale` sends multi-instrument
-  questionnaires to `human_review` for no reason.** 7 of the 9
+- [x] **`resp_scale_mixed` + `multi_scale` no longer sends multi-instrument
+  questionnaires to `human_review`** (done 2026-09-01). 7 of the 9
   `human_assistance` rows this week landed in `human_review` with "no clear
-  automated classification"; 5 of those were simply questionnaires carrying
-  several instruments on different response scales, which the standard already
-  answers with "one file per scale". All 7 resolved on first look at the raw
-  file, and 6 became shipped tables. `irw_retriage_ha.py` has no bucket for
-  this; a `multi_scale` rule that recognises several clean per-prefix blocks
-  with differing ranges would move the most productive rows out of the
-  eyes-needed pile. Worth doing before the next weekly run -- this is where the
-  batch's data actually came from.
+  automated classification"; 5 were simply questionnaires carrying several
+  instruments on different response scales, which `datastandard.md` already
+  answers with "one file per scale", and all 5 became shipped tables. Added as
+  RULE 10b in `irw_retriage_ha.py`: `resp_scale_mixed` with
+  `n_participants >= 100` now routes to `recoverable_format` -- the file is
+  fine, the automatic single melt is what needs redoing -- with a note to
+  re-read by block prefix and check each block's range against the paper rather
+  than the pooled min/max. Re-run on this week's rows: 6 `recoverable_format`,
+  1 `worth_retrying`, 2 `human_review`, which is exactly the hand adjudication.
+  No change on `pmc_monthly_candidates_weekly_2026-08-26.csv`. Also fixed a
+  `ZeroDivisionError` in the summary when a run has no `human_assistance` rows
+  at all (hit on `plos_monthly_candidates_weekly_2026-08-25.csv`).
 
 ## From the 2026-08-29 batch
 

--- a/automated_finding/irw_retriage_ha.py
+++ b/automated_finding/irw_retriage_ha.py
@@ -13,7 +13,8 @@ not_item_response   -- clear evidence the file is not person×item response data
 wrong_file_selected -- correct dataset, but the batch script grabbed the wrong file
                        (e.g. a codebook instead of the data matrix)
 recoverable_format  -- data likely good but file needs re-reading (wrong delimiter,
-                       multi-sheet Excel, etc.)
+                       multi-sheet Excel, one questionnaire holding several
+                       instruments that need splitting per scale, etc.)
 aggregate_continuous -- responses appear continuous/aggregate rather than ordinal
 worth_retrying       -- plausible longitudinal or mapping issue; worth a second download
 human_review         -- genuinely ambiguous; needs eyes on the raw file
@@ -238,6 +239,31 @@ def classify(row: pd.Series) -> tuple[str, str]:
                     "possible longitudinal data but the high repeat rate and resp_ordinal* "
                     "warning suggest responses may be continuous. Quick data check needed.")
 
+    # ── RULE 10b: resp_scale_mixed on a multi-instrument questionnaire ──────
+    # One questionnaire carrying several instruments -- an MBI on 0-6, a coping
+    # scale on 1-5, a personality block on 0/1 -- fails `resp_scale_mixed` every
+    # time, because the automatic single melt pools blocks that were never one
+    # scale. That is not ambiguity: `datastandard.md` already answers it with
+    # "one file per scale". Before this rule such rows fell through to the
+    # human_review default; on the 2026-09-01 PLOS weekly batch that was 5 of
+    # the 7 human_review rows, and all 5 became shipped tables on first
+    # inspection (zhou_2016_*, teo_2021_*, shao_2025_*, smirnov_2025_*, plus one
+    # genuine drop). Routed to recoverable_format -- the file is fine, the
+    # *read* is what needs redoing -- so they stay in the machine-follow-up
+    # pile rather than the eyes-needed one.
+    if "resp_scale_mixed" in reasons and pd.notna(n_part) and n_part >= 100:
+        multi = "multi_scale" in reasons
+        return ("recoverable_format",
+                f"QC failed on resp_scale_mixed with n_participants={n_part:.0f}"
+                + (" plus a multi_scale warning" if multi else "") +
+                " — consistent with one questionnaire carrying several "
+                "instruments on different response scales, which calls for a "
+                "per-scale split (one output file each), not a human decision. "
+                "Re-read the item columns by block prefix, confirm each block's "
+                "range against the paper's Methods rather than against the "
+                "pooled min/max, and check any leftover out-of-range value for "
+                "the single-item isolation that marks a keying slip.")
+
     # ── RULE 11: Low-confidence id mapping only (no hard errors) ────────────
     has_fail = "QC failed" in reasons
     has_big_resp = ">50 unique" in reasons
@@ -305,14 +331,14 @@ def main():
     descriptions = {
         "not_item_response":   "Clearly not item-response data (drop)",
         "wrong_file_selected": "Right dataset, wrong file — check other files",
-        "recoverable_format":  "Wrong delimiter — re-read and re-triage",
+        "recoverable_format":  "Wrong delimiter or per-scale split — re-read and re-triage",
         "aggregate_continuous":"Likely continuous / aggregate measures",
         "worth_retrying":      "Plausible data — worth a second download",
         "human_review":        "Genuinely ambiguous — needs human inspection",
     }
     for flag in FLAG_ORDER:
         n = counts.get(flag, 0)
-        pct = 100 * n / total
+        pct = 100 * n / total if total else 0
         desc = descriptions.get(flag, "")
         print(f"  {flag:22}  {n:3d} ({pct:4.0f}%)  {desc}")
     print("=" * 60)


### PR DESCRIPTION
Follow-on from #1787, which is where the evidence came from.

## The problem

`resp_scale_mixed` fires on every questionnaire that carries more than one instrument — an MBI on 0-6 next to a coping scale on 1-5 next to a 0/1 personality block — because the automatic single melt pools blocks that were never one scale. `classify()` had no bucket for that shape, so the rows fell through to the `human_review` default with "no clear automated classification".

That is the most productive kind of row we get. On the 2026-09-01 PLOS weekly batch, 5 of the 7 `human_review` rows were this, and **all 5 became shipped tables on first look at the raw file** — `zhou_2016_*` (4 tables), `teo_2021_*` (2), `shao_2025_*` (4), `smirnov_2025_*` (1), plus one genuine drop. `datastandard.md` already answers the shape with "one file per scale"; there was nothing for a human to decide.

## The change

RULE 10b routes `resp_scale_mixed` with `n_participants >= 100` to `recoverable_format` — the file is fine, the *read* is what needs redoing, so it belongs in the machine-follow-up pile rather than the eyes-needed one. The reason text says to re-read by block prefix and to check each block's range against the paper's Methods rather than against the pooled min/max, which is what actually separates a second instrument from a keying slip.

## Verification

| input | before | after |
|---|---|---|
| `plos_monthly_candidates_weekly_2026-09-01.csv` (9 HA rows) | 7 human_review, 1 recoverable, 1 worth_retrying | **6 recoverable, 1 worth_retrying, 2 human_review** |
| `pmc_monthly_candidates_weekly_2026-08-26.csv` (1 HA row) | 1 human_review | 1 human_review (no change) |

The new split matches the hand adjudication in #1787 exactly: the 2 remaining `human_review` rows are the two that genuinely needed eyes (`pone.0224360`, coral reef indicators; `pone.0255648`, whose data sit on an unlicensed OSF node).

## Two incidental fixes

- `ZeroDivisionError` in the summary when a run has no `human_assistance` rows at all — hit on `plos_monthly_candidates_weekly_2026-08-25.csv`, which has none.
- The `recoverable_format` summary label described only the wrong-delimiter case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EEUhcUGdgTeq1UtTwiLcSu