### PR TITLE
Make both issues-page checkers name the file they read

### DIFF
--- a/itemtext/.claude/skills/irw-auto-itemtext/scripts/check_issues_page.R
+++ b/itemtext/.claude/skills/irw-auto-itemtext/scripts/check_issues_page.R
@@ -26,6 +26,18 @@ if (!file.exists(qmd)) {
 }
 page <- paste(readLines(qmd, warn = FALSE), collapse = "\n")
 
+# Say which copy of the page this read. The default sibling checkout is often
+# parked on another branch -- on 2026-09-02 it sat 60 entries behind main, and a
+# sibling checker reported a gap that had already been closed. Silence about the
+# source is how a stale answer passes for a real one.
+cat(sprintf("issues page: %s (%d entries)\n", qmd,
+            sum(grepl("^- table:", strsplit(page, "\n")[[1]]))))
+.br <- suppressWarnings(system2("git", c("-C", shQuote(dirname(normalizePath(qmd))),
+                                         "rev-parse", "--abbrev-ref", "HEAD"),
+                                stdout = TRUE, stderr = FALSE))
+if (length(.br) && !is.na(.br[1]) && nzchar(.br[1]) && .br[1] != "main")
+  cat(sprintf("  NOTE: that checkout is on branch '%s', not main -- it may be stale.\n", .br[1]))
+
 # Every provenance record, not only the batches. The language backfill's 78
 # tables live outside itemtables/, and while this glob was batch-only they were
 # invisible here -- which is how 60 tables shipping project-generated English

--- a/itemtext/check_provenance.R
+++ b/itemtext/check_provenance.R
@@ -2,7 +2,8 @@
 ##
 ## Validate every item text provenance.csv against the one vocabulary.
 ##
-##   Rscript itemtext/check_provenance.R          # exit 1 if anything is off
+##   Rscript itemtext/check_provenance.R                     # exit 1 if anything is off
+##   Rscript itemtext/check_provenance.R path/to/page.qmd    # check against a specific page
 ##
 ## Why this exists. On 2026-09-02 a `translation_source` column was added twice,
 ## in two files, with two vocabularies: `official_instrument_english` /
@@ -68,7 +69,32 @@ if (length(bad)) {
 }
 
 ## A machine translation is IRW-generated content, so it is disclosed publicly.
-page <- file.path(here, "..", "..", "irw_site", "itemtext_issues.qmd")
+##
+## Which copy of the page gets read matters more than it looks. The default is
+## the sibling irw_site checkout, and that working tree is often parked on some
+## other branch -- on 2026-09-02 it sat 60 entries behind main and this check
+## confidently reported a gap that had already been closed. A checker that reads
+## the wrong file and says nothing about it is worse than no checker, so the
+## path is printed, its entry count with it, and the branch named when the
+## checkout is not on main.
+args <- commandArgs(trailingOnly = TRUE)
+page <- if (length(args)) args[1] else
+    file.path(here, "..", "..", "irw_site", "itemtext_issues.qmd")
+
+if (file.exists(page)) {
+    n_entries <- sum(grepl("^- table:", readLines(page, warn = FALSE)))
+    cat(sprintf("\nissues page: %s (%d entries)\n", page, n_entries))
+    site <- dirname(normalizePath(page))
+    br <- suppressWarnings(system2("git", c("-C", shQuote(site), "rev-parse",
+                                            "--abbrev-ref", "HEAD"),
+                                   stdout = TRUE, stderr = FALSE))
+    if (length(br) && !is.na(br[1]) && nzchar(br[1]) && br[1] != "main")
+        cat(sprintf("  NOTE: that checkout is on branch '%s', not main -- it may be stale.\n",
+                    br[1]))
+} else {
+    cat(sprintf("\nissues page not found at %s -- skipping the disclosure check\n", page))
+}
+
 if (file.exists(page) && length(needs_note)) {
     txt <- paste(readLines(page, warn = FALSE), collapse = "\n")
     undisclosed <- needs_note[!vapply(needs_note, grepl, logical(1),


### PR DESCRIPTION
Found by using `check_provenance.R` minutes after #1825 and datapages/irw#112 merged. It reported:

```
machine_translation tables: 64, of which 60 have no entry on the public issues page
```

**Wrong, and confidently so.** It reads the sibling `irw_site` checkout at a hardcoded path; that working tree was parked on `network-psych-huth-followup` and sat **60 entries behind main** — exactly the 60 that had just been merged. Against the merged page the same command reports `0` and exits `0`.

A false positive that looks precisely like a real finding is worse than no check. Someone acting on that output would have re-done a day's work.

## What changed

Nothing about the checks. Both `check_provenance.R` and `check_issues_page.R` now:

- accept the page path as an argument (`check_provenance.R` did not),
- **print which file they read and how many entries it holds**,
- and name the branch when that checkout is not on `main`.

```
issues page: ../../irw_site/itemtext_issues.qmd (88 entries)
  NOTE: that checkout is on branch 'network-psych-huth-followup', not main -- it may be stale.
```

Same lesson as the fetch-blocker guard: a check that reaches the wrong thing and reports it as fact is a liability rather than a safeguard. The fix is not to be cleverer about which file to read — the sibling checkout is the right default — but to make the answer carry its provenance.

## Verification

- Default (stale checkout): names the branch, reports 60, exits 1.
- Against the merged page: `64 tables, 0 without an entry`, exits 0 — confirming #1825 and datapages/irw#112 closed the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5VsAkTyiVWtFij13gVYGa