### PR TITLE
Drafts may sit for a week, and something now notices when they don't

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -161,6 +161,30 @@ ever creates a *draft* Redivis version — Redivis keeps an unpublished working
 copy that nobody outside the project can see until someone clicks publish. That
 click is always a human action taken after reviewing a diff.
 
+**Changes may sit in a draft for up to one week.** Releasing after every upload
+is unmanageable, so batching is the norm and an unreleased draft is a normal
+state rather than a loose end. The week is the outside limit, not a target.
+
+Two things follow that are easy to get wrong:
+
+- **Until the version is released, the upload has not happened** as far as
+  anyone outside the project is concerned. `irw_fetch()`, `irw_itemtext()`,
+  `irw_metadata()` and the site all read the *released* version. A script that
+  reports a successful upload and a `count(*)` that matches has told you about
+  the draft and nothing else.
+- **A correction to already-published data is not a normal draft item.** Adding
+  a table late means the corpus is missing something; correcting one means the
+  corpus is actively serving something wrong, and the week does not apply.
+  Release those when they land. `irw#1816` is the worked example: three item
+  text tables served at 2x for a day, and the fix sat correct-but-invisible in
+  the draft until the version went out.
+
+`python3 -m red_up.drafts` reports every dataset with unreleased changes and how
+long the public corpus has been behind, exiting non-zero past the window. It
+counts **time since the last released version**, because the two obvious clocks
+both lie: a table's `updatedAt` resets for every table in the draft whenever the
+draft is touched, and the draft version's own `createdAt` resets on each upload.
+
 `red_up` replaced thirteen near-identical copies of one script, each hardcoding
 a different dataset, so the destination used to be decided by which file you
 happened to run. It reads the dataset list from `metadata/redivis_config.R`,

--- a/red_up/README.md
+++ b/red_up/README.md
@@ -113,3 +113,30 @@ Roadmap 1.3–1.5: merging `misc/validate_irw.R` with
 `automated_finding/irw_triage_updated.py::run_qc()` into one validator, the
 GitHub Action, and the sweep over `data/pub/`. `checks.run_validator` is the
 seam it plugs into.
+
+## Drafts, and the one-week window
+
+`red_up` only ever writes a **draft** version. Releasing is a human action on
+Redivis, and project policy allows changes to sit in a draft for **up to one
+week** — releasing after every upload is unmanageable, so batching is expected.
+
+```
+python3 -m red_up.drafts              # every dataset, how far behind each one is
+python3 -m red_up.drafts --verbose    # and what the draft actually changes
+python3 -m red_up.drafts --days 3
+```
+
+Exit code 1 means something is past the window.
+
+Two cautions the tool exists to enforce:
+
+- **A successful upload is not a published one.** The `count(*)` check in
+  `red_up` verifies the draft. Everything users touch reads the released
+  version.
+- **Corrections to published data are exempt from the week.** A late addition
+  means the corpus is incomplete; a late correction means it is serving
+  something wrong. See `ARCHITECTURE.md` §4 and `ben-domingue/irw#1816`.
+
+The check counts *time since the last release*, not the age of a table or of the
+draft — both of those reset whenever the draft is touched, so both would read as
+minutes old on a month-old backlog.

