### PR TITLE
afps_vangsness_2019 documents two opposite scales at once (#1816)

### DIFF
--- a/irw_validate/core.py
+++ b/irw_validate/core.py
@@ -47,15 +47,60 @@ def _validate_item_text(df, label: str, profile: str) -> Report:
             f"missing required columns for item text: {', '.join(missing)}",
             table=table, group="core"))
         return report
-    for name, dup in (("dup_item_resp",
-                       df.duplicated(subset=[c for c in ("item", "resp")
-                                             if c in df.columns]).sum()),):
-        report.checks_run.append(name)
-        if dup:
+    keys = [c for c in ("item", "resp") if c in df.columns]
+    report.checks_run.append("dup_item_resp")
+    dup = int(df.duplicated(subset=keys).sum()) if keys else 0
+
+    # A scored table is a different object. Where `correct_response` is
+    # populated, `resp` is a scoring key (0 wrong / 1 right) rather than a point
+    # on a scale, so one resp value legitimately carries many option labels --
+    # spanishmegastudy has 1,270 multiple-choice items with three distractors
+    # each, all coded resp=0. Judging that by the Likert rule would flag 1,270
+    # correct items. For a scored table the only thing that still holds is that
+    # no *whole row* should repeat.
+    scored = False
+    if "correct_response" in df.columns:
+        col = df["correct_response"]
+        # notna() first: under pandas 3 an all-NaN column astype(str) keeps the
+        # values MISSING rather than rendering them "nan", so a string-only test
+        # matches nothing and reads an empty column as fully populated.
+        filled = col.notna() & ~col.astype(str).str.strip().isin(("", "NA", "nan", "None"))
+        scored = bool(filled.mean() > 0.5)
+    if scored:
+        exact = int(df.duplicated().sum())
+        if exact:
             report.findings.append(Finding(
-                name, "error",
-                f"{dup} duplicate item+resp rows -- an item text table carries one "
-                f"row per response option, so a repeat is a doubled upload (#1810)",
+                "dup_row", "error",
+                f"{exact} fully identical row(s) in a scored table. `resp` here is a "
+                f"scoring key, so one value carrying several option labels is "
+                f"expected -- but an exact repeat is still a duplicate.",
+                table=table, group="core"))
+    elif dup:
+        # Two different faults produce this, and the distinction matters to
+        # whoever has to fix it, so name which one this is. If the repeated rows
+        # carry the SAME option_text it is a doubled upload (#1810/#1816). If
+        # they carry DIFFERENT option_text, the table is asserting that one
+        # response value means two things -- afps_vangsness_2019 maps resp=1 to
+        # both "Strongly agree" and "Strongly disagree", which is two opposite
+        # scale directions written into one table and is worse than a duplicate.
+        conflicting = 0
+        if "option_text" in df.columns:
+            per_key = df.groupby(keys)["option_text"].nunique(dropna=False)
+            conflicting = int((per_key > 1).sum())
+        if conflicting:
+            report.findings.append(Finding(
+                "resp_ambiguous", "error",
+                f"{conflicting} response value(s) carry more than one option label -- "
+                f"the same `resp` is documented as meaning two different things, so "
+                f"nothing joining item text to responses can resolve it. Usually two "
+                f"opposite scale directions merged into one table.",
+                table=table, group="core"))
+        else:
+            report.findings.append(Finding(
+                "dup_item_resp", "error",
+                f"{dup} duplicate item+resp rows with identical option text -- an item "
+                f"text table carries one row per response option, so a repeat is a "
+                f"doubled upload (#1810)",
                 table=table, group="core"))
     for finding in extra.check_name(table):
         report.checks_run.append(finding.check)

--- a/irw_validate/tests/test_validate.py
+++ b/irw_validate/tests/test_validate.py
@@ -186,6 +186,20 @@ class ItemText(unittest.TestCase):
         report = validate_frame(self._items(n_rep=2), label="t_2024_scale__items.csv")
         self.assertIn("dup_item_resp", [f.check for f in report.errors])
 
+    def test_two_scale_directions_in_one_table_are_named_as_such(self):
+        # afps_vangsness_2019: resp=1 carries both "Strongly agree" and
+        # "Strongly disagree". Same repeated (item, resp), completely different
+        # fault, and calling it a doubled upload would send someone the wrong way.
+        df = self._items()
+        flipped = df.copy()
+        flipped["option_text"] = flipped["resp"].map(
+            {0: "option 3", 1: "option 2", 2: "option 1", 3: "option 0"})
+        both = pd.concat([df, flipped], ignore_index=True)
+        report = validate_frame(both, label="t_2024_scale__items.csv")
+        checks = [f.check for f in report.errors]
+        self.assertIn("resp_ambiguous", checks)
+        self.assertNotIn("dup_item_resp", checks)
+
     def test_missing_item_text_columns_block(self):
         df = pd.DataFrame({"id": [1], "item": ["a"], "resp": [1]})
         report = validate_frame(df, label="t_2024_scale__items.csv")
