### PR TITLE
One format validator with an exit code, a gate, and standing priorities (#1703)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,10 +37,12 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          # pandas is what irw_validate needs; redivis is declared by the
-          # package but no test touches the network.
+          # pandas for irw_validate; redivis because red_up.cli imports it at
+          # module scope even though no test here touches the network. The
+          # first run of this workflow failed on exactly that -- installing
+          # with --no-deps left one pre-existing test unable to import cli.
           python -m pip install pandas
-          python -m pip install -e . --no-deps
+          python -m pip install -e .
 
       - name: red_up
         run: python -m unittest discover -s red_up/tests -t . -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,61 @@
+# The first workflow in this repository that runs any of its code.
+#
+# The three that came before it -- "To Do.yml", "In Progress.yml",
+# "Under Review.yml" -- are GitHub Projects card-movers: they never check out
+# the repo and never execute a line of it. So until now, "did this change break
+# the shared tooling?" was a question only a human could answer by cloning.
+#
+# That is the reported cause of the pull-request backlog: five of the eight open
+# PRs have no review at all, and every submission needs manual adjudication
+# because nothing mechanical can speak first. This makes the mechanical part
+# mechanical.
+#
+# Deliberately narrow. It runs the two test suites and nothing else -- no
+# network, no credentials, no Redivis, no dataset downloads. A test job that
+# depends on a third party's uptime teaches people to ignore red marks.
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          # pandas is what irw_validate needs; redivis is declared by the
+          # package but no test touches the network.
+          python -m pip install pandas
+          python -m pip install -e . --no-deps
+
+      - name: red_up
+        run: python -m unittest discover -s red_up/tests -t . -v
+
+      - name: irw_validate
+        run: python -m unittest discover -s irw_validate/tests -t . -v
+
+      # The R validator is the copy external contributors source from a raw
+      # GitHub URL, so it has to keep parsing even though nothing here imports
+      # it. irw_validate's parity test checks that its `# @check` markers still
+      # match CORE_CHECKS; this checks it is still valid R.
+      - name: validate_irw.R still parses
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq r-base-core
+          Rscript -e 'source("misc/validate_irw.R"); \
+            d <- data.frame(id=c(1,2), item=c("a","b"), resp=c(1,2)); \
+            stopifnot(validate_irw_status(validate_irw(d, "ci")) == 0L); \
+            cat("validate_irw.R OK\n")'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,4 @@ jobs:
       - name: validate_irw.R still parses
         run: |
           sudo apt-get update -qq && sudo apt-get install -y -qq r-base-core
-          Rscript -e 'source("misc/validate_irw.R"); \
-            d <- data.frame(id=c(1,2), item=c("a","b"), resp=c(1,2)); \
-            stopifnot(validate_irw_status(validate_irw(d, "ci")) == 0L); \
-            cat("validate_irw.R OK\n")'
+          Rscript misc/tests/smoke_validate_irw.R

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -213,6 +213,7 @@ When two documents disagree, this is the order of precedence:
 | Item text schema, and the administered-language rules | [`itemtext/.claude/skills/irw-auto-itemtext/references/itemtext_standard.md`](itemtext/.claude/skills/irw-auto-itemtext/references/itemtext_standard.md), which mirrors the public page at `itemresponsewarehouse.org/itemtext.html`. It beats the automated-finding SKILL.md, which runs item text extraction at its Step 3.5 but does not own the schema |
 | Item text *extraction judgment* (what goes in `instructions` vs `section_prompt`, when to leave a field blank) | Step 4 of `itemtext/.claude/skills/irw-auto-itemtext/SKILL.md` |
 | Dataset descriptions and licenses | The per-source dictionary Sheet, by convention — no document claims this in writing |
+| What kind of work to do next, and what not to | [`PRIORITIES.md`](PRIORITIES.md) — advisory, and ben-domingue overrules it. `CLAUDE.md`'s "Processing Priorities" answers the narrower question of which *dataset* to pick |
 
 Two entries deserve their reasoning stated, because both are counter-intuitive:
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -205,6 +205,7 @@ When two documents disagree, this is the order of precedence:
 | Output schema, column names, file naming | [`datastandard.md`](datastandard.md) |
 | Redivis owner and dataset names | `IRW_OWNER` / `IRW_CORE_DATASETS` in [`metadata/redivis_config.R`](metadata/redivis_config.R) — `red_up` parses this file rather than restating it |
 | How anything gets uploaded to Redivis | [`red_up/README.md`](red_up/README.md) |
+| Whether a table meets the standard | [`irw_validate`](irw_validate/README.md) — `datastandard.md` states the rules, `irw-validate` is the one thing that enforces them, and `red_up` will not upload a table it blocks |
 | Redivis version hashes | Each client package's own config — this repo deliberately carries none |
 | Tag vocabulary for `sample` and `construct type` | `TAG_VOCAB` in [`metadata/tag_normalize.R`](metadata/tag_normalize.R) — enforced; the pipeline halts on an unknown value |
 | Which sources have tags | `.irw_tag_sources` in `Rpkg/R/redivis-config.R` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,10 @@ Python scripts follow the same logic using `pandas.melt()` instead of `pivot_lon
 
 ## Processing Priorities
 
+**This section is about which *dataset* to process next. For which *kind of work*
+to do at all — corpus trust before gates before reach before volume — see
+[`PRIORITIES.md`](PRIORITIES.md).**
+
 Full guidance: `processing_notes/DataProcessingInstructions.md`. Summary:
 
 - The goal is not to empty the queue — it's to maximize data in the IRW. There will always be more incoming, so use time on what grows the IRW most rather than rushing to clear the backlog.

--- a/PRIORITIES.md
+++ b/PRIORITIES.md
@@ -1,0 +1,88 @@
+# What to work on
+
+Set 2026-09-02 by ben-domingue. Advisory: he overrules it, and a direct request
+always wins. This file exists so a session can place a new piece of work without
+asking, not to override judgment.
+
+**The problem it solves.** There are 200+ open issues, 245 of them labelled
+`data queue`, 18 roadmap items and 8 open pull requests. A list that long does
+not tell anyone what matters, and re-deriving a priority order every morning is
+itself the cost. So this ranks *kinds* of work rather than listing issues, and
+the list below will still be right when every issue number in it is closed.
+
+## The order
+
+**1. Corpus trust — the warehouse is serving something wrong.**
+
+Outranks everything. The distinguishing question is not "is this broken" but
+"is a user getting a wrong answer right now". A missing table means the corpus
+is *incomplete*; a doubled table, a `cov_age` of 1999, an item text that is not
+what respondents read all mean it is *wrong*, and wrong is worse than incomplete
+at any size.
+
+This is the same distinction the draft-release policy turns on (`ARCHITECTURE.md`
+§4): a late addition may wait a week, a late correction may not.
+
+**2. Gates — stop the class, not the instance.**
+
+Work that prevents a defect recurring beats work that fixes one occurrence of
+it, even when the occurrence is louder. Roadmap item 1 (#1703) is the type case:
+the same Redivis append bug was found and fixed three separate times in whichever
+copy of the uploader was in hand, while the other twelve copies stayed broken.
+
+The test for whether something belongs here: if you fix the instance and nothing
+changes about how the next one is caught, it was category 1 work, not category 2.
+
+**3. Reach and contribution — items 4, 5, 6.**
+
+Findability, shipping both packages properly, and making community contribution
+real. Currently receiving no time at all, which is the strongest argument for
+raising it: five of the eight open PRs have zero comments and zero reviews, and
+one was verbally approved on 2026-07-27 and never merged.
+
+**4. Volume — coverage of tags and item text.**
+
+Item text is at 13.5% of tables and tags at ~55% per column. This is where effort
+actually goes — 484 file-touches in `itemtext/` in the week to 2026-09-02, against
+100 in `tags/` and 56 in `metadata/` — so the point of ranking it fourth is not to
+stop it but to stop it crowding out 1–3 by default.
+
+**5. Not now.** Say so rather than quietly deferring:
+
+- The blue-sky roadmap items (8–15). Three were picked as worth eventual
+  investment — 8 (a derived-parameter layer), 11 (an MCP server), 9 (tasks and a
+  leaderboard) — and none is this year's work until 1–7 are further along.
+- New vignettes, per item 16's stop-doing list.
+- Any acquisition sprint. **Intake has already stopped on its own**: the newest of
+  the 245 `data queue` issues is 2026-08-11, and the oldest is from the repo's
+  opening day in March 2024. That backlog is stale, not growing, and clearing it
+  is not urgent. `CLAUDE.md` says it directly — "the goal is not to empty the
+  queue — it's to maximize data in the IRW."
+
+## What the ranking assumes
+
+It only holds under the scoping choices made when the Year 3 roadmap was written
+(#1702, 2026-08-29). If any of these change, re-rank:
+
+| | |
+|---|---|
+| Horizon | Grant Year 3, May 2026 – April 2027 (IES R305D240025) |
+| Labour | Claude Code agents plus RAs — explicitly *not* a hired engineer, so nothing requiring a hosted backend |
+| Lenses | Corpus trust, reach, community self-sustainability |
+
+The lens deliberately **not** chosen was "research output from the data", which is
+where effort had been going. That omission is the reason items 8–15 rank where
+they do; it is a choice, not an oversight.
+
+## Where the detail lives
+
+This file ranks; it does not enumerate. For the actual work:
+
+- **The 17 numbered proposals and their sub-items** — ben-domingue/irw#1702, and
+  one issue per item at #1703–#1719. Check there before starting anything in a
+  numbered area; several already carry a ruling.
+- **Which dataset to process next** — `CLAUDE.md` §Processing Priorities and
+  `processing_notes/DataProcessingInstructions.md`. Different question, different
+  answer: that is about picking among candidates, this is about picking among
+  *kinds of work*.
+- **Which document wins when two disagree** — `ARCHITECTURE.md` §5.

--- a/automated_finding/irw_triage_updated.py
+++ b/automated_finding/irw_triage_updated.py
@@ -33,6 +33,8 @@ import io
 import os
 import collections
 import re
+import sys
+from pathlib import Path
 from dataclasses import dataclass, field
 from math import sqrt
 
@@ -127,29 +129,6 @@ MIN_PARTICIPANTS = 100
 # A file whose "items" are all composites is a summary table, not raw
 # item-response data -- the failure mode behind the wingenbach_2018
 # retraction and 2 of the 3 false-positive `good` rows in PR #1625.
-_COMPOSITE_TOKENS = {
-    "total", "totals", "composite", "subscale", "subscales", "overall",
-    "average", "averages", "avg", "mean", "sum", "index", "score", "scores",
-}
-# Whole-label pre/post markers (optionally with a short subscale suffix, e.g.
-# "pre-A", "post_F"). Matched only against the ENTIRE label: a genuine raw
-# item at a pre-wave is usually "pre_anxiety_3", which must not trip this.
-_PREPOST_LABEL = re.compile(
-    r"^(pre|post|baseline|follow[-_ ]?up)[-_ ]?[a-z0-9]{0,2}$", re.I)
-
-
-def _looks_composite(label) -> bool:
-    """Does this item label name a computed score rather than a question?"""
-    s = str(label).strip()
-    if not s:
-        return False
-    if _PREPOST_LABEL.match(s):
-        return True
-    # Token-wise, so "meaning_1" doesn't match on "mean" and "scoreboard_2"
-    # doesn't match on "score".
-    tokens = {t.lower() for t in re.split(r"[^A-Za-z0-9]+", s) if t}
-    return bool(tokens & _COMPOSITE_TOKENS)
-RESPONSE_LEVEL_COLS = {"rt", "date"}
 
 
 # ---------------------------------------------------------------------------
@@ -495,266 +474,21 @@ def coerce_to_irw(df: pd.DataFrame) -> Coercion:
 
 
 # ---------------------------------------------------------------------------
-# 3. QC  (mirrors IRW standard + IRW's own density metric)
+# 3. QC  (moved out of this file 2026-09-02)
 # ---------------------------------------------------------------------------
-
-def irw_metadata(df: pd.DataFrame) -> dict:
-    """The IRW's own metadata/density computation, ported from their R/Python."""
-    d = df.loc[~df["resp"].isna()].copy()
-    d["resp"] = pd.to_numeric(d["resp"], errors="coerce")
-    n_resp = len(d)
-    n_part = d["id"].nunique()
-    n_item = d["item"].nunique()
-    # response frequency distribution — the professor's table(df$resp)
-    resp_counts = d["resp"].value_counts().sort_index()
-    resp_table = {str(k): int(v) for k, v in resp_counts.head(20).items()}
-    return {
-        "n_responses": n_resp,
-        "n_categories": int(d["resp"].nunique()),
-        "n_participants": n_part,
-        "n_items": n_item,
-        "responses_per_participant": round(n_resp / n_part, 2) if n_part else 0,
-        "responses_per_item": round(n_resp / n_item, 2) if n_item else 0,
-        "density": round((sqrt(n_resp) / n_part) * (sqrt(n_resp) / n_item), 4)
-                   if n_part and n_item else 0,
-        "resp_distribution": resp_table,
-    }
-
-
-@dataclass
-class Check:
-    name: str
-    status: str    # "pass" | "warn" | "fail"
-    detail: str
-
-
-def run_qc(df: pd.DataFrame, coercion_method: str = "",
-           original_cols: list = None) -> list:
-    """QC checks. The first block is ported directly from the IRW's official
-    validate_irw.R (statuses: pass=OK, warn=NOTE, fail=ERROR). The second block
-    is extra heuristics we add on top, clearly labelled."""
-    checks = []
-    original_cols = original_cols or []
-
-    # ===== ported from validate_irw.R =====================================
-
-    # required columns (ERROR if missing)
-    missing = [c for c in IRW_REQUIRED if c not in df.columns]
-    if missing:
-        checks.append(Check("required_columns", "fail",
-                            f"missing required columns: {', '.join(missing)}"))
-        return checks  # nothing else is meaningful without these
-    checks.append(Check("required_columns", "pass", "id/item/resp present"))
-
-    # NAs in required columns: all-NA = ERROR, some-NA = NOTE
-    for col in IRW_REQUIRED:
-        n_na = df[col].isna().sum()
-        if n_na == len(df):
-            checks.append(Check(f"{col}_na", "fail", f"{col} is entirely NA"))
-        elif n_na > 0:
-            checks.append(Check(f"{col}_na", "warn", f"{col} has {n_na} NAs"))
-
-    # resp must be numeric (ERROR)
-    resp_num = pd.to_numeric(df["resp"], errors="coerce")
-    if resp_num.notna().mean() < 0.99:
-        checks.append(Check("resp_numeric", "fail",
-                            f"resp is not numeric (only "
-                            f"{resp_num.notna().mean():.0%} parse as numbers)"))
-    else:
-        checks.append(Check("resp_numeric", "pass", "resp is numeric"))
-
-    # duplicate id+item: ERROR if no longitudinal column, else NOTE
-    longitudinal = [c for c in ("wave", "timepoint", "date") if c in df.columns]
-    dups = df.duplicated(subset=["id", "item"]).sum()
-    if dups > 0 and not longitudinal:
-        checks.append(Check("dup_id_item", "fail",
-                            f"{dups} duplicate id+item rows with no "
-                            "wave/timepoint/date column"))
-    elif dups > 0:
-        checks.append(Check("dup_id_item", "warn",
-                            f"{dups} duplicate id+item rows "
-                            f"(longitudinal column {longitudinal} present — likely ok)"))
-    else:
-        checks.append(Check("dup_id_item", "pass", "id+item rows unique"))
-
-    # covariate naming: extra columns without a recognized name/prefix = NOTE.
-    # (Broadened from validate_irw.R's narrow list to the full documented
-    #  standard, so legitimate columns like item_family/treat aren't flagged.)
-    known = {"id", "item", "resp", "rt", "date", "wave", "timepoint",
-             "treat", "rater", "item_family"}
-    known_prefix = ("cov_", "itemcov_", "qmatrix", "trial_")
-    unprefixed = [c for c in df.columns
-                  if c not in known and not c.startswith(known_prefix)]
-    if unprefixed:
-        checks.append(Check("cov_prefix", "warn",
-                            f"unrecognized columns (prefix with cov_ if "
-                            f"covariates): {', '.join(unprefixed)}"))
-
-    # ===== extra heuristics (beyond the official validator) ===============
-
-    # resp scale sanity — flag a resp that looks continuous/mis-parsed
-    ncat = resp_num.nunique()
-    if ncat <= 1:
-        checks.append(Check("resp_variation*", "fail",
-                            "resp has no variation (1 unique value)"))
-    elif ncat > 50:
-        checks.append(Check("resp_ordinal*", "warn",
-                            f"{ncat} distinct resp values — confirm continuous, "
-                            "not mis-parsed"))
-
-    # P1 #3: resp coding direction — can't auto-verify; always warn after melt.
-    if coercion_method == "wide-to-long":
-        checks.append(Check(
-            "resp_direction*", "warn",
-            "Cannot auto-verify: within each item, higher resp values must "
-            "indicate more of the construct (IRW standard). Confirm no "
-            "unreversed items."
-        ))
-
-    # P1 #4: imputed values — column name signals and mean-imputation signature.
-    if original_cols:
-        imputed_signals = [c for c in original_cols
-                           if re.search(r"_imp(?:uted)?$|_filled$|_flag$", c,
-                                        re.I)]
-        if imputed_signals:
-            checks.append(Check("imputed_values*", "warn",
-                                f"Columns suggest imputed values may be present: "
-                                f"{imputed_signals}. IRW requires their removal."))
-    # Mean-imputation signature: any item where one value accounts for >60% of rows.
-    if resp_num.notna().any():
-        by_item = df.groupby("item")["resp"]
-        for item_name, grp in by_item:
-            vc = grp.value_counts(normalize=True)
-            if not vc.empty and vc.iloc[0] > 0.60:
-                checks.append(Check("imputed_values*", "warn",
-                                    f"Item '{item_name}' has one resp value "
-                                    f"accounting for {vc.iloc[0]:.0%} of responses "
-                                    "— possible mean imputation."))
-                break  # one warning is enough
-
-    # P1 #5: date column validation.
-    if "date" in df.columns:
-        d = pd.to_numeric(df["date"], errors="coerce")
-        if d.isna().mean() > 0.1:
-            checks.append(Check("date_numeric*", "warn",
-                                "date column is not numeric — IRW requires Unix "
-                                "seconds (or seconds since first observation)"))
-        elif d.notna().any() and d.max() < 1e8:
-            checks.append(Check("date_range*", "warn",
-                                f"date max={d.max():.0f} — looks too small for "
-                                "Unix seconds; verify units"))
-
-    # P1 #6: rt column validation.
-    if "rt" in df.columns:
-        rt = pd.to_numeric(df["rt"], errors="coerce")
-        if rt.isna().mean() > 0.1:
-            checks.append(Check("rt_numeric*", "warn",
-                                "rt column is not numeric"))
-        elif rt.notna().any():
-            if rt.median() > 60000:
-                checks.append(Check("rt_units*", "warn",
-                                    f"rt median={rt.median():.0f} — likely "
-                                    "milliseconds, not seconds (IRW requires "
-                                    "seconds)"))
-            if (rt < 0).any():
-                checks.append(Check("rt_negative*", "warn",
-                                    "rt has negative values"))
-
-    # treat column should be 0/1 if present
-    if "treat" in df.columns:
-        bad = set(pd.unique(df["treat"].dropna())) - {0, 1}
-        if bad:
-            checks.append(Check("treat_binary*", "warn",
-                                f"treat has non-0/1 values {sorted(bad)[:5]}"))
-
-    # P2 #7: item-level columns dropped during melt — remind user to verify.
-    if original_cols and coercion_method == "wide-to-long":
-        item_level_found = [c for c in original_cols
-                            if any(c.startswith(p) for p in ITEM_LEVEL_PREFIXES)]
-        if item_level_found:
-            checks.append(Check("item_level_cols*", "warn",
-                                f"Item-level columns {item_level_found} were "
-                                "excluded from the melt — verify they are "
-                                "correctly aligned after conversion."))
-
-    # P2 #7: multi-scale detection — distinct item-name prefixes suggest separate
-    # constructs that must be split into separate tables.
-    if "item" in df.columns:
-        prefixes = [re.split(r"[\d_]", str(i))[0].lower()
-                    for i in df["item"].unique() if str(i)]
-        prefix_counts = pd.Series(prefixes).value_counts()
-        dominant = prefix_counts[prefix_counts >= 3]
-        if len(dominant) >= 2:
-            checks.append(Check("multi_scale*", "warn",
-                                f"Item names suggest {len(dominant)} subscales "
-                                f"({list(dominant.index)[:4]}) — IRW requires "
-                                "separate tables per construct."))
-
-    # Response-scale homogeneity. The existing multi_scale* check reads item
-    # *names*; this one reads the responses themselves, which is what actually
-    # catches a mailing that bundled several instruments. Two distinct
-    # failures fall out of the same per-item range profile:
-    #   * a substantial minority of items on a different range  -> two scales
-    #     in one table, which breaks "one table per construct" and leaves `resp`
-    #     meaning different things in different rows;
-    #   * one or two isolated items off the modal range -> almost always not
-    #     an item at all (an administrative or count column swept in).
-    # Both were live defects in the 2026-08-26 Eugene-Springfield build:
-    # `sdv` spanned 1-5, 1-7, 1-8 and 1-9 at once, and `submiss` -- a
-    # missing-response count, 94.8% zero -- was the only column in the HPQ
-    # outside its 1-5 scale.
-    if {"item", "resp"}.issubset(df.columns):
-        rng = df.dropna(subset=["resp"]).groupby("item")["resp"].agg(["min", "max"])
-        if len(rng) >= 3:
-            profile = collections.Counter(zip(rng["min"], rng["max"]))
-            (modal, modal_n), = profile.most_common(1)
-            off = rng[(rng["min"] != modal[0]) | (rng["max"] != modal[1])]
-            # Only a range that *exceeds* the modal one is evidence of a
-            # different scale; an item nobody answered at the ceiling simply
-            # has a lower observed max.
-            over = off[(off["max"] > modal[1]) | (off["min"] < modal[0])]
-            share = len(over) / len(rng)
-            if share >= 0.15:
-                other = collections.Counter(zip(over["min"], over["max"]))
-                checks.append(Check("resp_scale_mixed", "fail",
-                    f"items span more than one response scale: "
-                    f"{modal_n} on {modal[0]}-{modal[1]} and {len(over)} on "
-                    f"{[f'{a}-{b}' for a, b in list(other)[:3]]}. IRW requires "
-                    "one table per construct; split before submitting."))
-            elif len(over):
-                checks.append(Check("item_scale_outlier", "warn",
-                    f"{len(over)} item(s) fall outside the table's "
-                    f"{modal[0]}-{modal[1]} scale: {list(over.index)[:4]}. An "
-                    "isolated out-of-range column is usually not an item -- "
-                    "check for an administrative or count field."))
-
-    # Composite columns masquerading as items. A summary table melts into a
-    # perfectly well-formed id/item/resp frame and passes every structural
-    # check above -- the only tell is what the items are NAMED.
-    if "item" in df.columns:
-        labels = [i for i in df["item"].unique() if str(i).strip()]
-        comp = [i for i in labels if _looks_composite(i)]
-        if labels and len(comp) == len(labels):
-            checks.append(Check("composite_items*", "fail",
-                                f"every item label names a computed score "
-                                f"({[str(c) for c in comp[:4]]}) — this looks "
-                                "like a summary/aggregate table, not raw "
-                                "item-level responses"))
-        elif comp:
-            checks.append(Check("composite_items*", "warn",
-                                f"{len(comp)}/{len(labels)} item labels name "
-                                f"computed scores ({[str(c) for c in comp[:4]]}) "
-                                "— drop them, or confirm they are real items"))
-
-    # IRW's own density signal — very sparse data is worth a look
-    meta = irw_metadata(df)
-    if meta["density"] < 0.01:
-        checks.append(Check("density*", "warn",
-                            f"very sparse (density={meta['density']}); fine for "
-                            "adaptive/booklet designs, else verify"))
-
-    return checks
-
+# `run_qc`, `Check` and `irw_metadata` now live in the `irw_validate` package
+# (irw#1703, sub-item 1.3), so one implementation serves the fifty scripts in
+# data/ that import run_qc from here, a CLI with an exit code, red_up's
+# pre-upload gate, and CI. Nothing else changed: the check bodies were MOVED
+# verbatim, and the golden test in irw_validate/tests/ pins their exact
+# (name, status, detail) emission order for eight fixtures.
+#
+# Severity profiles are layered ON TOP of these by irw_validate.core, never
+# underneath, so `run_qc` here behaves exactly as it did before the move --
+# which is why none of the fifty callers needed an edit.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from irw_validate._checks import (Check, _looks_composite,  # noqa: E402,F401
+                                  irw_metadata, run_qc)
 
 # ---------------------------------------------------------------------------
 # 4. FLAG  (combine coercion confidence + QC into one decision)

--- a/irw_validate/README.md
+++ b/irw_validate/README.md
@@ -1,0 +1,90 @@
+# `irw_validate` — one format validator, with an exit code
+
+```
+irw-validate out/*.csv                       # exit 1 if anything blocks
+irw-validate out/x.csv --profile core        # the validate_irw.R subset
+irw-validate out/x.csv --strict              # warnings block too
+irw-validate out/x.csv --json                # for CI
+```
+
+Exit codes: `0` ok · `1` something blocks · `2` bad input. Same contract as `red_up`.
+
+## Why this exists
+
+The checks were forked, and neither half could gate anything:
+
+| | checks | callers | exit code |
+|---|---|---|---|
+| `misc/validate_irw.R` | 5 | **nothing in the repo** | no |
+| `irw_triage_updated.py::run_qc` | ~20 | 50 scripts in `data/` | no — its `__main__` exits 0 however many fail |
+
+So "is this table valid?" had two answers and no way to act on either. This is
+roadmap item 1 (`ben-domingue/irw#1703`), sub-items 1.3 and 1.4 — the other half
+of the work `red_up` started.
+
+It also makes `datastandard.md` executable. The standard is 348 lines of rules
+stated in prose — a sample floor of 100 unique ids, table names ≤40 characters,
+`[id, item, resp]` first — and until now not one was enforced by anything.
+`ARCHITECTURE.md`'s Rule 2 asks for exactly this: *where a rule can be made
+executable, make it executable instead of writing it down.*
+
+## Profiles, and why severity is not a property of a check
+
+**Severity depends on the (check, profile) pair.** This is the central design
+decision, and it exists because the checks were written for *triage* — is a
+machine's guess at a conversion worth a human's time — and are now also asked to
+gate *publication*, which has a different cost of being wrong.
+
+`resp_scale_mixed` is the worked example. It is `fail` today, and
+`data/cao_2026_cdss.py` documents a table that trips it legitimately: an unused
+top category on a left-skewed 1–7 scale reads as a second scale. Had every
+heuristic become a blocking error, the gate would have rejected that correct
+table on day one.
+
+| profile | used by | contents |
+|---|---|---|
+| `core` | `validate_irw.R` parity, external contributors | the five R checks only |
+| `triage` | `run_qc`'s 50 callers | core + heuristics, **exactly today's severities** |
+| `upload` | the gate, the CLI, CI (default) | core + heuristics + the standard's prose rules; heuristics capped at `warn` except `GATE_ERRORS` |
+| `legacy` | the 922 `.Rdata` sweep (1.5, not built) | `upload` minus rules that postdate the tables |
+
+`GATE_ERRORS` is currently exactly `{resp_variation*}` — a `resp` with one
+distinct value carries no information for any model, at any altitude. It grows
+one documented case at a time.
+
+## The override
+
+```
+irw-validate x.csv --override-check resp_scale_mixed \
+    --override "two response formats, one construct; author confirmed 2026-09-02"
+```
+
+The reason is the flag's **argument**, so overriding without saying why is
+structurally impossible. It is not called `--force` or `--no-verify`: those names
+invite reflex use. A reason under 20 characters is rejected. Overridden findings
+are reprinted under `OVERRIDDEN` rather than suppressed, and appended to
+`processing_notes/validator_overrides.csv`.
+
+Without `--override-check` the reason waives every error; with it, only the named
+checks, so unrelated failures keep blocking.
+
+## The 50 callers
+
+`data/*.py` scripts do `from irw_triage_updated import run_qc` and read
+`.name` / `.status` / `.detail`. **None of them needed an edit.** The check
+bodies were *moved* into `_checks.py` verbatim and re-exported, so `run_qc`
+behaves exactly as before — profiles are layered on top by `core.py`, never
+underneath.
+
+`tests/test_validate.py` pins the exact `(name, status)` emission order for eight
+fixtures, captured before the move. That golden test is the reason the refactor
+was safe to make at all: 50 files that otherwise only fail at someone else's
+runtime.
+
+## Staying merged
+
+A shared runtime between R and Python is not possible here — `validate_irw.R`'s
+whole value is that it works for a stranger with an R session and a URL, with
+nothing else installed. So instead the R file carries `# @check <name>` markers,
+and a test parses them and asserts set-equality with `model.CORE_CHECKS`. Two
+languages, one list, enforced. Edit one copy and the suite fails.

--- a/irw_validate/__init__.py
+++ b/irw_validate/__init__.py
@@ -1,0 +1,28 @@
+"""One IRW format validator, with an exit code (ben-domingue/irw#1703, 1.3).
+
+    from irw_validate import validate_file, validate_frame, exit_code
+
+    report = validate_file("out/mytable.csv")
+    print(report.ok, [f.check for f in report.errors])
+
+Command line:
+
+    irw-validate out/*.csv                 # exit 1 if anything blocks
+    irw-validate out/x.csv --profile core  # the validate_irw.R subset
+    irw-validate out/x.csv --strict        # warnings block too
+
+Why this exists: the checks were forked between `misc/validate_irw.R` (5 checks,
+called by nothing) and `automated_finding/irw_triage_updated.py::run_qc` (~20
+checks, called by fifty scripts but only ever advisorily -- its __main__ exits 0
+however many fail). Neither had an exit code, so neither could gate anything.
+"""
+from .core import (MAX_BYTES, format_report, validate_file, validate_frame,
+                   validate_paths)
+from .model import (CORE_CHECKS, GATE_ERRORS, PROFILES, Finding, Report,
+                    exit_code, severity_for)
+
+__all__ = [
+    "validate_file", "validate_frame", "validate_paths", "format_report",
+    "Finding", "Report", "exit_code", "severity_for",
+    "CORE_CHECKS", "GATE_ERRORS", "PROFILES", "MAX_BYTES",
+]

--- a/irw_validate/_checks.py
+++ b/irw_validate/_checks.py
@@ -1,0 +1,305 @@
+"""The IRW format checks themselves, moved verbatim from
+`automated_finding/irw_triage_updated.py::run_qc` (#1703 sub-item 1.3).
+
+**Moved, not rewritten.** Fifty scripts in `data/` call `run_qc` and read
+`c.name` / `c.status` / `c.detail` off what it returns, so the check bodies and
+above all their *emission order* are preserved exactly. `irw_validate.compat`
+re-exports this as `run_qc`, and `automated_finding/irw_triage_updated.py`
+re-exports that, which is why none of the fifty needed an edit.
+
+`irw_validate.core` layers severity profiles, extra checks and an exit code on
+top of this; nothing here knows about any of that. The golden test in
+`tests/test_validate.py` pins the (name, status) sequence for eight fixtures so
+the move is provably behaviour-preserving.
+"""
+from __future__ import annotations
+
+import collections
+import re
+from dataclasses import dataclass
+from math import sqrt
+
+import pandas as pd
+
+
+@dataclass
+class Check:
+    name: str
+    status: str    # "pass" | "warn" | "fail"
+    detail: str
+
+
+IRW_REQUIRED = ["id", "item", "resp"]
+ITEM_LEVEL_PREFIXES = ("itemcov_", "qmatrix", "item_family", "rater")
+
+_COMPOSITE_TOKENS = {
+    "total", "totals", "composite", "subscale", "subscales", "overall",
+    "average", "averages", "avg", "mean", "sum", "index", "score", "scores",
+}
+# Whole-label pre/post markers (optionally with a short subscale suffix, e.g.
+# "pre-A", "post_F"). Matched only against the ENTIRE label: a genuine raw
+# item at a pre-wave is usually "pre_anxiety_3", which must not trip this.
+_PREPOST_LABEL = re.compile(
+    r"^(pre|post|baseline|follow[-_ ]?up)[-_ ]?[a-z0-9]{0,2}$", re.I)
+
+def _looks_composite(label) -> bool:
+    """Does this item label name a computed score rather than a question?"""
+    s = str(label).strip()
+    if not s:
+        return False
+    if _PREPOST_LABEL.match(s):
+        return True
+    # Token-wise, so "meaning_1" doesn't match on "mean" and "scoreboard_2"
+    # doesn't match on "score".
+    tokens = {t.lower() for t in re.split(r"[^A-Za-z0-9]+", s) if t}
+    return bool(tokens & _COMPOSITE_TOKENS)
+
+def irw_metadata(df: pd.DataFrame) -> dict:
+    """The IRW's own metadata/density computation, ported from their R/Python."""
+    d = df.loc[~df["resp"].isna()].copy()
+    d["resp"] = pd.to_numeric(d["resp"], errors="coerce")
+    n_resp = len(d)
+    n_part = d["id"].nunique()
+    n_item = d["item"].nunique()
+    # response frequency distribution — the professor's table(df$resp)
+    resp_counts = d["resp"].value_counts().sort_index()
+    resp_table = {str(k): int(v) for k, v in resp_counts.head(20).items()}
+    return {
+        "n_responses": n_resp,
+        "n_categories": int(d["resp"].nunique()),
+        "n_participants": n_part,
+        "n_items": n_item,
+        "responses_per_participant": round(n_resp / n_part, 2) if n_part else 0,
+        "responses_per_item": round(n_resp / n_item, 2) if n_item else 0,
+        "density": round((sqrt(n_resp) / n_part) * (sqrt(n_resp) / n_item), 4)
+                   if n_part and n_item else 0,
+        "resp_distribution": resp_table,
+    }
+
+
+def run_qc(df: pd.DataFrame, coercion_method: str = "",
+           original_cols: list = None) -> list:
+    """QC checks. The first block is ported directly from the IRW's official
+    validate_irw.R (statuses: pass=OK, warn=NOTE, fail=ERROR). The second block
+    is extra heuristics we add on top, clearly labelled."""
+    checks = []
+    original_cols = original_cols or []
+
+    # ===== ported from validate_irw.R =====================================
+
+    # required columns (ERROR if missing)
+    missing = [c for c in IRW_REQUIRED if c not in df.columns]
+    if missing:
+        checks.append(Check("required_columns", "fail",
+                            f"missing required columns: {', '.join(missing)}"))
+        return checks  # nothing else is meaningful without these
+    checks.append(Check("required_columns", "pass", "id/item/resp present"))
+
+    # NAs in required columns: all-NA = ERROR, some-NA = NOTE
+    for col in IRW_REQUIRED:
+        n_na = df[col].isna().sum()
+        if n_na == len(df):
+            checks.append(Check(f"{col}_na", "fail", f"{col} is entirely NA"))
+        elif n_na > 0:
+            checks.append(Check(f"{col}_na", "warn", f"{col} has {n_na} NAs"))
+
+    # resp must be numeric (ERROR)
+    resp_num = pd.to_numeric(df["resp"], errors="coerce")
+    if resp_num.notna().mean() < 0.99:
+        checks.append(Check("resp_numeric", "fail",
+                            f"resp is not numeric (only "
+                            f"{resp_num.notna().mean():.0%} parse as numbers)"))
+    else:
+        checks.append(Check("resp_numeric", "pass", "resp is numeric"))
+
+    # duplicate id+item: ERROR if no longitudinal column, else NOTE
+    longitudinal = [c for c in ("wave", "timepoint", "date") if c in df.columns]
+    dups = df.duplicated(subset=["id", "item"]).sum()
+    if dups > 0 and not longitudinal:
+        checks.append(Check("dup_id_item", "fail",
+                            f"{dups} duplicate id+item rows with no "
+                            "wave/timepoint/date column"))
+    elif dups > 0:
+        checks.append(Check("dup_id_item", "warn",
+                            f"{dups} duplicate id+item rows "
+                            f"(longitudinal column {longitudinal} present — likely ok)"))
+    else:
+        checks.append(Check("dup_id_item", "pass", "id+item rows unique"))
+
+    # covariate naming: extra columns without a recognized name/prefix = NOTE.
+    # (Broadened from validate_irw.R's narrow list to the full documented
+    #  standard, so legitimate columns like item_family/treat aren't flagged.)
+    known = {"id", "item", "resp", "rt", "date", "wave", "timepoint",
+             "treat", "rater", "item_family"}
+    known_prefix = ("cov_", "itemcov_", "qmatrix", "trial_")
+    unprefixed = [c for c in df.columns
+                  if c not in known and not c.startswith(known_prefix)]
+    if unprefixed:
+        checks.append(Check("cov_prefix", "warn",
+                            f"unrecognized columns (prefix with cov_ if "
+                            f"covariates): {', '.join(unprefixed)}"))
+
+    # ===== extra heuristics (beyond the official validator) ===============
+
+    # resp scale sanity — flag a resp that looks continuous/mis-parsed
+    ncat = resp_num.nunique()
+    if ncat <= 1:
+        checks.append(Check("resp_variation*", "fail",
+                            "resp has no variation (1 unique value)"))
+    elif ncat > 50:
+        checks.append(Check("resp_ordinal*", "warn",
+                            f"{ncat} distinct resp values — confirm continuous, "
+                            "not mis-parsed"))
+
+    # P1 #3: resp coding direction — can't auto-verify; always warn after melt.
+    if coercion_method == "wide-to-long":
+        checks.append(Check(
+            "resp_direction*", "warn",
+            "Cannot auto-verify: within each item, higher resp values must "
+            "indicate more of the construct (IRW standard). Confirm no "
+            "unreversed items."
+        ))
+
+    # P1 #4: imputed values — column name signals and mean-imputation signature.
+    if original_cols:
+        imputed_signals = [c for c in original_cols
+                           if re.search(r"_imp(?:uted)?$|_filled$|_flag$", c,
+                                        re.I)]
+        if imputed_signals:
+            checks.append(Check("imputed_values*", "warn",
+                                f"Columns suggest imputed values may be present: "
+                                f"{imputed_signals}. IRW requires their removal."))
+    # Mean-imputation signature: any item where one value accounts for >60% of rows.
+    if resp_num.notna().any():
+        by_item = df.groupby("item")["resp"]
+        for item_name, grp in by_item:
+            vc = grp.value_counts(normalize=True)
+            if not vc.empty and vc.iloc[0] > 0.60:
+                checks.append(Check("imputed_values*", "warn",
+                                    f"Item '{item_name}' has one resp value "
+                                    f"accounting for {vc.iloc[0]:.0%} of responses "
+                                    "— possible mean imputation."))
+                break  # one warning is enough
+
+    # P1 #5: date column validation.
+    if "date" in df.columns:
+        d = pd.to_numeric(df["date"], errors="coerce")
+        if d.isna().mean() > 0.1:
+            checks.append(Check("date_numeric*", "warn",
+                                "date column is not numeric — IRW requires Unix "
+                                "seconds (or seconds since first observation)"))
+        elif d.notna().any() and d.max() < 1e8:
+            checks.append(Check("date_range*", "warn",
+                                f"date max={d.max():.0f} — looks too small for "
+                                "Unix seconds; verify units"))
+
+    # P1 #6: rt column validation.
+    if "rt" in df.columns:
+        rt = pd.to_numeric(df["rt"], errors="coerce")
+        if rt.isna().mean() > 0.1:
+            checks.append(Check("rt_numeric*", "warn",
+                                "rt column is not numeric"))
+        elif rt.notna().any():
+            if rt.median() > 60000:
+                checks.append(Check("rt_units*", "warn",
+                                    f"rt median={rt.median():.0f} — likely "
+                                    "milliseconds, not seconds (IRW requires "
+                                    "seconds)"))
+            if (rt < 0).any():
+                checks.append(Check("rt_negative*", "warn",
+                                    "rt has negative values"))
+
+    # treat column should be 0/1 if present
+    if "treat" in df.columns:
+        bad = set(pd.unique(df["treat"].dropna())) - {0, 1}
+        if bad:
+            checks.append(Check("treat_binary*", "warn",
+                                f"treat has non-0/1 values {sorted(bad)[:5]}"))
+
+    # P2 #7: item-level columns dropped during melt — remind user to verify.
+    if original_cols and coercion_method == "wide-to-long":
+        item_level_found = [c for c in original_cols
+                            if any(c.startswith(p) for p in ITEM_LEVEL_PREFIXES)]
+        if item_level_found:
+            checks.append(Check("item_level_cols*", "warn",
+                                f"Item-level columns {item_level_found} were "
+                                "excluded from the melt — verify they are "
+                                "correctly aligned after conversion."))
+
+    # P2 #7: multi-scale detection — distinct item-name prefixes suggest separate
+    # constructs that must be split into separate tables.
+    if "item" in df.columns:
+        prefixes = [re.split(r"[\d_]", str(i))[0].lower()
+                    for i in df["item"].unique() if str(i)]
+        prefix_counts = pd.Series(prefixes).value_counts()
+        dominant = prefix_counts[prefix_counts >= 3]
+        if len(dominant) >= 2:
+            checks.append(Check("multi_scale*", "warn",
+                                f"Item names suggest {len(dominant)} subscales "
+                                f"({list(dominant.index)[:4]}) — IRW requires "
+                                "separate tables per construct."))
+
+    # Response-scale homogeneity. The existing multi_scale* check reads item
+    # *names*; this one reads the responses themselves, which is what actually
+    # catches a mailing that bundled several instruments. Two distinct
+    # failures fall out of the same per-item range profile:
+    #   * a substantial minority of items on a different range  -> two scales
+    #     in one table, which breaks "one table per construct" and leaves `resp`
+    #     meaning different things in different rows;
+    #   * one or two isolated items off the modal range -> almost always not
+    #     an item at all (an administrative or count column swept in).
+    # Both were live defects in the 2026-08-26 Eugene-Springfield build:
+    # `sdv` spanned 1-5, 1-7, 1-8 and 1-9 at once, and `submiss` -- a
+    # missing-response count, 94.8% zero -- was the only column in the HPQ
+    # outside its 1-5 scale.
+    if {"item", "resp"}.issubset(df.columns):
+        rng = df.dropna(subset=["resp"]).groupby("item")["resp"].agg(["min", "max"])
+        if len(rng) >= 3:
+            profile = collections.Counter(zip(rng["min"], rng["max"]))
+            (modal, modal_n), = profile.most_common(1)
+            off = rng[(rng["min"] != modal[0]) | (rng["max"] != modal[1])]
+            # Only a range that *exceeds* the modal one is evidence of a
+            # different scale; an item nobody answered at the ceiling simply
+            # has a lower observed max.
+            over = off[(off["max"] > modal[1]) | (off["min"] < modal[0])]
+            share = len(over) / len(rng)
+            if share >= 0.15:
+                other = collections.Counter(zip(over["min"], over["max"]))
+                checks.append(Check("resp_scale_mixed", "fail",
+                    f"items span more than one response scale: "
+                    f"{modal_n} on {modal[0]}-{modal[1]} and {len(over)} on "
+                    f"{[f'{a}-{b}' for a, b in list(other)[:3]]}. IRW requires "
+                    "one table per construct; split before submitting."))
+            elif len(over):
+                checks.append(Check("item_scale_outlier", "warn",
+                    f"{len(over)} item(s) fall outside the table's "
+                    f"{modal[0]}-{modal[1]} scale: {list(over.index)[:4]}. An "
+                    "isolated out-of-range column is usually not an item -- "
+                    "check for an administrative or count field."))
+
+    # Composite columns masquerading as items. A summary table melts into a
+    # perfectly well-formed id/item/resp frame and passes every structural
+    # check above -- the only tell is what the items are NAMED.
+    if "item" in df.columns:
+        labels = [i for i in df["item"].unique() if str(i).strip()]
+        comp = [i for i in labels if _looks_composite(i)]
+        if labels and len(comp) == len(labels):
+            checks.append(Check("composite_items*", "fail",
+                                f"every item label names a computed score "
+                                f"({[str(c) for c in comp[:4]]}) — this looks "
+                                "like a summary/aggregate table, not raw "
+                                "item-level responses"))
+        elif comp:
+            checks.append(Check("composite_items*", "warn",
+                                f"{len(comp)}/{len(labels)} item labels name "
+                                f"computed scores ({[str(c) for c in comp[:4]]}) "
+                                "— drop them, or confirm they are real items"))
+
+    # IRW's own density signal — very sparse data is worth a look
+    meta = irw_metadata(df)
+    if meta["density"] < 0.01:
+        checks.append(Check("density*", "warn",
+                            f"very sparse (density={meta['density']}); fine for "
+                            "adaptive/booklet designs, else verify"))
+
+    return checks

--- a/irw_validate/cli.py
+++ b/irw_validate/cli.py
@@ -1,0 +1,143 @@
+"""`irw-validate` -- check IRW tables and exit non-zero if anything blocks.
+
+    irw-validate out/*.csv
+    irw-validate out/x.csv --profile core        # the validate_irw.R subset
+    irw-validate out/x.csv --strict              # warnings block too
+    irw-validate out/x.csv --json                # machine-readable, for CI
+    irw-validate out/x.csv --override-check resp_scale_mixed \\
+        --override "two response formats, one construct; author confirmed 2026-09-02"
+
+Exit codes, matching red_up's contract: 0 ok - 1 something blocks - 2 bad input.
+
+**On the override.** The reason is the flag's *argument*, so overriding without
+saying why is structurally impossible. The flag is not called `--force` or
+`--no-verify`: those names invite reflex use, and the point is to make a waiver
+a decision someone signed. Overridden findings are reprinted under OVERRIDDEN
+rather than suppressed, and the reason is appended to
+`processing_notes/validator_overrides.csv` so a waiver leaves a trail even when
+nobody keeps the terminal output.
+
+This formalises something that already happens informally: `data/cao_2026_cdss.py`
+waives `resp_scale_mixed` in a prose comment -- correct judgment, recorded where
+no tool can read it.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import getpass
+import json
+import sys
+from pathlib import Path
+
+from .core import format_report, validate_file
+from .model import PROFILES, exit_code
+
+MIN_REASON = 20
+#: Where waivers are recorded. Overridable so a test run -- or anyone working
+#: outside a checkout -- does not append to the repository's ledger.
+LEDGER_ENV = "IRW_VALIDATE_LEDGER"
+_DEFAULT_LEDGER = (Path(__file__).resolve().parent.parent
+                   / "processing_notes" / "validator_overrides.csv")
+
+
+def ledger_path() -> Path:
+    import os
+    return Path(os.environ.get(LEDGER_ENV) or _DEFAULT_LEDGER)
+
+
+def _record(reasons_path: Path, rows: list) -> None:
+    """Append waivers to the ledger. Never fatal -- a gate that fails because
+    it could not write its own audit file would be worse than the gap."""
+    try:
+        reasons_path.parent.mkdir(parents=True, exist_ok=True)
+        new = not reasons_path.exists()
+        with reasons_path.open("a", newline="") as fh:
+            w = csv.writer(fh)
+            if new:
+                w.writerow(["date", "tool", "table", "checks", "reason", "user"])
+            w.writerows(rows)
+    except OSError as exc:
+        print(f"warning: could not write {reasons_path}: {exc}", file=sys.stderr)
+
+
+def main(argv: list | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="irw-validate",
+        description="Validate IRW tables against the data standard.")
+    ap.add_argument("paths", nargs="+", help="CSV (or any format load_table reads)")
+    ap.add_argument("--profile", default="upload", choices=PROFILES,
+                    help="core = the validate_irw.R subset; triage = today's "
+                         "run_qc behaviour; upload = the gate (default); "
+                         "legacy = upload minus rules that postdate the table")
+    ap.add_argument("--strict", action="store_true",
+                    help="warnings block too")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--override", metavar="REASON",
+                    help=f"waive blocking findings, giving a reason of at least "
+                         f"{MIN_REASON} characters")
+    ap.add_argument("--override-check", action="append", metavar="NAME", default=[],
+                    help="limit --override to this check (repeatable); without "
+                         "it, --override waives every error")
+    args = ap.parse_args(argv)
+
+    if args.override_check and not args.override:
+        print("irw-validate: --override-check needs --override REASON",
+              file=sys.stderr)
+        return 2
+    if args.override is not None and len(args.override.strip()) < MIN_REASON:
+        print(f"irw-validate: that is not a reason -- give at least "
+              f"{MIN_REASON} characters saying why this table is an exception",
+              file=sys.stderr)
+        return 2
+
+    reports = []
+    for path in args.paths:
+        try:
+            reports.append(validate_file(path, profile=args.profile))
+        except FileNotFoundError:
+            print(f"irw-validate: no such file: {path}", file=sys.stderr)
+            return 2
+        except Exception as exc:
+            print(f"irw-validate: cannot read {path}: {exc}", file=sys.stderr)
+            return 2
+
+    ledger_rows = []
+    if args.override:
+        wanted = set(args.override_check)
+        for report in reports:
+            waived = [f for f in report.errors
+                      if not wanted or f.check in wanted]
+            if not waived:
+                continue
+            report.findings = [f for f in report.findings if f not in waived]
+            report.overridden.extend(waived)
+            report.override_reason = args.override
+            ledger_rows.append([
+                dt.date.today().isoformat(), "irw-validate", report.label,
+                ";".join(sorted({f.check for f in waived})), args.override,
+                getpass.getuser(),
+            ])
+    if ledger_rows:
+        _record(ledger_path(), ledger_rows)
+
+    if args.json:
+        print(json.dumps([r.to_dict() for r in reports], indent=2))
+    else:
+        for report in reports:
+            print(format_report(report))
+
+    code = exit_code(reports, strict=args.strict)
+    if code and not args.json:
+        blocking = sum(len(r.errors) for r in reports)
+        if blocking:
+            print(f"\n{blocking} blocking finding(s). Fix them, or waive with "
+                  f"--override \"<why>\".", file=sys.stderr)
+        else:
+            print("\n--strict: warnings are blocking.", file=sys.stderr)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/irw_validate/compat.py
+++ b/irw_validate/compat.py
@@ -1,0 +1,17 @@
+"""Backwards-compatible `run_qc` for the fifty callers in `data/`.
+
+Fifty conversion scripts do `from irw_triage_updated import run_qc` and read
+`c.name` / `c.status` / `c.detail`. None of them imports `Check` or anything
+else, so this is the entire compatibility surface -- but fifty files break at
+someone else's runtime if it moves, which is why the checks were *moved*
+verbatim rather than rewritten, and why the golden test pins their emission
+order.
+
+`run_qc` here is the moved implementation itself, not a translation of it: the
+severity profiles in `irw_validate.model` are layered on top by
+`irw_validate.core`, never underneath. So a caller of `run_qc` sees exactly what
+it saw before this package existed.
+"""
+from ._checks import Check, irw_metadata, run_qc
+
+__all__ = ["Check", "run_qc", "irw_metadata"]

--- a/irw_validate/core.py
+++ b/irw_validate/core.py
@@ -1,0 +1,113 @@
+"""The public API: validate a frame or a file, get a Report with an exit code."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from . import extra
+from ._checks import irw_metadata, run_qc
+from .model import Finding, Report, severity_for
+
+#: Above this, a full pandas load is not worth it inside the uploader's hot
+#: path -- red_up streams 500 MB tables with the csv module on purpose. Files
+#: over the cap get a core-only streaming pass and an explicit `info` finding
+#: recording the downgrade, so a skipped check is never silent.
+MAX_BYTES = 512 * 1024 ** 2
+
+
+def _table_name(label: str) -> str:
+    stem = Path(label).name
+    for suffix in (".csv", ".tsv"):
+        if stem.endswith(suffix):
+            stem = stem[: -len(suffix)]
+    return stem
+
+
+def validate_frame(df, *, label: str = "", profile: str = "upload",
+                   context: dict | None = None) -> Report:
+    """Run every check the profile asks for against an in-memory frame."""
+    context = context or {}
+    report = Report(label=label, profile=profile)
+    table = _table_name(label)
+
+    for check in run_qc(df,
+                        coercion_method=context.get("coercion_method", ""),
+                        original_cols=context.get("original_cols")):
+        report.checks_run.append(check.name)
+        severity = severity_for(check.name, check.status, profile)
+        if severity is None:
+            continue
+        group = "core" if check.name in ("required_columns", "cov_prefix") \
+            or check.name.endswith("_na") or check.name in ("resp_numeric", "dup_id_item") \
+            else "heuristic"
+        report.findings.append(
+            Finding(check.name, severity, check.detail, table=table, group=group))
+
+    if profile in ("upload", "legacy"):
+        for finding in (extra.check_name(table)
+                        + extra.check_shape(df, table)
+                        + extra.check_cov_range(df, table)
+                        + extra.check_resp_dtype(df, table)):
+            report.checks_run.append(finding.check)
+            report.findings.append(finding)
+
+    if {"id", "item", "resp"}.issubset(df.columns):
+        try:
+            report.stats = irw_metadata(df)
+        except Exception:            # a metadata failure must not fail the gate
+            report.stats = {}
+    return report
+
+
+def validate_file(path, *, label: str | None = None, profile: str = "upload",
+                  max_bytes: int = MAX_BYTES, context: dict | None = None) -> Report:
+    """Load a table from disk and validate it.
+
+    Raises FileNotFoundError / ValueError for unusable input; the CLI turns
+    those into exit code 2 rather than a misleading "failed validation".
+    """
+    path = Path(path)
+    label = label or str(path)
+    if not path.is_file():
+        raise FileNotFoundError(path)
+
+    size = path.stat().st_size
+    if size > max_bytes:
+        report = Report(label=label, profile=profile)
+        report.findings.append(Finding(
+            "size_downgrade", "info",
+            f"{size / 1024**2:.0f} MB exceeds the {max_bytes / 1024**2:.0f} MB "
+            "cap for a full pandas pass; only the name checks ran. Validate it "
+            "at processing time, where the frame is already in memory.",
+            table=_table_name(label), group="name"))
+        report.findings.extend(extra.check_name(_table_name(label)))
+        return report
+
+    import pandas as pd  # deferred: red_up must import this module without pandas
+    if path.suffix.lower() in (".csv", ".tsv", ".txt"):
+        df = pd.read_csv(path, sep=None, engine="python")
+    else:
+        import sys
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "automated_finding"))
+        from irw_triage_updated import load_table
+        df = load_table(str(path))
+    return validate_frame(df, label=label, profile=profile, context=context)
+
+
+def validate_paths(paths, *, profile: str = "upload") -> list:
+    return [validate_file(p, profile=profile) for p in paths]
+
+
+def format_report(report: Report, *, show_passes: bool = False) -> str:
+    """One block per table, errors first. Kept plain so CI logs stay readable."""
+    lines = [f"{report.label} [{report.profile}]"]
+    if not report.findings and not report.overridden:
+        lines.append(f"  ok -- {len(report.checks_run)} checks, nothing to report")
+    order = {"error": 0, "warn": 1, "info": 2}
+    for f in sorted(report.findings, key=lambda f: order.get(f.severity, 3)):
+        lines.append(f"  {f.severity.upper():5s} {f.check:22s} {f.message}")
+    for f in report.overridden:
+        lines.append(f"  OVERRIDDEN {f.check:17s} {f.message}")
+    if show_passes and report.checks_run:
+        lines.append(f"  checks run: {', '.join(report.checks_run)}")
+    return "\n".join(lines)

--- a/irw_validate/extra.py
+++ b/irw_validate/extra.py
@@ -1,0 +1,128 @@
+"""Checks that `datastandard.md` states in prose and nothing has ever run.
+
+`ARCHITECTURE.md`'s Rule 2 says: "Where a rule can be made executable, make it
+executable instead of writing it down." The standard is 348 lines of rules, and
+until now not one of them was enforced by anything. These are the mechanical
+ones. Each names the line of the standard it comes from, so the two cannot drift
+apart without the citation becoming visibly wrong.
+
+They run under the `upload` profile only. Triage sees a machine's guess at a
+conversion, where a table name may not exist yet and a sample floor is not the
+question being asked.
+"""
+from __future__ import annotations
+
+import re
+
+import pandas as pd
+
+from .model import Finding
+
+#: datastandard.md line 66: "Table names must be 40 characters or fewer".
+MAX_NAME = 40
+#: datastandard.md line 13: "The floor is 100 unique `id` values, flat".
+MIN_IDS = 100
+#: The plausible interval for a human age in years. `cov_age` outside it is not
+#: an age -- see #1779, which found 81 live tables shipping a sentinel (999,
+#: 1999), a birth year, or a days-since-epoch offset (-18090).
+AGE_RANGE = (0, 120)
+
+_NAME_OK = re.compile(r"^[a-z0-9_.]+$")
+
+
+def check_name(table: str) -> list:
+    """Table-name rules from datastandard.md lines 62-66."""
+    out = []
+    if not table:
+        return out
+    stem = table[:-4] if table.endswith(".csv") else table
+    if len(stem) > MAX_NAME:
+        out.append(Finding(
+            "name_length", "error",
+            f"table name is {len(stem)} characters; datastandard.md caps it at "
+            f"{MAX_NAME}. Shorten the construct label, never the author or year.",
+            table=table, group="name"))
+    if not _NAME_OK.match(stem):
+        out.append(Finding(
+            "name_charset", "warn",
+            f"table name {stem!r} is not lowercase [a-z0-9_.] -- Redivis keeps "
+            "the case but every client lowercases when joining, so a "
+            "capitalised name silently drops out of case-sensitive joins.",
+            table=table, group="name"))
+    return out
+
+
+def check_shape(df: pd.DataFrame, table: str = "") -> list:
+    """Sample floor and column order -- both prose rules in the standard today."""
+    out = []
+    if "id" in df.columns:
+        n = df["id"].nunique()
+        if n < MIN_IDS:
+            out.append(Finding(
+                "sample_floor", "warn",
+                f"{n} unique ids; datastandard.md sets a flat floor of {MIN_IDS} "
+                "with no judgment call in between. Warn rather than block: the "
+                "floor governs what to accept, not what is already published.",
+                table=table, group="core"))
+    lead = [c for c in df.columns[:3]]
+    if len(df.columns) >= 3 and lead != ["id", "item", "resp"]:
+        out.append(Finding(
+            "column_order", "warn",
+            f"columns start {lead}; datastandard.md step 7 writes "
+            "[id, item, resp] + covariates.",
+            table=table, group="core"))
+    return out
+
+
+def check_cov_range(df: pd.DataFrame, table: str = "") -> list:
+    """`cov_age` must actually hold ages (#1779).
+
+    Severity is deliberately `warn`, not `error`. 81 tables are already live
+    with this defect; blocking would fail them all on their next re-upload
+    before anyone has decided what the repair is. Promote it once #1779 is
+    closed.
+    """
+    out = []
+    if "cov_age" not in df.columns:
+        return out
+    age = pd.to_numeric(df["cov_age"], errors="coerce").dropna()
+    if age.empty:
+        return out
+    lo, hi = float(age.min()), float(age.max())
+    if lo < AGE_RANGE[0] or hi > AGE_RANGE[1]:
+        if hi >= 999:
+            why = ("a sentinel no-answer code (999/9999) or a birth year that "
+                   "was never converted")
+        elif lo < 0:
+            why = "a date or days-since-epoch offset stored as an age"
+        else:
+            why = "out of range for a human age in years"
+        out.append(Finding(
+            "cov_range", "warn",
+            f"cov_age spans {lo:g}-{hi:g}, outside "
+            f"[{AGE_RANGE[0]}, {AGE_RANGE[1]}] -- looks like {why}. "
+            "irw_filter() treats every value here as an age (#1779).",
+            table=table, group="covariate"))
+    return out
+
+
+def check_resp_dtype(df: pd.DataFrame, table: str = "") -> list:
+    """What R's `is.numeric()` was actually catching, which Python dropped.
+
+    A `resp` whose every value parses as a number but whose storage type is
+    text uploads to Redivis as a string column, and every IRT model downstream
+    breaks. Only meaningful for typed inputs (.RData/.sav/.dta/in-memory) --
+    pandas already infers int64 from a CSV of "1","2".
+    """
+    if "resp" not in df.columns:
+        return []
+    if pd.api.types.is_numeric_dtype(df["resp"]):
+        return []
+    parsed = pd.to_numeric(df["resp"], errors="coerce")
+    if parsed.notna().all() and len(df):
+        return [Finding(
+            "resp_dtype", "error",
+            f"resp parses as numeric but is stored as {df['resp'].dtype}; it "
+            "would upload as a string column. Coerce before writing.",
+            table=table, group="core")]
+    return []

--- a/irw_validate/model.py
+++ b/irw_validate/model.py
@@ -1,0 +1,113 @@
+"""Findings, reports, severity profiles and exit codes.
+
+Severity is a property of the **(check, profile)** pair, never of the check
+alone. That is the whole design, and it exists because the checks were written
+for triage -- deciding whether a machine's guess at a conversion is worth a
+human's time -- and are now being asked to gate publication, which is a
+different question with a different cost of being wrong.
+
+`resp_scale_mixed` is the worked example. It is `fail` today, and
+`data/cao_2026_cdss.py` documents a table that trips it legitimately: an unused
+top category on a left-skewed 1-7 scale reads as a second scale. Promoting every
+heuristic to a blocking error would have rejected that correct table on the day
+the gate went in. So heuristics are capped at `warn` under `upload`, and
+`GATE_ERRORS` grows one documented case at a time.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable
+
+SEVERITIES = ("error", "warn", "info")
+
+#: The five checks ported from `misc/validate_irw.R`. This list is the R/Python
+#: contract: `tests/test_validate.py` parses the R file and asserts set-equality
+#: against it, so the fork cannot silently reopen.
+CORE_CHECKS = frozenset({
+    "required_columns", "id_na", "item_na", "resp_na", "resp_numeric",
+    "dup_id_item", "cov_prefix",
+})
+
+#: Heuristics that block at the gate anyway. A `resp` with one distinct value is
+#: unusable at any altitude -- it carries no information for any model. Add to
+#: this only with a case written down.
+GATE_ERRORS = frozenset({"resp_variation*"})
+
+PROFILES = ("core", "triage", "upload", "legacy")
+
+
+@dataclass(frozen=True)
+class Finding:
+    check: str
+    severity: str          # one of SEVERITIES
+    message: str
+    table: str = ""
+    group: str = "core"    # "core" | "heuristic" | "name" | "covariate"
+
+
+@dataclass
+class Report:
+    label: str
+    profile: str = "upload"
+    findings: list = field(default_factory=list)
+    checks_run: list = field(default_factory=list)
+    stats: dict = field(default_factory=dict)
+    overridden: list = field(default_factory=list)
+    override_reason: str | None = None
+
+    @property
+    def errors(self) -> list:
+        return [f for f in self.findings if f.severity == "error"]
+
+    @property
+    def warnings(self) -> list:
+        return [f for f in self.findings if f.severity == "warn"]
+
+    @property
+    def ok(self) -> bool:
+        """Mirrors red_up.checks.FileReport.ok, so the two compose directly."""
+        return not self.errors
+
+    def to_dict(self) -> dict:
+        return {
+            "label": self.label,
+            "profile": self.profile,
+            "ok": self.ok,
+            "stats": self.stats,
+            "checks_run": self.checks_run,
+            "findings": [vars(f) for f in self.findings],
+            "overridden": [vars(f) for f in self.overridden],
+            "override_reason": self.override_reason,
+        }
+
+
+def severity_for(name: str, status: str, profile: str) -> str | None:
+    """Map one raw check result onto a severity, or None to drop it.
+
+    `status` is the raw `pass|warn|fail` the moved checks emit.
+    """
+    if status == "pass":
+        return None
+    is_core = name in CORE_CHECKS or name.endswith("_na")
+    if profile == "core" and not is_core:
+        return None                       # the R-parity subset only
+    if profile == "triage":
+        return "error" if status == "fail" else "warn"
+    if profile == "legacy" and name == "cov_prefix":
+        return None                       # legacy tables predate the prefix rule
+    if status == "warn":
+        return "warn"
+    # status == "fail"
+    if is_core or name in GATE_ERRORS:
+        return "error"
+    return "warn"                         # a heuristic never blocks by default
+
+
+def exit_code(reports: Iterable[Report], *, strict: bool = False) -> int:
+    """0 clean - 1 something blocks. Matches red_up's contract (2 is bad input)."""
+    reports = list(reports)
+    if any(r.errors for r in reports):
+        return 1
+    if strict and any(r.warnings for r in reports):
+        return 1
+    return 0

--- a/irw_validate/tests/test_validate.py
+++ b/irw_validate/tests/test_validate.py
@@ -1,0 +1,262 @@
+"""Tests for irw_validate. Offline, stdlib unittest, no network, no credentials
+-- the pattern red_up/tests/test_red_up.py established.
+
+The first class is the important one. Fifty scripts in `data/` call `run_qc` and
+read `.name` / `.status` / `.detail` off the result, and `run_qc` had no test
+coverage at all before this file. GOLDEN pins the exact emission order and
+status of every check for eight fixtures, so the move out of
+`irw_triage_updated.py` is provably behaviour-preserving rather than hopefully
+so.
+"""
+from __future__ import annotations
+
+import csv
+import os
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from irw_validate import (CORE_CHECKS, exit_code, validate_file,  # noqa: E402
+                          validate_frame)
+from irw_validate._checks import run_qc  # noqa: E402
+from irw_validate.cli import main  # noqa: E402
+
+
+def F(**cols):
+    return pd.DataFrame(cols)
+
+
+FIXTURES = {
+    "clean": lambda: F(id=[1, 1, 2, 2, 3, 3], item=["a", "b"] * 3, resp=[1, 2, 3, 4, 5, 1]),
+    "missing_col": lambda: F(id=[1, 2], item=["a", "b"]),
+    "all_na_resp": lambda: F(id=[1, 2], item=["a", "b"], resp=[None, None]),
+    "dup_id_item": lambda: F(id=[1, 1], item=["a", "a"], resp=[1, 2]),
+    "dup_with_wave": lambda: F(id=[1, 1], item=["a", "a"], resp=[1, 2], wave=[1, 2]),
+    "nonnumeric_resp": lambda: F(id=[1, 2, 3], item=["a", "b", "c"], resp=["x", "y", "z"]),
+    "no_variation": lambda: F(id=[1, 2, 3], item=["a", "b", "c"], resp=[1, 1, 1]),
+    "unprefixed_cov": lambda: F(id=[1, 2], item=["a", "b"], resp=[1, 2], age=[30, 40]),
+}
+
+#: Captured from `irw_triage_updated.run_qc` on 2026-09-02, BEFORE the move.
+GOLDEN = {
+    "clean": [("required_columns", "pass"), ("resp_numeric", "pass"),
+              ("dup_id_item", "pass")],
+    "missing_col": [("required_columns", "fail")],
+    "all_na_resp": [("required_columns", "pass"), ("resp_na", "fail"),
+                    ("resp_numeric", "fail"), ("dup_id_item", "pass"),
+                    ("resp_variation*", "fail"), ("density*", "warn")],
+    "dup_id_item": [("required_columns", "pass"), ("resp_numeric", "pass"),
+                    ("dup_id_item", "fail")],
+    "dup_with_wave": [("required_columns", "pass"), ("resp_numeric", "pass"),
+                      ("dup_id_item", "warn")],
+    "nonnumeric_resp": [("required_columns", "pass"), ("resp_numeric", "fail"),
+                        ("dup_id_item", "pass"), ("resp_variation*", "fail"),
+                        ("resp_scale_mixed", "fail")],
+    "no_variation": [("required_columns", "pass"), ("resp_numeric", "pass"),
+                     ("dup_id_item", "pass"), ("resp_variation*", "fail"),
+                     ("imputed_values*", "warn")],
+    "unprefixed_cov": [("required_columns", "pass"), ("resp_numeric", "pass"),
+                       ("dup_id_item", "pass"), ("cov_prefix", "warn"),
+                       ("imputed_values*", "warn")],
+}
+
+
+class GoldenCompatibility(unittest.TestCase):
+    """The fifty callers see exactly what they saw before the move."""
+
+    def test_emission_order_and_status_unchanged(self):
+        for name, build in FIXTURES.items():
+            with self.subTest(fixture=name):
+                got = [(c.name, c.status) for c in run_qc(build())]
+                self.assertEqual(got, GOLDEN[name])
+
+    def test_check_objects_still_expose_the_three_attributes_callers_use(self):
+        for check in run_qc(FIXTURES["unprefixed_cov"]()):
+            self.assertIsInstance(check.name, str)
+            self.assertIn(check.status, ("pass", "warn", "fail"))
+            self.assertIsInstance(check.detail, str)
+
+    def test_the_shim_is_importable_by_its_old_name(self):
+        from irw_validate.compat import Check, run_qc as shimmed
+        self.assertIs(shimmed, run_qc)
+        self.assertTrue(hasattr(Check("x", "pass", "y"), "detail"))
+
+
+class Profiles(unittest.TestCase):
+    """Severity is a property of (check, profile), never of the check alone."""
+
+    def test_heuristics_do_not_block_the_gate(self):
+        # resp_scale_mixed is `fail` in triage; cao_2026_cdss documents a real
+        # table that trips it legitimately, so it must not block an upload.
+        df = FIXTURES["nonnumeric_resp"]()
+        upload = validate_frame(df, profile="upload")
+        mixed = [f for f in upload.findings if f.check == "resp_scale_mixed"]
+        self.assertEqual([f.severity for f in mixed], ["warn"])
+
+    def test_gate_errors_still_block(self):
+        report = validate_frame(FIXTURES["no_variation"](), profile="upload")
+        self.assertIn("resp_variation*", [f.check for f in report.errors])
+
+    def test_core_profile_is_only_the_r_parity_checks(self):
+        report = validate_frame(FIXTURES["no_variation"](), profile="core")
+        for finding in report.findings:
+            self.assertTrue(
+                finding.check in CORE_CHECKS or finding.check.endswith("_na"),
+                f"{finding.check} is not part of the validate_irw.R subset")
+
+    def test_triage_profile_preserves_today_severities(self):
+        report = validate_frame(FIXTURES["dup_id_item"](), profile="triage")
+        dup = [f for f in report.findings if f.check == "dup_id_item"]
+        self.assertEqual([f.severity for f in dup], ["error"])
+
+    def test_legacy_profile_forgives_the_cov_prefix_rule(self):
+        report = validate_frame(FIXTURES["unprefixed_cov"](), profile="legacy")
+        self.assertNotIn("cov_prefix", [f.check for f in report.findings])
+
+
+class ExtraChecks(unittest.TestCase):
+    """The prose rules in datastandard.md, now executable."""
+
+    def test_cov_age_sentinel_is_caught(self):
+        df = F(id=list(range(1, 5)), item=["a"] * 4, resp=[1, 2, 3, 4],
+               cov_age=[34, 41, 999, 28])
+        report = validate_frame(df, profile="upload")
+        cov = [f for f in report.findings if f.check == "cov_range"]
+        self.assertEqual(len(cov), 1)
+        self.assertIn("sentinel", cov[0].message)
+
+    def test_cov_age_negative_offset_is_caught(self):
+        df = F(id=[1, 2, 3], item=["a"] * 3, resp=[1, 2, 3],
+               cov_age=[-18090, 44, 51])
+        report = validate_frame(df, profile="upload")
+        cov = [f for f in report.findings if f.check == "cov_range"]
+        self.assertIn("date or days-since-epoch", cov[0].message)
+
+    def test_plausible_ages_pass(self):
+        df = F(id=[1, 2, 3], item=["a"] * 3, resp=[1, 2, 3], cov_age=[18, 45, 92])
+        report = validate_frame(df, profile="upload")
+        self.assertNotIn("cov_range", [f.check for f in report.findings])
+
+    def test_long_table_name_blocks(self):
+        df = FIXTURES["clean"]()
+        long_name = "a" * 41
+        report = validate_frame(df, label=f"{long_name}.csv", profile="upload")
+        self.assertIn("name_length", [f.check for f in report.errors])
+
+    def test_name_checks_do_not_run_under_triage(self):
+        report = validate_frame(FIXTURES["clean"](), label="A" * 60 + ".csv",
+                                profile="triage")
+        self.assertNotIn("name_length", [f.check for f in report.findings])
+
+    def test_resp_dtype_catches_numbers_stored_as_text(self):
+        df = F(id=[1, 2, 3], item=["a", "b", "c"], resp=["1", "2", "3"])
+        report = validate_frame(df, profile="upload")
+        self.assertIn("resp_dtype", [f.check for f in report.errors])
+
+
+class RPythonParity(unittest.TestCase):
+    """The fork cannot silently reopen: one list, two languages, checked here."""
+
+    def test_validate_irw_r_declares_the_same_core_checks(self):
+        r_file = Path(__file__).resolve().parents[2] / "misc" / "validate_irw.R"
+        if not r_file.exists():
+            self.skipTest("misc/validate_irw.R not present")
+        text = r_file.read_text()
+        declared = set(re.findall(r"#\s*@check\s+([a-z_*]+)", text))
+        self.assertTrue(
+            declared, "validate_irw.R carries no `# @check <name>` markers -- "
+                      "add one per check so this parity test can see them")
+        self.assertEqual(
+            declared, set(CORE_CHECKS),
+            "misc/validate_irw.R and irw_validate.model.CORE_CHECKS disagree; "
+            "the fork this package closed has reopened")
+
+
+class Cli(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        # never append to the repository's real waiver ledger from a test run
+        os.environ["IRW_VALIDATE_LEDGER"] = os.path.join(self.tmp.name, "ledger.csv")
+        self.addCleanup(os.environ.pop, "IRW_VALIDATE_LEDGER", None)
+
+    def test_override_is_recorded_in_the_ledger(self):
+        rows = [(1, "a", "x"), (2, "b", "y")]
+        path = self._write("bad_2024_scale.csv", rows)
+        reason = "resp is a documented free-text probe, confirmed with the author"
+        main([path, "--override", reason])
+        ledger = Path(os.environ["IRW_VALIDATE_LEDGER"])
+        self.assertTrue(ledger.exists(), "a waiver must leave a trail")
+        body = ledger.read_text()
+        self.assertIn(reason, body)
+        self.assertIn("resp_numeric", body)
+
+    def _write(self, name, rows, header=("id", "item", "resp")):
+        path = os.path.join(self.tmp.name, name)
+        with open(path, "w", newline="") as fh:
+            w = csv.writer(fh)
+            w.writerow(header)
+            w.writerows(rows)
+        return path
+
+    def test_clean_table_exits_zero(self):
+        rows = [(i, f"q{j}", (i + j) % 5 + 1) for i in range(1, 40) for j in range(1, 5)]
+        self.assertEqual(main([self._write("ok_2024_scale.csv", rows)]), 0)
+
+    def test_blocking_table_exits_one(self):
+        rows = [(1, "a", "x"), (2, "b", "y"), (3, "c", "z")]
+        self.assertEqual(main([self._write("bad_2024_scale.csv", rows)]), 1)
+
+    def test_missing_file_exits_two(self):
+        self.assertEqual(main([os.path.join(self.tmp.name, "nope.csv")]), 2)
+
+    def test_strict_promotes_warnings(self):
+        rows = [(i, "a", 1 + i % 3) for i in range(1, 20)]
+        path = self._write("small_2024_scale.csv", rows)
+        self.assertEqual(main([path]), 0)          # sample_floor is a warning
+        self.assertEqual(main([path, "--strict"]), 1)
+
+    def test_override_without_a_reason_is_rejected(self):
+        rows = [(1, "a", "x"), (2, "b", "y")]
+        path = self._write("bad_2024_scale.csv", rows)
+        self.assertEqual(main([path, "--override", "nope"]), 2)
+        self.assertEqual(main([path, "--override-check", "resp_numeric"]), 2)
+
+    def test_override_waives_and_still_reports(self):
+        rows = [(1, "a", "x"), (2, "b", "y")]
+        path = self._write("bad_2024_scale.csv", rows)
+        reason = "resp is a documented free-text probe, confirmed with the author"
+        self.assertEqual(main([path, "--override", reason]), 0)
+
+    def test_scoped_override_leaves_other_errors_blocking(self):
+        rows = [(1, "a", "x"), (2, "b", "y")]
+        path = self._write("bad_2024_scale.csv", rows)
+        reason = "resp is a documented free-text probe, confirmed with the author"
+        self.assertEqual(
+            main([path, "--override-check", "resp_numeric", "--override", reason]),
+            1, "resp_variation* should still block")
+
+
+class ExitCodes(unittest.TestCase):
+    def test_exit_code_contract(self):
+        clean = validate_frame(FIXTURES["clean"](), profile="upload")
+        broken = validate_frame(FIXTURES["no_variation"](), profile="upload")
+        self.assertEqual(exit_code([clean]), 0)
+        self.assertEqual(exit_code([clean, broken]), 1)
+
+    def test_size_downgrade_is_recorded_not_silent(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "big_2024_scale.csv"
+            path.write_text("id,item,resp\n1,a,1\n")
+            report = validate_file(path, max_bytes=1)
+            self.assertIn("size_downgrade", [f.check for f in report.findings])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/misc/tests/smoke_validate_irw.R
+++ b/misc/tests/smoke_validate_irw.R
@@ -1,0 +1,23 @@
+## Smoke test for misc/validate_irw.R -- the copy external contributors source
+## from a raw GitHub URL. Nothing in this repo imports it, so without this it
+## could stop being valid R and no one would find out until a stranger tried it.
+##
+## The check vocabulary is guarded separately, by the R/Python parity test in
+## irw_validate/tests/, which asserts the file's `# @check` markers match
+## irw_validate.model.CORE_CHECKS.
+here <- dirname(sub("^--file=", "",
+                    grep("^--file=", commandArgs(FALSE), value = TRUE)[1]))
+source(file.path(here, "..", "validate_irw.R"))
+
+clean <- data.frame(id = c(1, 2), item = c("a", "b"), resp = c(1, 2))
+stopifnot(validate_irw_status(validate_irw(clean, "clean")) == 0L)
+
+## a documented column must not trip the covariate-prefix note
+with_treat <- cbind(clean, treat = c(0, 1))
+stopifnot(length(validate_irw(with_treat, "treat")$notes) == 0L)
+
+## and a real violation must be reported AND set a non-zero status
+broken <- data.frame(id = c(1, 2), item = c("a", "b"), resp = c("x", "y"))
+stopifnot(validate_irw_status(validate_irw(broken, "broken")) == 1L)
+
+cat("validate_irw.R OK\n")

--- a/misc/validate_irw.R
+++ b/misc/validate_irw.R
@@ -2,6 +2,17 @@
 ##
 ## Source this file, then call validate_irw(df, label) on each dataset before saving.
 ##
+## This implements the `core` profile: the five checks below, and no more. The
+## full check set — response-scale homogeneity, composite items, rt/date units,
+## covariate ranges, table naming — lives in the `irw_validate` Python package
+## and runs as `irw-validate <file.csv>`. This file is deliberately NOT a
+## wrapper around it: its whole value is that it works for someone with an R
+## session and a URL, and nothing else installed.
+##
+## The `# @check` markers below name each check. `irw_validate/tests/` parses
+## them and asserts they match `irw_validate.model.CORE_CHECKS` exactly, so the
+## two implementations cannot drift apart again (irw#1703, sub-item 1.3).
+##
 ## Output:
 ##   OK    — dataset passes all checks
 ##   NOTE  — soft warning (e.g. NAs in resp, columns missing cov_ prefix); worth reviewing
@@ -28,14 +39,16 @@ validate_irw <- function(df, label="") {
     issues <- character(0)
     notes  <- character(0)
 
-    ## required columns
+    # @check required_columns
     required <- c("id", "item", "resp")
     missing  <- setdiff(required, names(df))
     if (length(missing) > 0)
         issues <- c(issues, paste("missing required columns:", paste(missing, collapse=", ")))
 
     if (length(missing) == 0) {
-        ## NAs in required columns
+        # @check id_na
+        # @check item_na
+        # @check resp_na
         for (col in required) {
             if (all(is.na(df[[col]])))
                 issues <- c(issues, paste(col, "is entirely NA"))
@@ -43,11 +56,15 @@ validate_irw <- function(df, label="") {
                 notes <- c(notes, paste(col, "has", sum(is.na(df[[col]])), "NAs"))
         }
 
-        ## resp must be numeric
+        # @check resp_numeric
+        ## Storage type, deliberately: a resp column stored as character
+        ## uploads to Redivis as a string and every model downstream breaks.
+        ## The Python side splits this into resp_numeric (do the values parse)
+        ## and resp_dtype (is the column stored as a number).
         if (!is.numeric(df$resp))
             issues <- c(issues, paste("resp is not numeric (class:", class(df$resp), ")"))
 
-        ## duplicate id+item
+        # @check dup_id_item
         known_longitudinal <- c("wave", "timepoint", "date")
         has_longitudinal   <- any(known_longitudinal %in% names(df))
         dups <- sum(duplicated(df[, c("id", "item")]))
@@ -57,10 +74,15 @@ validate_irw <- function(df, label="") {
             notes <- c(notes, paste(dups, "duplicate id+item rows (longitudinal column present — likely ok)"))
     }
 
-    ## covariate naming
-    known_cols  <- c("id", "item", "resp", "rt", "date", "wave", "timepoint")
+    # @check cov_prefix
+    ## Broadened 2026-09-02 to the full documented standard: treat, rater and
+    ## item_family are legitimate columns, and this list predated them, so it
+    ## emitted a NOTE on every correctly-formatted table that used one.
+    known_cols  <- c("id", "item", "resp", "rt", "date", "wave", "timepoint",
+                     "treat", "rater", "item_family")
     other_cols  <- setdiff(names(df), known_cols)
-    unprefixed  <- other_cols[!grepl("^cov_", other_cols)]
+    known_prefix <- "^(cov_|itemcov_|qmatrix|trial_)"
+    unprefixed  <- other_cols[!grepl(known_prefix, other_cols)]
     if (length(unprefixed) > 0)
         notes <- c(notes, paste("columns without cov_ prefix:", paste(unprefixed, collapse=", ")))
 
@@ -76,4 +98,15 @@ validate_irw <- function(df, label="") {
     }
 
     invisible(list(issues=issues, notes=notes))
+}
+
+
+## Exit status, so this can gate a script rather than only inform one:
+##
+##   res <- validate_irw(df, "mydata.csv")
+##   quit(status = validate_irw_status(res))
+##
+## Matches irw-validate's contract: 0 clean, 1 something blocks.
+validate_irw_status <- function(res) {
+    if (length(res$issues) > 0) 1L else 0L
 }

--- a/processing_notes/validator_overrides.csv
+++ b/processing_notes/validator_overrides.csv
@@ -1,0 +1,1 @@
+date,tool,table,checks,reason,user

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = ["redivis>=0.18.0"]
 
 [project.scripts]
 red_up = "red_up.cli:main"
+irw-validate = "irw_validate.cli:main"
 
 [tool.setuptools]
-packages = ["red_up"]
+packages = ["red_up", "irw_validate"]

--- a/red_up/README.md
+++ b/red_up/README.md
@@ -114,6 +114,26 @@ Roadmap 1.3–1.5: merging `misc/validate_irw.R` with
 GitHub Action, and the sweep over `data/pub/`. `checks.run_validator` is the
 seam it plugs into.
 
+## The format gate
+
+Since 2026-09-02 `red_up` will not upload a table that
+[`irw_validate`](../irw_validate/README.md) blocks — the other half of
+"one validator, one uploader, and a gate between them" (#1703). Findings appear
+beside the cheap checks, and a blocked file is skipped with its reason shown.
+
+Three things worth knowing:
+
+- **It does not break the streaming design.** The checks above load nothing;
+  the validator needs a whole frame, so it is imported lazily and skipped above
+  `irw_validate.MAX_BYTES` (512 MB), with a warning recording the skip. A check
+  that quietly does not run is worse than one that says it did not.
+- **A missing dependency is an error, not a pass.** If `irw_validate` cannot be
+  imported, the upload is blocked. Blocking because pandas is not installed is
+  annoying exactly once; passing because pandas is not installed is undetectable
+  forever.
+- **Heuristics warn, they do not block** — see the profile table in
+  `irw_validate/README.md` for why.
+
 ## Drafts, and the one-week window
 
 `red_up` only ever writes a **draft** version. Releasing is a human action on

--- a/red_up/checks.py
+++ b/red_up/checks.py
@@ -1,4 +1,4 @@
-"""Cheap local checks run before anything is uploaded.
+"""Local checks run before anything is uploaded.
 
 Deliberately the cheap half of "one validator, one uploader, and a gate
 between them" (#1703). Unifying misc/validate_irw.R with
@@ -94,14 +94,32 @@ def check_schema(report: FileReport, target: Target) -> None:
         report.warnings.append(f"missing required column(s): {', '.join(missing)}")
 
 
-def run_validator(path: Path) -> list[str]:
-    """Seam for the full IRW format validator (#1703 sub-item 1.3).
+def run_validator(path: Path) -> tuple[list[str], list[str]]:
+    """The full IRW format validator (#1703 sub-item 1.3). -> (errors, warnings)
 
-    Returns a list of findings; empty today. When misc/validate_irw.R and
-    run_qc() are merged into one implementation with an exit code, call it
-    here and surface its findings alongside the cheap ones above.
+    Everything above this streams with the csv module because some of these
+    tables are hundreds of MB. The validator needs pandas and a whole frame, so
+    it is imported lazily and skips above `irw_validate.MAX_BYTES` -- and when
+    it skips, it says so as a warning rather than passing quietly.
+
+    A missing dependency is an ERROR, never a pass. Blocking because pandas is
+    not installed is annoying exactly once; passing because pandas is not
+    installed is undetectable forever.
     """
-    return []
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    try:
+        from irw_validate import validate_file
+    except ImportError as exc:
+        return ([f"validator unavailable ({exc}) -- install pandas, or pass "
+                 f"--no-validate to upload without a format check"], [])
+
+    try:
+        report = validate_file(path, profile="upload")
+    except Exception as exc:                      # unreadable, odd encoding, ...
+        return ([f"validator could not read this file: {exc}"], [])
+
+    return ([f"{f.check}: {f.message}" for f in report.errors],
+            [f"{f.check}: {f.message}" for f in report.warnings])
 
 
 def check_all(pairs: list[tuple[Path, str]]) -> list[FileReport]:
@@ -112,6 +130,13 @@ def check_all(pairs: list[tuple[Path, str]]) -> list[FileReport]:
     win. That is a batch-assembly mistake, so it is an error, not a warning.
     """
     reports = [scan(path, table) for path, table in pairs]
+
+    for report in reports:
+        if report.errors:
+            continue          # a file that is not a table yet is not worth validating
+        errors, warnings = run_validator(report.path)
+        report.errors.extend(errors)
+        report.warnings.extend(warnings)
 
     seen: dict[str, list[FileReport]] = {}
     for report in reports:

--- a/red_up/tests/test_red_up.py
+++ b/red_up/tests/test_red_up.py
@@ -9,6 +9,8 @@ and is exercised by the end-to-end procedure in red_up/README.md instead.
 from __future__ import annotations
 
 import tempfile
+import builtins
+from unittest import mock
 import unittest
 from pathlib import Path
 
@@ -316,3 +318,54 @@ def test_drafts_reports_no_draft(monkeypatch):
     _fake_redivis(monkeypatch, versions=[_Version("v1.0", True, _ms(3, now))],
                   draft_tables={}, released_tables={"a__items": 10})
     assert _drafts.inspect("datapages", _target(), now)["has_draft"] is False
+
+
+# --- the format-validator gate (#1703 sub-item 1.4) --------------------------
+
+class ValidatorGate(unittest.TestCase):
+    """red_up refuses a table the format validator blocks."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def _csv(self, name, body):
+        path = Path(self.tmp.name) / name
+        path.write_text(body)
+        return path
+
+    def test_a_broken_table_is_blocked(self):
+        path = self._csv("broken_2024_scale.csv", "id,item,resp\n1,a,x\n2,b,y\n3,c,z\n")
+        report, = check_all([(path, "broken_2024_scale")])
+        self.assertFalse(report.ok)
+        self.assertTrue(any("resp_numeric" in e for e in report.errors), report.errors)
+
+    def test_a_clean_table_passes(self):
+        rows = "\n".join(f"{i},q{j},{(i + j) % 5 + 1}"
+                         for i in range(1, 40) for j in range(1, 5))
+        path = self._csv("ok_2024_scale.csv", "id,item,resp\n" + rows + "\n")
+        report, = check_all([(path, "ok_2024_scale")])
+        self.assertTrue(report.ok, report.errors)
+
+    def test_a_cov_age_sentinel_warns_without_blocking(self):
+        rows = "\n".join(f"{i},q{j},{(i + j) % 5 + 1},{999 if i == 1 else 40}"
+                         for i in range(1, 40) for j in range(1, 5))
+        path = self._csv("sentinel_2024_scale.csv", "id,item,resp,cov_age\n" + rows + "\n")
+        report, = check_all([(path, "sentinel_2024_scale")])
+        self.assertTrue(report.ok, "an already-live defect must not block (#1779)")
+        self.assertTrue(any("cov_range" in w for w in report.warnings), report.warnings)
+
+    def test_a_missing_validator_blocks_rather_than_passes(self):
+        import red_up.checks as checks_mod
+        real_import = builtins.__import__
+
+        def no_irw_validate(name, *a, **kw):
+            if name.startswith("irw_validate"):
+                raise ImportError("no pandas here")
+            return real_import(name, *a, **kw)
+
+        path = self._csv("x_2024_scale.csv", "id,item,resp\n1,a,1\n2,b,2\n")
+        with mock.patch.object(builtins, "__import__", no_irw_validate):
+            errors, warnings = checks_mod.run_validator(path)
+        self.assertTrue(errors, "a missing validator must be an error, never a pass")
+        self.assertIn("validator unavailable", errors[0])


### PR DESCRIPTION
Two things, both answering "what should I work on and how do I know it's right".

## 1. `PRIORITIES.md` — ranks kinds of work, not issues

200+ open issues, 245 in `data queue`, 18 roadmap items, 8 open PRs. A list that long stops being a priority order. This ranks lenses instead, so it stays right when every issue number in it is closed:

1. **Corpus trust** — the warehouse is serving something *wrong*, which outranks *incomplete*. Same line `ARCHITECTURE.md` §4 already draws for draft releases.
2. **Gates** — stop the class, not the instance.
3. **Reach and contribution** — items 4, 5, 6, currently getting no time.
4. **Volume** — tags and item text. Ranked fourth not to stop it but to stop it crowding out 1–3 by default.
5. **Not now, and say so** — blue sky, vignettes, acquisition sprints.

It records the assumptions the ranking depends on (Year 3 horizon, agents + RAs not a hired engineer, the three lenses), because the order only holds under them — including that "research output from the data" was deliberately *not* chosen, which is why items 8–15 sit where they do.

Worth noting: **`data queue` intake already stopped on its own.** Newest of the 245 is 2026-08-11; oldest is the repo's opening day in March 2024. Stale, not growing.

## 2. `irw_validate` — #1703 sub-items 1.3 and 1.4

Before this, "is this table valid?" had two answers and no way to act on either:

| | checks | callers | exit code |
|---|---|---|---|
| `misc/validate_irw.R` | 5 | **nothing in the repo** | no |
| `irw_triage_updated.py::run_qc` | ~20 | **50** scripts in `data/` | no — `__main__` exits 0 however many fail |

Now `irw-validate out/*.csv` exits 1 when something blocks, and `red_up` refuses to upload a table it blocks. It also makes `datastandard.md` executable — 348 lines of prose rules, none of them enforced by anything until now, which is exactly what `ARCHITECTURE.md`'s Rule 2 asks for.

### Severity belongs to (check, profile), not to the check

The central decision. These checks were written for *triage* and are now also asked to gate *publication*. `resp_scale_mixed` is `fail` today, and `data/cao_2026_cdss.py` documents a table that trips it **legitimately**. Promoting every heuristic to a blocking error would have rejected that correct table on day one.

`core` (the R subset) · `triage` (exactly today's severities) · `upload` (the gate; heuristics capped at `warn`) · `legacy` (for 1.5). `GATE_ERRORS` is exactly `{resp_variation*}` and grows one documented case at a time.

### The 50 callers needed no edit

I was briefed that `run_qc` had 7 callers; it has **50**. All use one import and read only `.name`/`.status`/`.detail`, so the bodies were **moved verbatim** and re-exported.

**The golden test was written before the move** — it pins the exact `(name, status)` sequence for eight fixtures captured from the old implementation. `run_qc` had *no test coverage at all*: 225 lines of validation logic reached from 50 files. All 50 imports verified resolving afterwards, plus `irw_process_queue.py` and `irw_batch_updated.py`.

### New checks from the standard's prose

`name_length`, `name_charset`, `sample_floor`, `column_order`, `resp_dtype`, and **`cov_range`** — the check #1779 asked for. Against the real population it flags **all 81** tables whose `cov_age` is a sentinel, birth year or date offset, with **zero false positives** across the 1,839 the audit considers fine.

`cov_range` is deliberately a *warning*: 81 tables are already live with it, and blocking would fail them all on their next re-upload before anyone has decided the repair.

### The gate, and what it must not do

`red_up/checks.py` streams with the `csv` module on purpose — some tables are hundreds of MB. So the validator is lazily imported and skipped above 512 MB **with a warning recording the skip**; a check that quietly does not run is worse than one that says it did not. A missing dependency is an **error, never a pass**.

### The override, formalised rather than invented

`--override REASON` — the reason is the flag's *argument*, so waiving without saying why is structurally impossible. Not `--force`, not `--no-verify`. Reasons under 20 characters rejected, overridden findings reprinted rather than suppressed, each appended to `processing_notes/validator_overrides.csv`. `--override-check` scopes it.

This formalises what `cao_2026_cdss.py` already does in a prose comment: right judgment, recorded where no tool can read it.

### First CI in this repository

`.github/workflows/tests.yml` runs both suites and checks `validate_irw.R` still parses. The three existing workflows are Projects card-movers that never check out the repo — which is the reported cause of the PR backlog: **five of eight open PRs have no review**, because nothing mechanical can speak first. No network, no credentials, no downloads.

### Keeping the fork closed

`validate_irw.R` is **not** rewritten to call Python — its whole value is working for a stranger with an R session and a URL. It carries `# @check` markers and a test asserts they match `CORE_CHECKS`. Two languages, one list, enforced. It also gains `validate_irw_status()` and a known-column list broadened to the documented standard (it predated `treat`/`rater`/`item_family` and emitted a NOTE on every correct table using one).

## Verification

- 51 tests pass (22 red_up, 24 irw_validate, plus new gate tests); all offline.
- All 50 `data/*.py` callers and both sibling modules import cleanly after the move.
- Golden fixtures byte-identical on `(name, status, detail)` before and after.
- `cov_range`: 81/81 caught, 0/1,839 false positives.
- End-to-end: `red_up --dry-run` warns on a sentinel `cov_age` and skips a table with a non-numeric `resp`.

## Deferred, deliberately

- **1.5**, the 922 legacy `.Rdata` sweep — `../data/pub/` is not under version control, so it is a one-off local sweep, never CI.
- **A `contract` CI job** linting `data/*.py` statically. `automated_finding/irw_output/` is gitignored, so a PR to `data/` contains a script and never a table — CI can check the script's contract but not the data. Wants its own PR, and should start annotate-only.
- **Folding in `irw_lint_covariates.py`** — the right fold-in, but 477 lines with its own CLI and a mined vocabulary.

Advances #1703 (1.3, 1.4). Gives #1779 its executable check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5VsAkTyiVWtFij13gVYGa