### PR TITLE
Check the contract of data/ scripts in CI, blocking only what a PR adds (#1703)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,3 +58,38 @@ jobs:
         run: |
           sudo apt-get update -qq && sudo apt-get install -y -qq r-base-core
           Rscript misc/tests/smoke_validate_irw.R
+
+  # A PR to data/ contains a conversion SCRIPT, never a table --
+  # automated_finding/irw_output/ is gitignored, so no output is ever in the
+  # diff. This checks the script's contract; the data is checked by
+  # irw-validate at processing time. See irw_validate/contract.py.
+  contract:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - run: python -m pip install --upgrade pip && python -m pip install -e .
+
+      # Added files block; modified files are annotated and never fail. 776 of
+      # the 843 scripts in data/ predate the validator rule, so failing a PR
+      # that merely edits one would stall the contributor queue this is meant
+      # to unstick.
+      - name: Contract
+        run: |
+          base="origin/${{ github.base_ref }}"
+          git fetch -q origin "${{ github.base_ref }}"
+          added=$(git diff --name-only --diff-filter=A "$base"...HEAD -- 'data/*.py' 'data/*.R' || true)
+          modified=$(git diff --name-only --diff-filter=M "$base"...HEAD -- 'data/*.py' 'data/*.R' || true)
+          if [ -z "$added$modified" ]; then echo "no data/ scripts in this PR"; exit 0; fi
+          args=""
+          for f in $added;    do args="$args --added $f";    done
+          for f in $modified; do args="$args --modified $f"; done
+          python -m irw_validate.contract --annotate $args

--- a/irw_validate/contract.py
+++ b/irw_validate/contract.py
@@ -1,0 +1,214 @@
+"""Static checks on a `data/` conversion script (#1703, sub-item 1.4).
+
+    python3 -m irw_validate.contract data/foo_2026_bar.py
+    python3 -m irw_validate.contract --added data/new.py --modified data/old.py
+
+**Why static.** Sub-item 1.4 asks for a gate on pull requests touching `data/`,
+and the obvious reading -- validate the table -- is impossible there: a PR to
+`data/` contains a *conversion script*, and `automated_finding/irw_output/` is
+gitignored, so no table is ever in the diff. Running the script in CI would mean
+fetching from Mendeley, OSF, Zenodo and Dryad, which 404, rate-limit and expire
+tokens; making corpus admission depend on a third party's uptime is a worse
+failure than the one it prevents. So CI checks the script's *contract* and
+leaves the data to `irw-validate` at processing time.
+
+**Why added files block and modified files do not.** 843 scripts live in
+`data/` and 50 of them call the validator. A rule applied to every file touched
+would fail 793 scripts for sins they were written with, and a one-line fix to a
+2019 script would be blocked by a check about something else entirely. That
+makes the contributor queue worse, which is the opposite of what 1.4 is for.
+New files carry the standard; old files get an annotation and no more.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import csv
+import pathlib
+import re
+import sys
+
+from .extra import MAX_NAME, _NAME_OK
+from .model import Finding
+
+#: A local path baked into a script means nobody else can re-run it.
+#: `data/AAQ-II.R` reads and writes `D:/Desktop/...`.
+LOCAL_PATH = re.compile(r"""['"](?:[A-Za-z]:[\\/]|/Users/|/home/|/mnt/[a-z]/)""")
+
+#: What counts as "the validator was called".
+VALIDATOR_NAMES = ("run_qc", "irw_validate", "validate_frame", "validate_file")
+
+
+def _corpus_names(root: pathlib.Path) -> set:
+    path = root / "metadata" / "metadata.csv"
+    if not path.exists():
+        return set()
+    with path.open() as fh:
+        return {r["table"] for r in csv.DictReader(fh) if r.get("table")}
+
+
+def _string_constants(tree: ast.AST):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            yield node
+
+
+def check_script(path: pathlib.Path, *, corpus: set | None = None) -> list:
+    """Findings for one conversion script. Severity is assigned by the caller."""
+    out: list = []
+    name = path.name
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return [Finding("unreadable", "error", str(exc), table=name, group="contract")]
+
+    # --- text-level: works for .R and .do too
+    for i, line in enumerate(source.splitlines(), 1):
+        if LOCAL_PATH.search(line) and not line.lstrip().startswith("#"):
+            out.append(Finding(
+                "local_path", "error",
+                f"line {i} hardcodes a path on one person's machine, so nobody else "
+                f"can re-run this script: {line.strip()[:90]}",
+                table=name, group="contract"))
+            break
+
+    if path.suffix.lower() != ".py":
+        return out          # no R parser here; the text checks are what we have
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        return out + [Finding("syntax", "error", f"does not parse: {exc}",
+                              table=name, group="contract")]
+
+    # --- the validator must run before anything is written
+    writes = [n.lineno for n in ast.walk(tree)
+              if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+              and n.func.attr in ("to_csv", "write_csv")]
+    validated = [n.lineno for n in ast.walk(tree)
+                 if isinstance(n, ast.Call)
+                 and ((isinstance(n.func, ast.Name) and n.func.id in VALIDATOR_NAMES)
+                      or (isinstance(n.func, ast.Attribute) and n.func.attr in VALIDATOR_NAMES))]
+    if writes and not validated:
+        out.append(Finding(
+            "no_validator", "error",
+            f"writes a table (line {min(writes)}) without calling the validator. "
+            f"Import `run_qc` and assert no check fails before `to_csv`, or run "
+            f"`irw-validate` on the output -- SKILL.md asks for this and nothing "
+            f"has ever enforced it.",
+            table=name, group="contract"))
+    elif writes and min(validated) > min(writes):
+        out.append(Finding(
+            "validator_after_write", "warn",
+            f"calls the validator at line {min(validated)} but writes at line "
+            f"{min(writes)} -- a table checked after it is written is not a gate.",
+            table=name, group="contract"))
+
+    # --- literal output table names
+    #
+    # Only names the script actually WRITES. An earlier version checked every
+    # string constant ending in .csv and flagged 94 scripts for the length of an
+    # *input* filename -- `raw_data_export_2019.csv` is not a table name and the
+    # 40-character cap does not apply to it. So: resolve the first argument of
+    # each to_csv call, following a simple variable assignment once, and check
+    # nothing else.
+    assigned: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant) \
+                and isinstance(node.value.value, str):
+            for t in node.targets:
+                if isinstance(t, ast.Name):
+                    assigned[t.id] = node.value.value
+
+    def written_names():
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                    and node.func.attr in ("to_csv", "write_csv") and node.args):
+                continue
+            arg = node.args[0]
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                yield node.lineno, arg.value
+            elif isinstance(arg, ast.Name) and arg.id in assigned:
+                yield node.lineno, assigned[arg.id]
+
+    seen = set()
+    for lineno, v in written_names():
+        v = v.rsplit("/", 1)[-1]
+        if not v.endswith(".csv") or "{" in v:
+            continue
+        stem = v[:-4]
+        if not stem or stem in seen:
+            continue
+        seen.add(stem)
+        node = type("N", (), {"lineno": lineno})
+        if len(stem) > MAX_NAME:
+            out.append(Finding(
+                "name_length", "error",
+                f"line {node.lineno}: table name `{stem}` is {len(stem)} characters; "
+                f"datastandard.md caps it at {MAX_NAME}.",
+                table=name, group="contract"))
+        elif not _NAME_OK.match(stem):
+            out.append(Finding(
+                "name_charset", "warn",
+                f"line {node.lineno}: table name `{stem}` is not lowercase "
+                f"[a-z0-9_.]; every client lowercases when joining.",
+                table=name, group="contract"))
+        if corpus and stem in corpus:
+            out.append(Finding(
+                "name_taken", "warn",
+                f"line {node.lineno}: `{stem}` is already a table in the corpus. "
+                f"Uploading under this name replaces it rather than adding.",
+                table=name, group="contract"))
+    return out
+
+
+def main(argv: list | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="irw_validate.contract",
+        description="Static contract checks on data/ conversion scripts.")
+    ap.add_argument("paths", nargs="*", help="scripts to check (treated as added)")
+    ap.add_argument("--added", action="append", default=[],
+                    help="a file added by this PR: findings block")
+    ap.add_argument("--modified", action="append", default=[],
+                    help="a file this PR only edits: findings are reported, never fatal")
+    ap.add_argument("--annotate", action="store_true",
+                    help="emit GitHub Actions ::error/::warning annotations")
+    args = ap.parse_args(argv)
+
+    added = [pathlib.Path(p) for p in (args.added + args.paths)]
+    modified = [pathlib.Path(p) for p in args.modified]
+    if not added and not modified:
+        print("nothing to check")
+        return 0
+
+    root = pathlib.Path(__file__).resolve().parent.parent
+    corpus = _corpus_names(root)
+    blocking = 0
+
+    for group, paths, fatal in (("added", added, True), ("modified", modified, False)):
+        for path in paths:
+            if not path.exists():
+                continue
+            findings = check_script(path, corpus=corpus)
+            if not findings:
+                print(f"ok   {path}")
+                continue
+            for f in findings:
+                level = f.severity if fatal else "warn"
+                if fatal and f.severity == "error":
+                    blocking += 1
+                print(f"{level.upper():5s} {path}: {f.check} -- {f.message}")
+                if args.annotate:
+                    kind = "error" if (fatal and f.severity == "error") else "warning"
+                    msg = f.message.replace("\n", " ")
+                    print(f"::{kind} file={path}::{f.check}: {msg}")
+
+    if blocking:
+        print(f"\n{blocking} blocking finding(s) in files this PR adds. Files it only "
+              f"edits are reported but never fail -- see irw_validate/contract.py.",
+              file=sys.stderr)
+    return 1 if blocking else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/irw_validate/tests/test_contract.py
+++ b/irw_validate/tests/test_contract.py
@@ -1,0 +1,114 @@
+"""Tests for the data/ script contract check. Offline, no network, no repo state."""
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from irw_validate.contract import check_script, main  # noqa: E402
+
+GOOD = '''
+import pandas as pd
+from irw_triage_updated import run_qc
+
+df = pd.read_csv("raw_export_from_the_repository_2019.csv")
+checks = run_qc(df)
+assert not [c for c in checks if c.status == "fail"]
+df.to_csv("author_2026_scale.csv", index=False)
+'''
+
+NO_VALIDATOR = '''
+import pandas as pd
+df = pd.read_csv("raw.csv")
+df.to_csv("author_2026_scale.csv", index=False)
+'''
+
+
+def write(d, name, body):
+    p = pathlib.Path(d) / name
+    p.write_text(body)
+    return p
+
+
+class Contract(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def checks(self, body, name="s_2026_x.py", **kw):
+        return {f.check for f in check_script(write(self.tmp.name, name, body), **kw)}
+
+    def test_a_conforming_script_is_clean(self):
+        self.assertEqual(self.checks(GOOD), set())
+
+    def test_an_input_filename_is_not_a_table_name(self):
+        # the check once flagged 94 scripts for the length of a file they READ
+        self.assertNotIn("name_length", self.checks(GOOD))
+
+    def test_writing_without_validating_is_an_error(self):
+        self.assertIn("no_validator", self.checks(NO_VALIDATOR))
+
+    def test_validating_after_writing_is_not_a_gate(self):
+        body = ('import pandas as pd\nfrom irw_triage_updated import run_qc\n'
+                'df = pd.read_csv("r.csv")\ndf.to_csv("a_2026_x.csv")\nrun_qc(df)\n')
+        self.assertIn("validator_after_write", self.checks(body))
+
+    def test_a_local_absolute_path_is_an_error(self):
+        body = GOOD.replace('"raw_export_from_the_repository_2019.csv"',
+                            '"/Users/someone/Desktop/raw.csv"')
+        self.assertIn("local_path", self.checks(body))
+
+    def test_a_commented_out_local_path_is_ignored(self):
+        body = GOOD + '\n# old: input_file = "/Users/someone/raw.csv"\n'
+        self.assertNotIn("local_path", self.checks(body))
+
+    def test_an_over_long_written_name_is_an_error(self):
+        body = GOOD.replace("author_2026_scale.csv", "a" * 41 + ".csv")
+        self.assertIn("name_length", self.checks(body))
+
+    def test_a_name_assigned_to_a_variable_is_still_checked(self):
+        body = GOOD.replace('df.to_csv("author_2026_scale.csv", index=False)',
+                            f'out = "{"a" * 41}.csv"\ndf.to_csv(out, index=False)')
+        self.assertIn("name_length", self.checks(body))
+
+    def test_a_name_already_in_the_corpus_warns(self):
+        got = self.checks(GOOD, corpus={"author_2026_scale"})
+        self.assertIn("name_taken", got)
+
+    def test_r_scripts_get_the_text_checks_only(self):
+        body = 'd <- read.csv("/Users/someone/raw.csv")\n'
+        got = self.checks(body, name="s_2026_x.R")
+        self.assertEqual(got, {"local_path"})
+
+    def test_a_file_that_does_not_parse_is_reported_not_crashed(self):
+        self.assertIn("syntax", self.checks("def (:\n"))
+
+
+class Cli(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_added_files_block(self):
+        p = write(self.tmp.name, "new_2026_x.py", NO_VALIDATOR)
+        self.assertEqual(main(["--added", str(p)]), 1)
+
+    def test_modified_files_never_block(self):
+        # 776 of 843 existing scripts would fail no_validator; blocking on an
+        # edit to one of them would stall the queue this check exists to unstick
+        p = write(self.tmp.name, "old_2019_x.py", NO_VALIDATOR)
+        self.assertEqual(main(["--modified", str(p)]), 0)
+
+    def test_a_clean_added_file_passes(self):
+        p = write(self.tmp.name, "new_2026_x.py", GOOD)
+        self.assertEqual(main(["--added", str(p)]), 0)
+
+    def test_nothing_to_check_is_success(self):
+        self.assertEqual(main([]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The second half of sub-item **1.4**. The first half — run the tests — shipped in #1821. This is the gate on PRs touching `data/`, and it completes roadmap item 1.

## The obvious reading of 1.4 cannot be done

1.4 says "gate PRs to `src/data/`", which sounds like *validate the table*. There is no table. A PR to `data/` contains a **conversion script**, and `automated_finding/irw_output/` is gitignored, so output is never in the diff.

Running the script in CI would mean fetching from Mendeley, OSF, Zenodo and Dryad — which 404, rate-limit and expire tokens. Making corpus admission depend on a third party's uptime is a worse failure than the one it prevents, and it teaches people to ignore red marks. So CI checks the script's **contract**, and the data is checked by `irw-validate` at processing time, where the frame is already in memory.

## What it checks

- the validator is called **before** anything is written (and warns if called after, which is not a gate)
- written table names obey the 40-character cap and the lowercase rule
- no path baked into one person's machine

R and Stata files get the path check only — there is no R parser here, and 390 `.R` scripts predate every one of these rules.

## Added files block; modified files never do

843 scripts live in `data/` and **50** call the validator. Applied to every file a PR touches, this would fail 793 of them for sins they were written with — and a one-line fix to a 2019 script would be blocked by a check about something else entirely. That makes the contributor queue worse, which is the opposite of what 1.4 is for: five of the eight open PRs still have no review.

## Calibrated against the corpus, not guessed

My first version flagged every string constant ending in `.csv` and failed **94** scripts for the length of a file they *read*. `raw_data_export_2019.csv` is not a table name. Narrowing to the first argument of each `to_csv` call, following a simple variable assignment once:

| check | before | after |
|---|---|---|
| `name_length` | 94 | **1** |
| `name_charset` | 533 | **13** |
| `name_taken` | 531 | **11** |

The survivors are real — a 48-character table name in `developmental_delay_anunciacao_2026.py`, `OUS-FR_irw_format` and `Karim2022_tmoca_mci` among the uppercase names, and **25 scripts with a `/Users/...` path** that means nobody else can re-run them.

`no_validator` stays at 776. That is the honest state of the corpus, and exactly why blocking is scoped to added files.

## Verified end to end

Ran the workflow's exact shell sequence against a real branch diff:

```
added: data/zz_smoke_2026_test.py
ERROR local_path   -- line 2 hardcodes a path on one person's machine ...
ERROR no_validator -- writes a table (line 3) without calling the validator ...
ERROR name_length  -- `zz_..._exceeding_the_cap` is 54 characters ...
::error file=data/zz_smoke_2026_test.py::local_path: ...
exit=1
```

and the same file passed as `--modified` reports three warnings and **exits 0**. The scratch file was deleted; the tree is clean.

44 tests pass, including the input-filename false positive and the added-blocks/modified-does-not split.

Completes #1703 sub-item 1.4. Item 1's remaining piece is 1.5, the 922 legacy `.Rdata` sweep, which is a one-off local pass rather than CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5VsAkTyiVWtFij13gVYGa