@@ -195,6 +209,43 @@ class ItemText(unittest.TestCase):
     def test_the_name_cap_still_applies_to_item_text(self):
         report = validate_frame(self._items(), label=("x" * 41) + "__items.csv")
         self.assertIn("name_length", [f.check for f in report.errors])
+
+
+class ScoredTables(unittest.TestCase):
+    """A scored table is a different object and needs a different rule."""
+
+    def _mc(self, n_items=20, dup=False):
+        rows = {k: [] for k in ("table", "item", "item_text", "correct_response",
+                                "option_text", "resp")}
+        for i in range(n_items):
+            for j, opt in enumerate(("right", "wrong a", "wrong b")):
+                rows["table"].append("mc_2024_quiz")
+                rows["item"].append(i)
+                rows["item_text"].append(f"question {i}")
+                rows["correct_response"].append("right")
+                rows["option_text"].append(opt)
+                rows["resp"].append(1 if j == 0 else 0)
+        df = pd.DataFrame(rows)
+        return pd.concat([df, df.iloc[[0]]], ignore_index=True) if dup else df
+
+    def test_distractors_sharing_a_resp_are_not_a_defect(self):
+        # spanishmegastudy: 1,270 items, three distractors each, all resp=0.
+        # Judged by the Likert rule this would flag every one of them.
+        report = validate_frame(self._mc(), label="mc_2024_quiz__items.csv")
+        self.assertTrue(report.ok, report.findings)
+
+    def test_an_exact_repeat_in_a_scored_table_still_counts(self):
+        report = validate_frame(self._mc(dup=True), label="mc_2024_quiz__items.csv")
+        self.assertIn("dup_row", [f.check for f in report.errors])
+
+    def test_an_empty_correct_response_does_not_read_as_scored(self):
+        # pandas 3 keeps an all-NaN column MISSING through astype(str), so a
+        # string-only emptiness test matches nothing and reads it as populated.
+        df = self._mc()
+        df["correct_response"] = pd.NA
+        df.loc[0, "option_text"] = "wrong a"     # now resp=1 has two labels
+        report = validate_frame(df, label="likert_2024__items.csv")
+        self.assertIn("resp_ambiguous", [f.check for f in report.errors])
 
 
 class RPythonParity(unittest.TestCase):

--- a/itemtext/.claude/skills/irw-auto-itemtext/scripts/check_issues_page.R
+++ b/itemtext/.claude/skills/irw-auto-itemtext/scripts/check_issues_page.R
@@ -26,6 +26,18 @@ if (!file.exists(qmd)) {
 }
 page <- paste(readLines(qmd, warn = FALSE), collapse = "\n")
 
+# Say which copy of the page this read. The default sibling checkout is often
+# parked on another branch -- on 2026-09-02 it sat 60 entries behind main, and a
+# sibling checker reported a gap that had already been closed. Silence about the
+# source is how a stale answer passes for a real one.
+cat(sprintf("issues page: %s (%d entries)\n", qmd,
+            sum(grepl("^- table:", strsplit(page, "\n")[[1]]))))
+.br <- suppressWarnings(system2("git", c("-C", shQuote(dirname(normalizePath(qmd))),
+                                         "rev-parse", "--abbrev-ref", "HEAD"),
+                                stdout = TRUE, stderr = FALSE))
+if (length(.br) && !is.na(.br[1]) && nzchar(.br[1]) && .br[1] != "main")
+  cat(sprintf("  NOTE: that checkout is on branch '%s', not main -- it may be stale.\n", .br[1]))
+
 # Every provenance record, not only the batches. The language backfill's 78
 # tables live outside itemtables/, and while this glob was batch-only they were
 # invisible here -- which is how 60 tables shipping project-generated English

--- a/itemtext/check_provenance.R
+++ b/itemtext/check_provenance.R
@@ -2,7 +2,8 @@
 ##
 ## Validate every item text provenance.csv against the one vocabulary.
 ##
-##   Rscript itemtext/check_provenance.R          # exit 1 if anything is off
+##   Rscript itemtext/check_provenance.R                     # exit 1 if anything is off
+##   Rscript itemtext/check_provenance.R path/to/page.qmd    # check against a specific page
 ##
 ## Why this exists. On 2026-09-02 a `translation_source` column was added twice,
 ## in two files, with two vocabularies: `official_instrument_english` /
@@ -68,7 +69,32 @@ if (length(bad)) {
 }
 
 ## A machine translation is IRW-generated content, so it is disclosed publicly.