--- a/red_up/drafts.py
+++ b/red_up/drafts.py
@@ -1,0 +1,152 @@
+"""How long a Redivis dataset has had unreleased changes sitting in its draft.
+
+Uploads only ever write a *draft* version (see `red_up.push`), and publishing is
+a human action. That is deliberate -- it puts a review between a script and the
+public corpus -- but it means a draft can quietly accumulate, and until the
+version is released nothing a script uploaded is visible to `irw_fetch()`,
+`irw_itemtext()` or the site. Project policy is that changes may sit on `next`
+for **up to one week**. This reports datasets past that line, so the window is
+something that gets noticed rather than a sentence in a document.
+
+    python3 -m red_up.drafts                 # every dataset in redivis_config.R
+    python3 -m red_up.drafts --dataset irw_text
+    python3 -m red_up.drafts --days 3
+    python3 -m red_up.drafts --verbose       # also list what the draft changes
+
+Exit codes: 0 nothing overdue - 1 something is overdue - 2 bad input.
+
+**What is measured, and why it is not the obvious thing.** Two tempting clocks
+are both wrong:
+
+  * A *table's* `updatedAt` resets for every table in the draft whenever the
+    draft is touched, because opening a draft copies the whole dataset. Every
+    table in a 578-table draft reads as minutes old the moment you upload one.
+  * The *draft version's* own `createdAt` resets on each upload too, so a
+    dataset that receives something weekly would never look overdue even with
+    changes from a month ago still unpublished.
+
+What survives both is **time since the last released version**, counted only
+when the draft actually differs from it. That is also the quantity the policy is
+about: how long the public corpus has been behind what we have.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import sys
+
+from .auth import authenticate
+from .targets import ConfigError, load_registry
+
+POLICY_DAYS = 7
+
+
+def _when(epoch_ms: int | None) -> dt.datetime | None:
+    if not epoch_ms:
+        return None
+    return dt.datetime.fromtimestamp(epoch_ms / 1000, tz=dt.timezone.utc)
+
+
+def inspect(owner: str, target, now: dt.datetime):
+    """Return a dict describing one dataset's draft, or an `error` key."""
+    import redivis
+
+    out = {"dataset": target.name, "label": target.label}
+    try:
+        ds = redivis.user(owner).dataset(target.name)
+        versions = ds.list_versions()
+    except Exception as exc:
+        return {**out, "error": str(exc).splitlines()[0][:90]}
+
+    released = [v for v in versions if v.properties.get("isReleased")]
+    draft = next((v for v in versions if not v.properties.get("isReleased")), None)
+    if draft is None:
+        return {**out, "has_draft": False}
+
+    last = max(released, key=lambda v: v.properties.get("createdAt") or 0, default=None)
+    since = _when(last.properties.get("createdAt")) if last is not None else None
+    out.update(
+        has_draft=True,
+        released_tag=(last.properties.get("tag") if last is not None else None),
+        days_since_release=((now - since).total_seconds() / 86400 if since else None),
+    )
+
+    # Only count it as a backlog if the draft actually differs from the release.
+    try:
+        d_tables = {t.name: t.properties.get("numRows")
+                    for t in redivis.user(owner).dataset(target.name, version="next").list_tables()}
+        r_tables = {t.name: t.properties.get("numRows")
+                    for t in redivis.user(owner).dataset(target.name, version="current").list_tables()} \
+            if last is not None else {}
+    except Exception as exc:
+        return {**out, "error": str(exc).splitlines()[0][:90]}
+
+    out.update(
+        added=sorted(set(d_tables) - set(r_tables)),
+        removed=sorted(set(r_tables) - set(d_tables)),
+        changed=sorted(t for t in set(d_tables) & set(r_tables) if d_tables[t] != r_tables[t]),
+    )
+    out["pending"] = len(out["added"]) + len(out["removed"]) + len(out["changed"])
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="red_up.drafts",
+        description="Report Redivis datasets with unreleased changes past the policy window.",
+    )
+    ap.add_argument("--dataset", help="only this dataset (default: all of them)")
+    ap.add_argument("--days", type=int, default=POLICY_DAYS,
+                    help=f"the policy window in days (default {POLICY_DAYS})")
+    ap.add_argument("--verbose", action="store_true", help="list the tables the draft changes")
+    args = ap.parse_args(argv)
+
+    try:
+        owner, targets = load_registry()
+    except ConfigError as exc:
+        print(f"red_up.drafts: {exc}", file=sys.stderr)
+        return 2
+    if args.dataset:
+        targets = [t for t in targets if t.name == args.dataset]
+        if not targets:
+            print(f"red_up.drafts: no dataset named {args.dataset!r} in redivis_config.R",
+                  file=sys.stderr)
+            return 2
+
+    authenticate()
+    now = dt.datetime.now(dt.timezone.utc)
+    overdue = []
+    for target in targets:
+        r = inspect(owner, target, now)
+        if r.get("error"):
+            print(f"{r['dataset']:36s} -- could not read ({r['error']})")
+            continue
+        if not r.get("has_draft"):
+            print(f"{r['dataset']:36s} no draft")
+            continue
+        if not r.get("pending"):
+            print(f"{r['dataset']:36s} draft matches {r.get('released_tag')} -- nothing pending")
+            continue
+        age = r.get("days_since_release")
+        age_s = f"{age:.1f}d" if age is not None else "never released"
+        late = age is not None and age > args.days
+        if late:
+            overdue.append(r)
+        print(f"{r['dataset']:36s} {r['pending']:>4} pending, {age_s:>14} since "
+              f"{r.get('released_tag')}  {'OVERDUE' if late else ''}")
+        if args.verbose:
+            for kind in ("added", "removed", "changed"):
+                for name in r.get(kind, []):
+                    print(f"      {kind:8s} {name}")
+
+    if overdue:
+        print(f"\n{len(overdue)} dataset(s) past the {args.days}-day window: "
+              f"{', '.join(r['dataset'] for r in overdue)}")
+        print("Release the version on Redivis, or record on the issue why it is held.")
+        return 1
+    print("\nnothing past the window.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/red_up/tests/test_red_up.py
+++ b/red_up/tests/test_red_up.py
@@ -229,3 +229,90 @@ class Planning(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# --- red_up.drafts -----------------------------------------------------------
+
+import datetime as _dt
+
+from red_up import drafts as _drafts
+
+
+class _Version:
+    def __init__(self, tag, released, created_ms):
+        self.properties = {"tag": tag, "isReleased": released, "createdAt": created_ms}
+
+
+class _Table:
+    def __init__(self, name, rows):
+        self.name = name
+        self.properties = {"numRows": rows}
+
+
+def _ms(days_ago, now):
+    return int((now - _dt.timedelta(days=days_ago)).timestamp() * 1000)
+
+
+def _fake_redivis(monkeypatch, versions, draft_tables, released_tables):
+    """Stand in for the redivis module inside inspect()."""
+    class _DS:
+        def __init__(self, version=None):
+            self._v = version
+
+        def list_versions(self):
+            return versions
+
+        def list_tables(self):
+            src = draft_tables if self._v == "next" else released_tables
+            return [_Table(n, r) for n, r in src.items()]
+
+    class _User:
+        def dataset(self, name, version=None):
+            return _DS(version)
+
+    import sys, types
+    mod = types.ModuleType("redivis")
+    mod.user = lambda owner: _User()
+    monkeypatch.setitem(sys.modules, "redivis", mod)
+
+
+def _target(name="irw_text"):
+    from red_up.targets import Target
+    return Target(name=name, label="item text", kind="aux", source="text")
+
+
+def test_drafts_reports_pending_and_age(monkeypatch):
+    now = _dt.datetime.now(_dt.timezone.utc)
+    _fake_redivis(
+        monkeypatch,
+        versions=[_Version("v1.0", True, _ms(10, now)), _Version("next", False, _ms(0.1, now))],
+        draft_tables={"a__items": 10, "b__items": 20, "c__items": 5},
+        released_tables={"a__items": 10, "b__items": 99},
+    )
+    r = _drafts.inspect("datapages", _target(), now)
+    assert r["has_draft"] is True
+    assert r["added"] == ["c__items"]
+    assert r["changed"] == ["b__items"]
+    assert r["removed"] == []
+    assert r["pending"] == 2
+    # age is time since the last RELEASE, not since the draft was touched
+    assert 9.5 < r["days_since_release"] < 10.5
+
+
+def test_drafts_ignores_a_draft_identical_to_the_release(monkeypatch):
+    now = _dt.datetime.now(_dt.timezone.utc)
+    _fake_redivis(
+        monkeypatch,
+        versions=[_Version("v1.0", True, _ms(30, now)), _Version("next", False, _ms(0.1, now))],
+        draft_tables={"a__items": 10},
+        released_tables={"a__items": 10},
+    )
+    r = _drafts.inspect("datapages", _target(), now)
+    assert r["pending"] == 0, "an untouched draft is not a backlog, however old the release"
+
+
+def test_drafts_reports_no_draft(monkeypatch):
+    now = _dt.datetime.now(_dt.timezone.utc)
+    _fake_redivis(monkeypatch, versions=[_Version("v1.0", True, _ms(3, now))],
+                  draft_tables={}, released_tables={"a__items": 10})
+    assert _drafts.inspect("datapages", _target(), now)["has_draft"] is False


### PR DESCRIPTION
Policy set by @ben-domingue 2026-09-02: **changes may live in a Redivis draft for up to one week.** Releasing after every upload is unmanageable, so batching is the norm and an unreleased draft is a normal state rather than a loose end. Recorded in `ARCHITECTURE.md` §4, beside the existing "nothing uploads automatically", and in `red_up/README.md`.

## Two consequences written down with it

Both have already bitten, today:

- **Until the version is released, the upload has not happened** as far as anyone outside the project is concerned. `red_up`'s `count(*)` check verifies the *draft*; `irw_fetch()`, `irw_itemtext()`, `irw_metadata()` and the site all read the *released* version. A green upload and a matching row count tell you nothing about what users are getting.
- **A correction to already-published data is exempt from the week.** A late addition means the corpus is incomplete; a late correction means it is actively serving something wrong. #1816 is the worked example — three item text tables served at 2x, with the fix sitting correct-but-invisible in the draft.

## The check

```
python3 -m red_up.drafts              # every dataset, how far behind each one is
python3 -m red_up.drafts --verbose    # and what the draft actually changes
python3 -m red_up.drafts --days 3
```

Exit code 1 past the window. It reuses `red_up`'s auth and dataset registry rather than carrying its own.

**It counts time since the last released version**, which is not the obvious clock. The two obvious ones both lie:

| clock | why it fails |
|---|---|
| a table's `updatedAt` | resets for *every* table in the draft whenever the draft is touched — opening a draft copies the whole dataset. All 578 tables in `irw_text`'s draft currently read as minutes old. |
| the draft version's `createdAt` | resets on each upload, so a dataset receiving something weekly would never look overdue with a month of unpublished changes in it. |

Time since last release survives both, and it is the quantity the policy is about: how far behind the public corpus is. A draft that is byte-identical to the release is not counted as a backlog however old the release is.

## First run

```
item_response_warehouse_5              38 pending,           4.1d since v1.2
irw_text                               14 pending,           0.5d since v13.0
```

Shard 5 has **38 unreleased response-data tables** that nobody was tracking. Neither dataset is over the line yet; neither was visible before.

Tests: 3 new, 22 passing. The Redivis client is faked, so they run offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5VsAkTyiVWtFij13gVYGa