-page <- file.path(here, "..", "..", "irw_site", "itemtext_issues.qmd")
+##
+## Which copy of the page gets read matters more than it looks. The default is
+## the sibling irw_site checkout, and that working tree is often parked on some
+## other branch -- on 2026-09-02 it sat 60 entries behind main and this check
+## confidently reported a gap that had already been closed. A checker that reads
+## the wrong file and says nothing about it is worse than no checker, so the
+## path is printed, its entry count with it, and the branch named when the
+## checkout is not on main.
+args <- commandArgs(trailingOnly = TRUE)
+page <- if (length(args)) args[1] else
+    file.path(here, "..", "..", "irw_site", "itemtext_issues.qmd")
+
+if (file.exists(page)) {
+    n_entries <- sum(grepl("^- table:", readLines(page, warn = FALSE)))
+    cat(sprintf("\nissues page: %s (%d entries)\n", page, n_entries))
+    site <- dirname(normalizePath(page))
+    br <- suppressWarnings(system2("git", c("-C", shQuote(site), "rev-parse",
+                                            "--abbrev-ref", "HEAD"),
+                                   stdout = TRUE, stderr = FALSE))
+    if (length(br) && !is.na(br[1]) && nzchar(br[1]) && br[1] != "main")
+        cat(sprintf("  NOTE: that checkout is on branch '%s', not main -- it may be stale.\n",
+                    br[1]))
+} else {
+    cat(sprintf("\nissues page not found at %s -- skipping the disclosure check\n", page))
+}
+
 if (file.exists(page) && length(needs_note)) {
     txt <- paste(readLines(page, warn = FALSE), collapse = "\n")
     undisclosed <- needs_note[!vapply(needs_note, grepl, logical(1),


### PR DESCRIPTION
The three tables left on #1816 were flagged as *"one to nine duplicate rows each — possibly legitimate"*. Two are. The third is a worse defect than anything else in that issue, and the duplicate count was hiding it.

## `afps_vangsness_2019`

Nine items, five options — 45 rows expected. It has 90. **But it is not a doubling.** Every item carries *both* scale directions:

| `resp` | option labels present |
|---|---|
| 1 | **"Strongly agree"** *and* **"Strongly disagree"** |
| 2 | "Somewhat agree" *and* "Somewhat disagree" |
| 3 | "Neither agree nor disagree" *(identical either way)* |
| 4 | "Somewhat agree" *and* "Somewhat disagree" |
| 5 | "Strongly agree" *and* "Strongly disagree" |

The table states that a response of `1` means both strongly agree and strongly disagree. Anyone joining item text to responses to learn what a value means gets a contradiction, and taking the first match reverse-codes half the items. That is worse than the #1816 doublings, where a reader saw the same thing twice rather than two opposite things.

**Only the midpoints are exact duplicates** — the neutral option is the same under either direction — which is why the whole-row check reported 9 and nearly missed it.

**Not repaired here.** Which direction is correct needs the source, and the table has no provenance row anywhere in the repo — same as `phq_insomnia_wang2025`. That is a decision, not a repair.

## The other two are what they looked like

`shu_2025_translation_eib`: one exact duplicate row. `spanishmegastudy`: one exact duplicate row among 5,080. Both minor, both real.

## Two corrections to the gate this turned up

**The message was wrong.** `dup_item_resp` called every repeated `(item, resp)` a doubled upload — right for `shu` and for #1816's three, wrong for `afps`, and it would have sent someone hunting a bad upload instead of a merged scale. Now split:

- `dup_item_resp` — repeated rows with *identical* option text → a doubled upload
- `resp_ambiguous` — one `resp` value carrying *several* labels → two scales in one table

**And it would have failed 1,270 correct items.** `spanishmegastudy` is a scored multiple-choice test: `resp` is a key, not a scale point, and three distractors per item all share `resp=0`. Under the Likert rule every one of those items is "ambiguous". A scored table — `correct_response` populated — is now judged only on whole-row duplication, which still catches its one real defect. Verified against a synthetic 199-item MC table: clean, exit 0.

Detecting "populated" needed care. **Under pandas 3, an all-NaN column keeps its values MISSING through `astype(str)`**, so a string-only emptiness test matches nothing and reads an empty column as fully populated — which read `afps` and `shu` as scored. `notna()` first.

59 tests pass, including one pinning that pandas-3 behaviour.

## What this leaves on #1816

Only decisions, no unexamined data:

- `afps_vangsness_2019` — which scale direction is correct
- `phq_insomnia_wang2025` — the missing em-dash, and the table named for the wrong instrument
- `shu_2025_translation_eib` / `spanishmegastudy` — one duplicate row each, worth a cleanup pass but not urgent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5VsAkTyiVWtFij13gVYGa