### PR TITLE
Sweep the 922 legacy tables — and find that data/pub is not the corpus (#1703, 1.5)

### DIFF
--- a/irw_validate/core.py
+++ b/irw_validate/core.py
@@ -139,6 +139,22 @@ def validate_frame(df, *, label: str = "", profile: str = "upload",
         report.findings.append(
             Finding(check.name, severity, check.detail, table=table, group=group))
 
+    # `resp_numeric` as inherited from run_qc measures how many values parse as
+    # numbers over ALL rows, so a float column with missing values fails it --
+    # NaN does not parse. That conflates "not a number" with "not present", and
+    # `resp_na` already reports the second. In the legacy sweep it flagged
+    # 16_personalityfactors, whose resp is float64 and 99% non-null.
+    #
+    # Triage keeps the inherited behaviour (50 callers depend on it); the gate
+    # profiles re-judge it over non-null values only.
+    if profile in ("upload", "legacy") and "resp" in df.columns:
+        import pandas as pd
+        present = df["resp"].dropna()
+        if len(present):
+            parses = pd.to_numeric(present, errors="coerce").notna().mean()
+            if parses >= 0.99:
+                report.findings = [f for f in report.findings if f.check != "resp_numeric"]
+
     if profile in ("upload", "legacy"):
         for finding in (extra.check_name(table)
                         + extra.check_shape(df, table)

--- a/irw_validate/core.py
+++ b/irw_validate/core.py
@@ -15,11 +15,18 @@ from .model import Finding, Report, severity_for
 MAX_BYTES = 512 * 1024 ** 2
 
 
+#: Every extension a table can arrive as. Matched case-insensitively: the legacy
+#: files are `.Rdata`, and stripping only `.csv` made every one of the 922 fail
+#: the lowercase-name rule on the capital R of its own extension.
+TABLE_SUFFIXES = (".csv", ".tsv", ".txt", ".rdata", ".rda", ".rds")
+
+
 def _table_name(label: str) -> str:
     stem = Path(label).name
-    for suffix in (".csv", ".tsv"):
-        if stem.endswith(suffix):
-            stem = stem[: -len(suffix)]
+    low = stem.lower()
+    for suffix in TABLE_SUFFIXES:
+        if low.endswith(suffix):
+            return stem[: -len(suffix)]
     return stem
 
 
@@ -175,6 +182,22 @@ def validate_file(path, *, label: str | None = None, profile: str = "upload",
     import pandas as pd  # deferred: red_up must import this module without pandas
     if path.suffix.lower() in (".csv", ".tsv", ".txt"):
         df = pd.read_csv(path, sep=None, engine="python")
+    elif path.suffix.lower() in (".rdata", ".rda", ".rds"):
+        # The 922 legacy tables in ../data/pub/ (#1703 sub-item 1.5). Not
+        # routed through irw_triage_updated.load_table because that pulls in
+        # the whole discovery pipeline for a two-line read.
+        import pyreadr
+        objs = pyreadr.read_r(str(path))
+        if not objs:
+            raise ValueError(f"{path.name} holds no R object")
+        if len(objs) > 1:
+            # An IRW table file should hold exactly one data frame. More than
+            # one means the file is carrying something else besides the table,
+            # and picking silently would validate the wrong object.
+            raise ValueError(
+                f"{path.name} holds {len(objs)} R objects "
+                f"({', '.join(str(k) for k in objs)}); expected one table")
+        df = next(iter(objs.values()))
     else:
         import sys
         sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "automated_finding"))

--- a/irw_validate/results/README.md
+++ b/irw_validate/results/README.md
@@ -1,0 +1,76 @@
+# Legacy sweep, 2026-09-02 — and why its findings are a candidate list
+
+`legacy_sweep_2026-09-02.csv` is the first run of `irw-validate` over the 922
+`.Rdata` tables in `../data/pub/` (#1703 sub-item 1.5). No checker had ever
+touched them.
+
+```
+nice -n 19 python3 -m irw_validate.sweep_legacy ../data/pub \
+    -o irw_validate/results/legacy_sweep_2026-09-02.csv --resume --max-mb 8
+```
+
+852 tables opened, 70 deferred by the 8 MB cap, 28 with nothing to report.
+
+## Read this before acting on the findings
+
+**`data/pub/` is not a faithful mirror of what is published.** Comparing each
+archive file's row count against `metadata/metadata.csv`:
+
+| | tables |
+|---|---|
+| archive matches published exactly | 603 |
+| differs by under 1% | 125 |
+| archive holds 50–99% of published | 65 |
+| archive holds under 50% | 3 |
+| **archive is empty, published is not** | **16** |
+| archive holds *more* than published | 2 |
+
+The under-1% group is most likely an artefact of the comparison rather than
+drift — this sweep counts rows with a non-null `resp`, and `metadata.csv` may
+not. The other 86 are real divergence.
+
+**The 16 empty ones are every PISA cycle from 2000 to 2012** — `pisa2000_math`
+through `pisa2012_science`. Each is a 4 KB file holding the right columns and
+**zero rows**, while the published tables hold between 1.5M and 22.6M responses.
+The newer cycles (2015, 2018, 2022) are the real 130–196 MB files. So the local
+archive lost the older PISA data at some point, and nothing noticed because
+nothing reads these files.
+
+**56 of the 131 tables with an error have an archive copy that differs from what
+is published.** So more than a third of the errors below may be defects in a
+stale local file rather than in the corpus. Confirm against live data before
+treating any single finding as a corpus defect.
+
+## What it found, in the 852 opened
+
+Errors:
+
+| check | tables | |
+|---|---|---|
+| `dup_id_item` | 101 | the same person answering the same item twice, with no `wave`/`timepoint`/`date` to distinguish them |
+| `name_length` | 19 | over the 40-character cap — `threatperceptions_isler_2024_*` accounts for 11 |
+| `id_na` / `item_na` / `resp_na` | 16 | the empty PISA files above |
+| `resp_variation*` | 16 | the same 16 |
+
+Warnings worth a look: `imputed_values*` (557), `column_order` (444),
+`name_charset` (254 — the known non-lowercase names), `cov_range` (24, the
+#1779 class), `sample_floor` (52 under 100 respondents).
+
+## One correction this sweep forced
+
+`resp_numeric` as inherited from `run_qc` measures how many values parse as
+numbers over **all** rows, so NaN counts as "does not parse". A float column
+with missing values therefore failed it — and `resp_na` already reports
+missingness. That produced 86 false errors here, including
+`BAFACALO_Golino_2013_CIS`, whose `resp` is 39% null and **100% numeric over the
+values that are present**.
+
+The gate profiles (`upload`, `legacy`) now re-judge it over non-null values.
+`triage` keeps the inherited behaviour, because fifty scripts in `data/` depend
+on it.
+
+## What should happen next
+
+The useful version of 1.5 points at **live data**, not this directory. The
+tooling is the same; only the loader changes. This run's value is the candidate
+list and the fidelity measurement above — not a verdict on the corpus.

--- a/irw_validate/results/legacy_sweep_2026-09-02.csv
+++ b/irw_validate/results/legacy_sweep_2026-09-02.csv
@@ -1,0 +1,2270 @@
+table,check,severity,message,n_rows,n_items,n_participants
+16_personalityfactors,resp_na,warn,resp has 98919 NAs,7913998,163,49004
+4thgrade_math_sirt,imputed_values*,warn,Item 'MA1' has one resp value accounting for 89% of responses — possible mean imputation.,19920,30,664
+4thgrade_math_sirt,multi_scale*,warn,"Item names suggest 7 subscales (['ma', 'mb', 'mc', 'md']) — IRW requires separate tables per construct.",19920,30,664
+4thgrade_math_sirt,column_order,warn,"columns start ['item', 'id', 'resp']; datastandard.md step 7 writes [id, item, resp] + covariates.",19920,30,664
+5personalityfactors,resp_na,warn,resp has 3675 NAs,623105,70,8936
+5personalityfactors,dup_id_item,error,1260 duplicate id+item rows with no wave/timepoint/date column,623105,70,8936
+AAQ-II,dup_id_item,error,42 duplicate id+item rows with no wave/timepoint/date column,10521,7,1497
+AAQ-II,name_charset,warn,"table name 'AAQ-II' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",10521,7,1497
+AAQ-II,column_order,warn,"columns start ['id', 'age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",10521,7,1497
+ALSECYPIAMH_WU_2022_CPS,name_charset,warn,"table name 'ALSECYPIAMH_WU_2022_CPS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",114804,12,9567
+ALSECYPIAMH_WU_2022_Empathy,name_charset,warn,"table name 'ALSECYPIAMH_WU_2022_Empathy' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",54894,7,7842
+ALSECYPIAMH_WU_2022_MIL,multi_scale*,warn,"Item names suggest 2 subscales (['mils', 'milp']) — IRW requires separate tables per construct.",78420,10,7842
+ALSECYPIAMH_WU_2022_MIL,name_charset,warn,"table name 'ALSECYPIAMH_WU_2022_MIL' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",78420,10,7842
+ALSECYPIAMH_WU_2022_NEI,imputed_values*,warn,Item 'NEI1' has one resp value accounting for 71% of responses — possible mean imputation.,39210,5,7842
+ALSECYPIAMH_WU_2022_NEI,name_charset,warn,"table name 'ALSECYPIAMH_WU_2022_NEI' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",39210,5,7842
+ALSECYPIAMH_WU_2022_PEI,imputed_values*,warn,Item 'PEI1' has one resp value accounting for 64% of responses — possible mean imputation.,39210,5,7842
+ALSECYPIAMH_WU_2022_PEI,name_charset,warn,"table name 'ALSECYPIAMH_WU_2022_PEI' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",39210,5,7842
+ALSECYPIAMH_WU_2022_PHQ,name_charset,warn,"table name 'ALSECYPIAMH_WU_2022_PHQ' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",15684,2,7842
+ALSECYPIAMH_WU_2022_PIL,name_charset,warn,"table name 'ALSECYPIAMH_WU_2022_PIL' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",31368,4,7842
+ALSECYPIAMH_WU_2022_SDQ,name_charset,warn,"table name 'ALSECYPIAMH_WU_2022_SDQ' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",47046,6,7841
+ALSECYPIAMH_WU_2022_SWEMWBS,name_charset,warn,"table name 'ALSECYPIAMH_WU_2022_SWEMWBS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",54894,7,7842
+ALSECYPIAMH_WU_2022_SWLS,name_charset,warn,"table name 'ALSECYPIAMH_WU_2022_SWLS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",39210,5,7842
+AMI_CV_Hewitt2024,resp_na,warn,resp has 5 NAs,3397,18,189
+AMI_CV_Hewitt2024,name_charset,warn,"table name 'AMI_CV_Hewitt2024' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3397,18,189
+AMI_CV_Hewitt2024,column_order,warn,"columns start ['id', 'age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",3397,18,189
+AOMT_BR_SF_EDPANAB_Geiger_2021_AOT,dup_id_item,error,3094 duplicate id+item rows with no wave/timepoint/date column,7098,14,286
+AOMT_BR_SF_EDPANAB_Geiger_2021_AOT,imputed_values*,warn,Item 'AOT10' has one resp value accounting for 68% of responses — possible mean imputation.,7098,14,286
+AOMT_BR_SF_EDPANAB_Geiger_2021_AOT,name_charset,warn,"table name 'AOMT_BR_SF_EDPANAB_Geiger_2021_AOT' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",7098,14,286
+AOMT_BR_SF_EDPANAB_Geiger_2021_BRS,dup_id_item,error,4420 duplicate id+item rows with no wave/timepoint/date column,10140,20,286
+AOMT_BR_SF_EDPANAB_Geiger_2021_BRS,multi_scale*,warn,"Item names suggest 2 subscales (['bsr', 'mot']) — IRW requires separate tables per construct.",10140,20,286
+AOMT_BR_SF_EDPANAB_Geiger_2021_BRS,name_charset,warn,"table name 'AOMT_BR_SF_EDPANAB_Geiger_2021_BRS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",10140,20,286
+AOMT_BR_SF_EDPANAB_Geiger_2021_RF,dup_id_item,error,6188 duplicate id+item rows with no wave/timepoint/date column,14196,28,286
+AOMT_BR_SF_EDPANAB_Geiger_2021_RF,multi_scale*,warn,"Item names suggest 4 subscales (['afp', 'rcg', 'rcl', 'afn']) — IRW requires separate tables per construct.",14196,28,286
+AOMT_BR_SF_EDPANAB_Geiger_2021_RF,name_charset,warn,"table name 'AOMT_BR_SF_EDPANAB_Geiger_2021_RF' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",14196,28,286
+Adherence_Zissette_2018_SDB,imputed_values*,warn,Item 'q_s_025_SDB' has one resp value accounting for 88% of responses — possible mean imputation.,18409,26,709
+Adherence_Zissette_2018_SDB,name_charset,warn,"table name 'Adherence_Zissette_2018_SDB' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",18409,26,709
+Aspirations_Sonmez_2023,resp_na,warn,resp has 4 NAs,16551,35,265
+Aspirations_Sonmez_2023,dup_id_item,error,7280 duplicate id+item rows with no wave/timepoint/date column,16551,35,265
+Aspirations_Sonmez_2023,imputed_values*,warn,Item 'Asp11_Relationships' has one resp value accounting for 75% of responses — possible mean imputation.,16551,35,265
+Aspirations_Sonmez_2023,name_charset,warn,"table name 'Aspirations_Sonmez_2023' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",16551,35,265
+BAFACALO_Golino_2013_BVPS,resp_na,warn,resp has 2046 NAs,16058,62,292
+BAFACALO_Golino_2013_BVPS,imputed_values*,warn,Item 'CFi01' has one resp value accounting for 87% of responses — possible mean imputation.,16058,62,292
+BAFACALO_Golino_2013_BVPS,multi_scale*,warn,"Item names suggest 2 subscales (['cfi', 'vzi']) — IRW requires separate tables per construct.",16058,62,292
+BAFACALO_Golino_2013_BVPS,name_charset,warn,"table name 'BAFACALO_Golino_2013_BVPS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",16058,62,292
+BAFACALO_Golino_2013_BVPS,column_order,warn,"columns start ['id', 'age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",16058,62,292
+BAFACALO_Golino_2013_CIS,resp_na,warn,resp has 6911 NAs,10609,60,292
+BAFACALO_Golino_2013_CIS,imputed_values*,warn,Item 'V1i01' has one resp value accounting for 75% of responses — possible mean imputation.,10609,60,292
+BAFACALO_Golino_2013_CIS,name_charset,warn,"table name 'BAFACALO_Golino_2013_CIS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",10609,60,292
+BAFACALO_Golino_2013_CIS,column_order,warn,"columns start ['id', 'age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",10609,60,292
+BAFACALO_Golino_2013_FIS,resp_na,warn,resp has 2888 NAs,14632,60,292
+BAFACALO_Golino_2013_FIS,imputed_values*,warn,Item 'Ii01' has one resp value accounting for 96% of responses — possible mean imputation.,14632,60,292
+BAFACALO_Golino_2013_FIS,multi_scale*,warn,"Item names suggest 3 subscales (['rli', 'ii', 'rgi']) — IRW requires separate tables per construct.",14632,60,292
+BAFACALO_Golino_2013_FIS,name_charset,warn,"table name 'BAFACALO_Golino_2013_FIS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",14632,60,292
+BAFACALO_Golino_2013_FIS,column_order,warn,"columns start ['id', 'age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",14632,60,292
+BAFACALO_Golino_2013_SMS,resp_na,warn,resp has 3199 NAs,7605,37,292
+BAFACALO_Golino_2013_SMS,imputed_values*,warn,Item 'MA1i01' has one resp value accounting for 77% of responses — possible mean imputation.,7605,37,292
+BAFACALO_Golino_2013_SMS,multi_scale*,warn,"Item names suggest 3 subscales (['ma', 'mvio', 'mvi']) — IRW requires separate tables per construct.",7605,37,292
+BAFACALO_Golino_2013_SMS,name_charset,warn,"table name 'BAFACALO_Golino_2013_SMS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",7605,37,292
+BAFACALO_Golino_2013_SMS,column_order,warn,"columns start ['id', 'age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",7605,37,292
+BPAQ_Christopher_2024_BPAQSF,resp_na,warn,resp has 672 NAs,3408,12,170
+BPAQ_Christopher_2024_BPAQSF,dup_id_item,warn,2040 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),3408,12,170
+BPAQ_Christopher_2024_BPAQSF,imputed_values*,warn,Item 'bpaqsf_q12' has one resp value accounting for 69% of responses — possible mean imputation.,3408,12,170
+BPAQ_Christopher_2024_BPAQSF,name_charset,warn,"table name 'BPAQ_Christopher_2024_BPAQSF' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3408,12,170
+BPAQ_Christopher_2024_BPAQSF,column_order,warn,"columns start ['id', 'group', 'treat']; datastandard.md step 7 writes [id, item, resp] + covariates.",3408,12,170
+BPAQ_Christopher_2024_FFMQSF,resp_na,warn,resp has 4 NAs,2546,15,170
+BPAQ_Christopher_2024_FFMQSF,name_charset,warn,"table name 'BPAQ_Christopher_2024_FFMQSF' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2546,15,170
+BPAQ_Christopher_2024_OBSI,name_charset,warn,"table name 'BPAQ_Christopher_2024_OBSI' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2720,16,170
+BPAQ_Christopher_2024_PCL5,imputed_values*,warn,Item 'pcl5_q12_b' has one resp value accounting for 61% of responses — possible mean imputation.,2180,20,109
+BPAQ_Christopher_2024_PCL5,name_charset,warn,"table name 'BPAQ_Christopher_2024_PCL5' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2180,20,109
+BPAQ_Christopher_2024_PROMIS,resp_na,warn,resp has 762 NAs,3318,24,170
+BPAQ_Christopher_2024_PROMIS,imputed_values*,warn,Item 'promis_alc1_b' has one resp value accounting for 68% of responses — possible mean imputation.,3318,24,170
+BPAQ_Christopher_2024_PROMIS,name_charset,warn,"table name 'BPAQ_Christopher_2024_PROMIS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3318,24,170
+BPAQ_Christopher_2024_PSS10,name_charset,warn,"table name 'BPAQ_Christopher_2024_PSS10' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1090,10,109
+BPAQ_Christopher_2024_SCSS,resp_na,warn,resp has 1 NAs,2039,12,170
+BPAQ_Christopher_2024_SCSS,name_charset,warn,"table name 'BPAQ_Christopher_2024_SCSS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2039,12,170
+BSCS_fadplus_goto2021,name_charset,warn,"table name 'BSCS_fadplus_goto2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",10426,13,802
+BSCS_fadplus_goto2021,column_order,warn,"columns start ['id', 'age', 'gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",10426,13,802
+CBI_Rodriguez_2021,imputed_values*,warn,Item 'cbi10' has one resp value accounting for 84% of responses — possible mean imputation.,58296,28,2082
+CBI_Rodriguez_2021,name_charset,warn,"table name 'CBI_Rodriguez_2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",58296,28,2082
+CFC_Balaji_2019,name_charset,warn,"table name 'CFC_Balaji_2019' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1584,12,132
+CHEXI_Lin_2019,resp_na,warn,resp has 289 NAs,52799,24,2212
+CHEXI_Lin_2019,name_charset,warn,"table name 'CHEXI_Lin_2019' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",52799,24,2212
+COACH_Chen_2022_ADL,dup_id_item,warn,62557 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),95653,14,2364
+COACH_Chen_2022_ADL,imputed_values*,warn,Item 'ra_adl_q10' has one resp value accounting for 67% of responses — possible mean imputation.,95653,14,2364
+COACH_Chen_2022_ADL,name_charset,warn,"table name 'COACH_Chen_2022_ADL' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",95653,14,2364
+COACH_Chen_2022_ADL,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",95653,14,2364
+COACH_Chen_2022_CSQ,name_charset,warn,"table name 'COACH_Chen_2022_CSQ' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",18891,8,2362
+COACH_Chen_2022_CSQ,column_order,warn,"columns start ['id', 'resp', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",18891,8,2362
+COACH_Chen_2022_HDRS,dup_id_item,warn,191801 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),232006,17,2365
+COACH_Chen_2022_HDRS,imputed_values*,warn,Item 'ra_hdrs_q17' has one resp value accounting for 90% of responses — possible mean imputation.,232006,17,2365
+COACH_Chen_2022_HDRS,name_charset,warn,"table name 'COACH_Chen_2022_HDRS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",232006,17,2365
+COACH_Chen_2022_HDRS,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",232006,17,2365
+COACH_Chen_2022_IADL,dup_id_item,warn,35741 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),54653,8,2364
+COACH_Chen_2022_IADL,imputed_values*,warn,Item 'ra_iadl_q7' has one resp value accounting for 67% of responses — possible mean imputation.,54653,8,2364
+COACH_Chen_2022_IADL,name_charset,warn,"table name 'COACH_Chen_2022_IADL' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",54653,8,2364
+COACH_Chen_2022_IADL,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",54653,8,2364
+COACH_Chen_2022_MOS_SSS_C,dup_id_item,warn,84731 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),129644,19,2364
+COACH_Chen_2022_MOS_SSS_C,name_charset,warn,"table name 'COACH_Chen_2022_MOS_SSS_C' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",129644,19,2364
+COACH_Chen_2022_MOS_SSS_C,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",129644,19,2364
+COACH_Chen_2022_PHQ9,dup_id_item,warn,101378 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),122645,9,2363
+COACH_Chen_2022_PHQ9,imputed_values*,warn,Item 'pcp_phq9_q9' has one resp value accounting for 95% of responses — possible mean imputation.,122645,9,2363
+COACH_Chen_2022_PHQ9,name_charset,warn,"table name 'COACH_Chen_2022_PHQ9' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",122645,9,2363
+COACH_Chen_2022_PHQ9,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",122645,9,2363
+COACH_Chen_2022_SNS,dup_id_item,warn,24270 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),50272,11,2364
+COACH_Chen_2022_SNS,imputed_values*,warn,Item 'ra_social_network_size_q9' has one resp value accounting for 70% of responses — possible mean imputation.,50272,11,2364
+COACH_Chen_2022_SNS,name_charset,warn,"table name 'COACH_Chen_2022_SNS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",50272,11,2364
+COACH_Chen_2022_SNS,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",50272,11,2364
+COACH_Chen_2022_WHOQOL_BREF,dup_id_item,warn,114914 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),176081,26,2364
+COACH_Chen_2022_WHOQOL_BREF,name_charset,warn,"table name 'COACH_Chen_2022_WHOQOL_BREF' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",176081,26,2364
+COACH_Chen_2022_WHOQOL_BREF,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",176081,26,2364
+COACH_Chen_2022_treatmentStigma,dup_id_item,warn,6627 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),13722,3,2365
+COACH_Chen_2022_treatmentStigma,imputed_values*,warn,Item 'ra_treatment_stigma_2' has one resp value accounting for 70% of responses — possible mean imputation.,13722,3,2365
+COACH_Chen_2022_treatmentStigma,name_charset,warn,"table name 'COACH_Chen_2022_treatmentStigma' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",13722,3,2365
+COACH_Chen_2022_treatmentStigma,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",13722,3,2365
+CPDMMC_Kunnari_2020_HCD,name_charset,warn,"table name 'CPDMMC_Kunnari_2020_HCD' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",12516,12,1043
+CPDMMC_Kunnari_2020_PDP,imputed_values*,warn,Item 'AB_C' has one resp value accounting for 75% of responses — possible mean imputation.,18774,18,1043
+CPDMMC_Kunnari_2020_PDP,name_charset,warn,"table name 'CPDMMC_Kunnari_2020_PDP' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",18774,18,1043
+CQTMS_Hur_2023,resp_na,warn,resp has 157 NAs,122563,160,767
+CQTMS_Hur_2023,imputed_values*,warn,Item 'itm118' has one resp value accounting for 61% of responses — possible mean imputation.,122563,160,767
+CQTMS_Hur_2023,name_charset,warn,"table name 'CQTMS_Hur_2023' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",122563,160,767
+CSE_Bayazit_2022,name_charset,warn,"table name 'CSE_Bayazit_2022' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",9765,15,651
+CV_OASIS_ODSIS_PPE_Novak_2020_BFI,dup_id_item,error,8 duplicate id+item rows with no wave/timepoint/date column,19280,8,2409
+CV_OASIS_ODSIS_PPE_Novak_2020_BFI,name_charset,warn,"table name 'CV_OASIS_ODSIS_PPE_Novak_2020_BFI' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",19280,8,2409
+CV_OASIS_ODSIS_PPE_Novak_2020_DSES,dup_id_item,error,7 duplicate id+item rows with no wave/timepoint/date column,17325,7,2474
+CV_OASIS_ODSIS_PPE_Novak_2020_DSES,imputed_values*,warn,Item 'DSES_10' has one resp value accounting for 61% of responses — possible mean imputation.,17325,7,2474
+CV_OASIS_ODSIS_PPE_Novak_2020_DSES,name_charset,warn,"table name 'CV_OASIS_ODSIS_PPE_Novak_2020_DSES' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",17325,7,2474
+CV_OASIS_ODSIS_PPE_Novak_2020_PANAS,imputed_values*,warn,Item 'panas_13' has one resp value accounting for 78% of responses — possible mean imputation.,29160,20,1458
+CV_OASIS_ODSIS_PPE_Novak_2020_PANAS,name_charset,warn,"table name 'CV_OASIS_ODSIS_PPE_Novak_2020_PANAS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",29160,20,1458
+CV_OASIS_ODSIS_PPE_Novak_2020_RSES,dup_id_item,error,10 duplicate id+item rows with no wave/timepoint/date column,23740,10,2373
+CV_OASIS_ODSIS_PPE_Novak_2020_RSES,imputed_values*,warn,Item 'RSES_1' has one resp value accounting for 61% of responses — possible mean imputation.,23740,10,2373
+CV_OASIS_ODSIS_PPE_Novak_2020_RSES,name_charset,warn,"table name 'CV_OASIS_ODSIS_PPE_Novak_2020_RSES' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",23740,10,2373
+DART_Brysbaert_2020_1,imputed_values*,warn,Item 'Is de volgende persoon een auteur- [1mes Patterson]' has one resp value accounting for 68% of responses — possible mean imputation.,26268,132,199
+DART_Brysbaert_2020_1,name_charset,warn,"table name 'DART_Brysbaert_2020_1' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",26268,132,199
+DART_Brysbaert_2020_1,column_order,warn,"columns start ['id', 'gender', 'age']; datastandard.md step 7 writes [id, item, resp] + covariates.",26268,132,199
+DART_Brysbaert_2020_3.4.5,resp_na,warn,resp has 124 NAs,28784,262,219
+DART_Brysbaert_2020_3.4.5,imputed_values*,warn,Item 'AFTh_Van_der_Heijden' has one resp value accounting for 94% of responses — possible mean imputation.,28784,262,219
+DART_Brysbaert_2020_3.4.5,name_charset,warn,"table name 'DART_Brysbaert_2020_3.4.5' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",28784,262,219
+DEMOS,resp_ordinal*,warn,"2876 distinct resp values — confirm continuous, not mis-parsed",10656,4,2664
+DEMOS,resp_scale_mixed,warn,"items span more than one response scale: 1 on 0.0-1.0 and 3 on ['3.61904761904762-8.61904761904762', '119.769-1121.863', '2.04761904761905-8.45238095238095']. IRW requires one table per construct; split before submitting.",10656,4,2664
+DEMOS,composite_items*,warn,"every item label names a computed score (['accuracy_mean', 'intensity_mean', 'subj_move_mean', 'obj_move_mean']) — this looks like a summary/aggregate table, not raw item-level responses",10656,4,2664
+DEMOS,name_charset,warn,"table name 'DEMOS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",10656,4,2664
+DMCT_Addis_2020_MCT,imputed_values*,warn,Item 'MC10_acc' has one resp value accounting for 100% of responses — possible mean imputation.,4048,44,92
+DMCT_Addis_2020_MCT,resp_scale_mixed,warn,items span more than one response scale: 24 on 1-1 and 20 on ['2-2']. IRW requires one table per construct; split before submitting.,4048,44,92
+DMCT_Addis_2020_MCT,name_charset,warn,"table name 'DMCT_Addis_2020_MCT' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",4048,44,92
+DMCT_Addis_2020_MCT,sample_floor,warn,"92 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",4048,44,92
+DMCT_Addis_2020_PSYQ,multi_scale*,warn,"Item names suggest 2 subscales (['psyq', 'psiq']) — IRW requires separate tables per construct.",3220,35,92
+DMCT_Addis_2020_PSYQ,resp_scale_mixed,warn,items span more than one response scale: 15 on 1-10 and 14 on ['0-10']. IRW requires one table per construct; split before submitting.,3220,35,92
+DMCT_Addis_2020_PSYQ,name_charset,warn,"table name 'DMCT_Addis_2020_PSYQ' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3220,35,92
+DMCT_Addis_2020_PSYQ,sample_floor,warn,"92 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",3220,35,92
+DMCT_Addis_2020_SUIS,name_charset,warn,"table name 'DMCT_Addis_2020_SUIS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1656,18,92
+DMCT_Addis_2020_SUIS,sample_floor,warn,"92 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",1656,18,92
+DbdIFdM_Puga_2021,name_charset,warn,"table name 'DbdIFdM_Puga_2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",7602,14,543
+EEEDPRM_Bulut_2021,name_charset,warn,"table name 'EEEDPRM_Bulut_2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",9610,10,961
+EEEDPRM_Bulut_2021,column_order,warn,"columns start ['id', 'gender', 'age']; datastandard.md step 7 writes [id, item, resp] + covariates.",9610,10,961
+EEN_Lacey_2024_Children,imputed_values*,warn,Item 'anxiety_major' has one resp value accounting for 93% of responses — possible mean imputation.,30524,13,2348
+EEN_Lacey_2024_Children,resp_scale_mixed,warn,items span more than one response scale: 5 on 1-5 and 4 on ['0-1']. IRW requires one table per construct; split before submitting.,30524,13,2348
+EEN_Lacey_2024_Children,name_charset,warn,"table name 'EEN_Lacey_2024_Children' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",30524,13,2348
+EEN_Lacey_2024_Children,column_order,warn,"columns start ['id', 'treat', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",30524,13,2348
+EEN_Lacey_2024_Parent,resp_na,warn,resp has 184 NAs,59456,24,2485
+EEN_Lacey_2024_Parent,imputed_values*,warn,Item 'anxiety_major' has one resp value accounting for 85% of responses — possible mean imputation.,59456,24,2485
+EEN_Lacey_2024_Parent,treat_binary*,warn,treat has non-0/1 values [np.int32(2)],59456,24,2485
+EEN_Lacey_2024_Parent,multi_scale*,warn,"Item names suggest 4 subscales (['mh', 'covid', 'counsellor', 'counselling']) — IRW requires separate tables per construct.",59456,24,2485
+EEN_Lacey_2024_Parent,resp_scale_mixed,warn,"items span more than one response scale: 9 on 0-1 and 15 on ['1-2', '1-5', '0-2']. IRW requires one table per construct; split before submitting.",59456,24,2485
+EEN_Lacey_2024_Parent,name_charset,warn,"table name 'EEN_Lacey_2024_Parent' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",59456,24,2485
+EEN_Lacey_2024_Parent,column_order,warn,"columns start ['id', 'treat', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",59456,24,2485
+EMSC_Kuan-chin_2023,resp_na,warn,resp has 8 NAs,685,7,99
+EMSC_Kuan-chin_2023,imputed_values*,warn,Item 'STN10RES_COLS' has one resp value accounting for 65% of responses — possible mean imputation.,685,7,99
+EMSC_Kuan-chin_2023,item_scale_outlier,warn,1 item(s) fall outside the table's 2-5 scale: ['STN10ASE_COLS']. An isolated out-of-range column is usually not an item -- check for an administrative or count field.,685,7,99
+EMSC_Kuan-chin_2023,name_charset,warn,"table name 'EMSC_Kuan-chin_2023' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",685,7,99
+EMSC_Kuan-chin_2023,sample_floor,warn,"99 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",685,7,99
+EWAS_Sanford_2024,dup_id_item,error,1416 duplicate id+item rows with no wave/timepoint/date column,9972,30,482
+EWAS_Sanford_2024,multi_scale*,warn,"Item names suggest 5 subscales (['mea', 'sat', 'enri', 'enga']) — IRW requires separate tables per construct.",9972,30,482
+EWAS_Sanford_2024,resp_scale_mixed,warn,items span more than one response scale: 20 on 1-6 and 5 on ['1-7']. IRW requires one table per construct; split before submitting.,9972,30,482
+EWAS_Sanford_2024,name_charset,warn,"table name 'EWAS_Sanford_2024' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",9972,30,482
+EWAS_Sanford_2024_Flourish,name_charset,warn,"table name 'EWAS_Sanford_2024_Flourish' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3856,8,482
+Ellipse_Corssley_2024,dup_id_item,error,71120 duplicate id+item rows with no wave/timepoint/date column,142240,8,8890
+Ellipse_Corssley_2024,imputed_values*,warn,Item 'Identifying_Info' has one resp value accounting for 99% of responses — possible mean imputation.,142240,8,8890
+Ellipse_Corssley_2024,composite_items*,warn,"1/8 item labels name computed scores (['Overall']) — drop them, or confirm they are real items",142240,8,8890
+Ellipse_Corssley_2024,name_charset,warn,"table name 'Ellipse_Corssley_2024' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",142240,8,8890
+Ellipse_Corssley_2024,column_order,warn,"columns start ['id', 'rater', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",142240,8,8890
+FACES_Spanish_Vegas_2022_FACES,resp_na,warn,resp has 844 NAs,49388,42,1187
+FACES_Spanish_Vegas_2022_FACES,name_charset,warn,"table name 'FACES_Spanish_Vegas_2022_FACES' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",49388,42,1187
+FACES_Spanish_Vegas_2022_FSS,resp_na,warn,resp has 136 NAs,11824,10,1188
+FACES_Spanish_Vegas_2022_FSS,name_charset,warn,"table name 'FACES_Spanish_Vegas_2022_FSS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",11824,10,1188
+FACIT_YOUNT_2021_clinic10,imputed_values*,warn,Item 'clinic10ever1_Anxiety' has one resp value accounting for 70% of responses — possible mean imputation.,10926,18,607
+FACIT_YOUNT_2021_clinic10,name_charset,warn,"table name 'FACIT_YOUNT_2021_clinic10' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",10926,18,607
+FACIT_YOUNT_2021_clinic10,column_order,warn,"columns start ['id', 'date', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",10926,18,607
+FACIT_YOUNT_2021_crqsasx,resp_na,warn,resp has 273 NAs,11887,20,608
+FACIT_YOUNT_2021_crqsasx,name_charset,warn,"table name 'FACIT_YOUNT_2021_crqsasx' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",11887,20,608
+FACIT_YOUNT_2021_crqsasx,column_order,warn,"columns start ['id', 'date', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",11887,20,608
+FACIT_YOUNT_2021_hadsx,imputed_values*,warn,Item 'hadsx14' has one resp value accounting for 76% of responses — possible mean imputation.,8512,14,608
+FACIT_YOUNT_2021_hadsx,name_charset,warn,"table name 'FACIT_YOUNT_2021_hadsx' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",8512,14,608
+FACIT_YOUNT_2021_hadsx,column_order,warn,"columns start ['id', 'date', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",8512,14,608
+FACIT_YOUNT_2021_limitations,resp_na,warn,resp has 10276 NAs,31924,100,608
+FACIT_YOUNT_2021_limitations,imputed_values*,warn,Item 'a2_facit2x01' has one resp value accounting for 76% of responses — possible mean imputation.,31924,100,608
+FACIT_YOUNT_2021_limitations,multi_scale*,warn,"Item names suggest 2 subscales (['facit', 'a']) — IRW requires separate tables per construct.",31924,100,608
+FACIT_YOUNT_2021_limitations,name_charset,warn,"table name 'FACIT_YOUNT_2021_limitations' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",31924,100,608
+FACIT_YOUNT_2021_limitations,column_order,warn,"columns start ['id', 'date', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",31924,100,608
+FAD_fadplus_goto2021,name_charset,warn,"table name 'FAD_fadplus_goto2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",43308,54,802
+FAD_fadplus_goto2021,column_order,warn,"columns start ['id', 'age', 'gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",43308,54,802
+FEDSP_Trzcinska_2023_MonKnow,dup_id_item,error,2 duplicate id+item rows with no wave/timepoint/date column,396,2,197
+FEDSP_Trzcinska_2023_MonKnow,imputed_values*,warn,Item 'c_MonKnow_1' has one resp value accounting for 94% of responses — possible mean imputation.,396,2,197
+FEDSP_Trzcinska_2023_MonKnow,name_charset,warn,"table name 'FEDSP_Trzcinska_2023_MonKnow' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",396,2,197
+FEDSP_Trzcinska_2023_PRD,resp_na,warn,resp has 2 NAs,988,5,197
+FEDSP_Trzcinska_2023_PRD,dup_id_item,error,5 duplicate id+item rows with no wave/timepoint/date column,988,5,197
+FEDSP_Trzcinska_2023_PRD,name_charset,warn,"table name 'FEDSP_Trzcinska_2023_PRD' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",988,5,197
+FEDSP_Trzcinska_2023_PSPCSA,dup_id_item,warn,1200 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),3564,12,197
+FEDSP_Trzcinska_2023_PSPCSA,name_charset,warn,"table name 'FEDSP_Trzcinska_2023_PSPCSA' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3564,12,197
+FEDSP_Trzcinska_2023_SMSD,resp_na,warn,resp has 7 NAs,2567,13,197
+FEDSP_Trzcinska_2023_SMSD,dup_id_item,error,13 duplicate id+item rows with no wave/timepoint/date column,2567,13,197
+FEDSP_Trzcinska_2023_SMSD,imputed_values*,warn,Item 'p_SMSD_13' has one resp value accounting for 91% of responses — possible mean imputation.,2567,13,197
+FEDSP_Trzcinska_2023_SMSD,name_charset,warn,"table name 'FEDSP_Trzcinska_2023_SMSD' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2567,13,197
+FGSIS_Berzeviczy_2018,imputed_values*,warn,Item 'Q11. Have you ever had gynaecological exam?' has one resp value accounting for 61% of responses — possible mean imputation.,1693,10,170
+FGSIS_Berzeviczy_2018,resp_scale_mixed,warn,items span more than one response scale: 6 on 1-4 and 3 on ['0-1']. IRW requires one table per construct; split before submitting.,1693,10,170
+FGSIS_Berzeviczy_2018,name_charset,warn,"table name 'FGSIS_Berzeviczy_2018' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1693,10,170
+FIVPEI_Perrig_2023_AttDiff,multi_scale*,warn,"Item names suggest 3 subscales (['hqi', 'hqs', 'att']) — IRW requires separate tables per construct.",32571,21,1551
+FIVPEI_Perrig_2023_AttDiff,name_charset,warn,"table name 'FIVPEI_Perrig_2023_AttDiff' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",32571,21,1551
+FIVPEI_Perrig_2023_IMI,name_charset,warn,"table name 'FIVPEI_Perrig_2023_IMI' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",10857,7,1551
+FIVPEI_Perrig_2023_PENS,name_charset,warn,"table name 'FIVPEI_Perrig_2023_PENS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",32571,21,1551
+FIVPEI_Perrig_2023_PXI,name_charset,warn,"table name 'FIVPEI_Perrig_2023_PXI' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",51183,33,1551
+Fh_Okcsr_Roos_2022_study1_Feeling_Heard,resp_na,warn,resp has 14744 NAs,8148,106,194
+Fh_Okcsr_Roos_2022_study1_Feeling_Heard,dup_id_item,error,2328 duplicate id+item rows with no wave/timepoint/date column,8148,106,194
+Fh_Okcsr_Roos_2022_study1_Feeling_Heard,imputed_values*,warn,Item 'Q3.14_16' has one resp value accounting for 95% of responses — possible mean imputation.,8148,106,194
+Fh_Okcsr_Roos_2022_study1_Feeling_Heard,item_scale_outlier,warn,"4 item(s) fall outside the table's 1-5 scale: ['Q3.11', 'Q3.12', 'Q4.12', 'Q5.12']. An isolated out-of-range column is usually not an item -- check for an administrative or count field.",8148,106,194
+Fh_Okcsr_Roos_2022_study1_Feeling_Heard,name_charset,warn,"table name 'Fh_Okcsr_Roos_2022_study1_Feeling_Heard' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",8148,106,194
+Fh_Okcsr_Roos_2022_study2_Feeling_Heard,resp_na,warn,resp has 8000 NAs,32854,102,1000
+Fh_Okcsr_Roos_2022_study2_Feeling_Heard,imputed_values*,warn,Item 'Q12.1_4' has one resp value accounting for 99% of responses — possible mean imputation.,32854,102,1000
+Fh_Okcsr_Roos_2022_study2_Feeling_Heard,resp_scale_mixed,warn,items span more than one response scale: 45 on 1-7 and 23 on ['1-9']. IRW requires one table per construct; split before submitting.,32854,102,1000
+Fh_Okcsr_Roos_2022_study2_Feeling_Heard,name_charset,warn,"table name 'Fh_Okcsr_Roos_2022_study2_Feeling_Heard' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",32854,102,1000
+GART_Grolig_2020,imputed_values*,warn,Item 'Agatha.Christie' has one resp value accounting for 82% of responses — possible mean imputation.,9000,75,120
+GART_Grolig_2020,name_charset,warn,"table name 'GART_Grolig_2020' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",9000,75,120
+GART_Grolig_2020,column_order,warn,"columns start ['id', 'age', 'gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",9000,75,120
+GBJW_fadplus_goto2021,name_charset,warn,"table name 'GBJW_fadplus_goto2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",5614,7,802
+GBJW_fadplus_goto2021,column_order,warn,"columns start ['id', 'age', 'gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",5614,7,802
+HEARD_Roch_2022_COPE,resp_na,warn,resp has 193 NAs,14207,24,600
+HEARD_Roch_2022_COPE,imputed_values*,warn,Item 'COPE04_T1' has one resp value accounting for 97% of responses — possible mean imputation.,14207,24,600
+HEARD_Roch_2022_COPE,name_charset,warn,"table name 'HEARD_Roch_2022_COPE' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",14207,24,600
+HEARD_Roch_2022_IDSS,resp_na,warn,resp has 8 NAs,7192,12,600
+HEARD_Roch_2022_IDSS,imputed_values*,warn,Item 'IDSS07_T1' has one resp value accounting for 63% of responses — possible mean imputation.,7192,12,600
+HEARD_Roch_2022_IDSS,name_charset,warn,"table name 'HEARD_Roch_2022_IDSS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",7192,12,600
+HEARD_Roch_2022_K6,resp_na,warn,resp has 16 NAs,3584,6,600
+HEARD_Roch_2022_K6,imputed_values*,warn,Item 'KESS06_T1' has one resp value accounting for 68% of responses — possible mean imputation.,3584,6,600
+HEARD_Roch_2022_K6,name_charset,warn,"table name 'HEARD_Roch_2022_K6' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3584,6,600
+HEARD_Roch_2022_SWLPWI,imputed_values*,warn,Item 'PWI08_T1' has one resp value accounting for 84% of responses — possible mean imputation.,4800,8,600
+HEARD_Roch_2022_SWLPWI,name_charset,warn,"table name 'HEARD_Roch_2022_SWLPWI' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",4800,8,600
+HEARD_Roch_2022_WHODAS,resp_na,warn,resp has 9 NAs,7191,12,600
+HEARD_Roch_2022_WHODAS,imputed_values*,warn,Item 'WHODAS04_T1' has one resp value accounting for 70% of responses — possible mean imputation.,7191,12,600
+HEARD_Roch_2022_WHODAS,name_charset,warn,"table name 'HEARD_Roch_2022_WHODAS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",7191,12,600
+IJLS_Eersel_2024_Anxiety,name_charset,warn,"table name 'IJLS_Eersel_2024_Anxiety' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1393,7,199
+IJLS_Eersel_2024_DenialAcceptance,name_charset,warn,"table name 'IJLS_Eersel_2024_DenialAcceptance' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",796,4,199
+IJLS_Eersel_2024_Depression,name_charset,warn,"table name 'IJLS_Eersel_2024_Depression' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1393,7,199
+IJLS_Eersel_2024_ICECAP,name_charset,warn,"table name 'IJLS_Eersel_2024_ICECAP' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",995,5,199
+IJLS_Eersel_2024_IJLSreaction,dup_id_item,warn,1503 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),3303,9,200
+IJLS_Eersel_2024_IJLSreaction,name_charset,warn,"table name 'IJLS_Eersel_2024_IJLSreaction' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3303,9,200
+IJLS_Eersel_2024_IJLSreaction,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",3303,9,200
+IJLS_Eersel_2024_IUS,name_charset,warn,"table name 'IJLS_Eersel_2024_IUS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2388,12,199
+IJLS_Eersel_2024_IUS,column_order,warn,"columns start ['id', 'IUS_sum', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",2388,12,199
+IJLS_Eersel_2024_Optimism,name_charset,warn,"table name 'IJLS_Eersel_2024_Optimism' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1194,6,199
+IJLS_Eersel_2024_Work,multi_scale*,warn,"Item names suggest 3 subscales (['workcen', 'uwes', 'commit']) — IRW requires separate tables per construct.",1800,9,200
+IJLS_Eersel_2024_Work,resp_scale_mixed,warn,items span more than one response scale: 6 on 1-5 and 3 on ['1-7']. IRW requires one table per construct; split before submitting.,1800,9,200
+IJLS_Eersel_2024_Work,name_charset,warn,"table name 'IJLS_Eersel_2024_Work' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1800,9,200
+K-PCQ_Huh_2022,imputed_values*,warn,Item 'Crav9' has one resp value accounting for 63% of responses — possible mean imputation.,4291,12,358
+K-PCQ_Huh_2022,name_charset,warn,"table name 'K-PCQ_Huh_2022' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",4291,12,358
+KTEEM_Schoen_2019-2022,dup_id_item,error,49357 duplicate id+item rows with no wave/timepoint/date column,87404,35,1130
+KTEEM_Schoen_2019-2022,imputed_values*,warn,Item 'CMMI_4' has one resp value accounting for 68% of responses — possible mean imputation.,87404,35,1130
+KTEEM_Schoen_2019-2022,multi_scale*,warn,"Item names suggest 7 subscales (['iss', 'lg', 'npt', 'es']) — IRW requires separate tables per construct.",87404,35,1130
+KTEEM_Schoen_2019-2022,name_charset,warn,"table name 'KTEEM_Schoen_2019-2022' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",87404,35,1130
+KTEEM_Schoen_2019-2022,column_order,warn,"columns start ['id', 'group', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",87404,35,1130
+LOC_fadplus_goto2021,name_charset,warn,"table name 'LOC_fadplus_goto2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",5614,7,802
+LOC_fadplus_goto2021,column_order,warn,"columns start ['id', 'age', 'gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",5614,7,802
+LSHS-E_Quidaja_2022,resp_na,warn,resp has 25 NAs,42599,16,2664
+LSHS-E_Quidaja_2022,imputed_values*,warn,Item 'alu_10' has one resp value accounting for 64% of responses — possible mean imputation.,42599,16,2664
+LSHS-E_Quidaja_2022,name_charset,warn,"table name 'LSHS-E_Quidaja_2022' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",42599,16,2664
+MEFSIRODGAS_Nileksela_2023_freq,resp_na,warn,resp has 1556 NAs,43853,91,497
+MEFSIRODGAS_Nileksela_2023_freq,multi_scale*,warn,"Item names suggest 6 subscales (['ccaps', 'cuxos', 'cudos', 'phq']) — IRW requires separate tables per construct.",43853,91,497
+MEFSIRODGAS_Nileksela_2023_freq,resp_scale_mixed,warn,items span more than one response scale: 52 on 1-4 and 39 on ['1-5']. IRW requires one table per construct; split before submitting.,43853,91,497
+MEFSIRODGAS_Nileksela_2023_freq,composite_items*,warn,"1/91 item labels name computed scores (['Anx_overall_imp']) — drop them, or confirm they are real items",43853,91,497
+MEFSIRODGAS_Nileksela_2023_freq,name_charset,warn,"table name 'MEFSIRODGAS_Nileksela_2023_freq' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",43853,91,497
+MEFSIRODGAS_Nileksela_2023_freq,column_order,warn,"columns start ['id', 'age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",43853,91,497
+MEFSIRODGAS_Nileksela_2023_severity,resp_na,warn,resp has 1556 NAs,43853,91,497
+MEFSIRODGAS_Nileksela_2023_severity,multi_scale*,warn,"Item names suggest 6 subscales (['ccaps', 'cuxos', 'cudos', 'phq']) — IRW requires separate tables per construct.",43853,91,497
+MEFSIRODGAS_Nileksela_2023_severity,resp_scale_mixed,warn,items span more than one response scale: 52 on 1-4 and 39 on ['1-5']. IRW requires one table per construct; split before submitting.,43853,91,497
+MEFSIRODGAS_Nileksela_2023_severity,composite_items*,warn,"1/91 item labels name computed scores (['Anx_overall_imp']) — drop them, or confirm they are real items",43853,91,497
+MEFSIRODGAS_Nileksela_2023_severity,name_charset,warn,"table name 'MEFSIRODGAS_Nileksela_2023_severity' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",43853,91,497
+MEFSIRODGAS_Nileksela_2023_severity,column_order,warn,"columns start ['id', 'age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",43853,91,497
+MGSISGCLQ_Hollyhead_2018,resp_na,warn,resp has 175 NAs,775,25,31
+MGSISGCLQ_Hollyhead_2018,imputed_values*,warn,Item 'Do.you.have.limited.movement.of.your.ankle?' has one resp value accounting for 94% of responses — possible mean imputation.,775,25,31
+MGSISGCLQ_Hollyhead_2018,resp_scale_mixed,warn,items span more than one response scale: 18 on 0-1 and 5 on ['1-4']. IRW requires one table per construct; split before submitting.,775,25,31
+MGSISGCLQ_Hollyhead_2018,name_charset,warn,"table name 'MGSISGCLQ_Hollyhead_2018' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",775,25,31
+MGSISGCLQ_Hollyhead_2018,sample_floor,warn,"38 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",775,25,31
+MGSISGCLQ_Hollyhead_2018,column_order,warn,"columns start ['id', 'cov_medical_condition', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",775,25,31
+MMF_Solis_2020,name_charset,warn,"table name 'MMF_Solis_2020' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",89156,10,10746
+Mechanical_Turk_Lexical,resp_na,warn,resp has 136 NAs,68024,4588,142
+Mechanical_Turk_Lexical,dup_id_item,error,20 duplicate id+item rows with no wave/timepoint/date column,68024,4588,142
+Mechanical_Turk_Lexical,imputed_values*,warn,Item 'abdominal' has one resp value accounting for 100% of responses — possible mean imputation.,68024,4588,142
+Mechanical_Turk_Lexical,composite_items*,warn,"9/4588 item labels name computed scores (['preen', 'preci', 'total', 'post']) — drop them, or confirm they are real items",68024,4588,142
+Mechanical_Turk_Lexical,name_charset,warn,"table name 'Mechanical_Turk_Lexical' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",68024,4588,142
+Mechanical_Turk_Lexical,column_order,warn,"columns start ['id', 'resp', 'rt']; datastandard.md step 7 writes [id, item, resp] + covariates.",68024,4588,142
+Mechanical_Turk_Recognition,resp_na,warn,resp has 284 NAs,76624,2202,142
+Mechanical_Turk_Recognition,dup_id_item,error,12 duplicate id+item rows with no wave/timepoint/date column,76624,2202,142
+Mechanical_Turk_Recognition,imputed_values*,warn,Item 'abdominal' has one resp value accounting for 85% of responses — possible mean imputation.,76624,2202,142
+Mechanical_Turk_Recognition,composite_items*,warn,"7/2202 item labels name computed scores (['mean', 'index', 'post', 'poster']) — drop them, or confirm they are real items",76624,2202,142
+Mechanical_Turk_Recognition,name_charset,warn,"table name 'Mechanical_Turk_Recognition' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",76624,2202,142
+Mechanical_Turk_Recognition,column_order,warn,"columns start ['id', 'resp', 'rt']; datastandard.md step 7 writes [id, item, resp] + covariates.",76624,2202,142
+MotAcademica_Ribeiro_2019,imputed_values*,warn,Item 'Item1' has one resp value accounting for 65% of responses — possible mean imputation.,33553,29,1157
+MotAcademica_Ribeiro_2019,name_charset,warn,"table name 'MotAcademica_Ribeiro_2019' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",33553,29,1157
+NAMPRB_Siwiak_2024_AOT,imputed_values*,warn,Item 'AOT_4' has one resp value accounting for 63% of responses — possible mean imputation.,1248,8,156
+NAMPRB_Siwiak_2024_AOT,name_charset,warn,"table name 'NAMPRB_Siwiak_2024_AOT' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1248,8,156
+NAMPRB_Siwiak_2024_BSR10,imputed_values*,warn,Item 'BSR_14' has one resp value accounting for 65% of responses — possible mean imputation.,4680,30,156
+NAMPRB_Siwiak_2024_BSR10,name_charset,warn,"table name 'NAMPRB_Siwiak_2024_BSR10' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",4680,30,156
+NAMPRB_Siwiak_2024_DESRPL,resp_na,warn,resp has 1 NAs,4815,28,172
+NAMPRB_Siwiak_2024_DESRPL,imputed_values*,warn,Item 'DES-R-PL_11' has one resp value accounting for 72% of responses — possible mean imputation.,4815,28,172
+NAMPRB_Siwiak_2024_DESRPL,name_charset,warn,"table name 'NAMPRB_Siwiak_2024_DESRPL' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",4815,28,172
+NAMPRB_Siwiak_2024_GCBS,imputed_values*,warn,Item 'GCBS_3' has one resp value accounting for 63% of responses — possible mean imputation.,6075,15,405
+NAMPRB_Siwiak_2024_GCBS,name_charset,warn,"table name 'NAMPRB_Siwiak_2024_GCBS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",6075,15,405
+NAMPRB_Siwiak_2024_KON2066,imputed_values*,warn,Item 'KON-2006_FANTAZJA_174' has one resp value accounting for 66% of responses — possible mean imputation.,3784,22,172
+NAMPRB_Siwiak_2024_KON2066,name_charset,warn,"table name 'NAMPRB_Siwiak_2024_KON2066' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3784,22,172
+NAMPRB_Siwiak_2024_KOP20,imputed_values*,warn,Item 'KOP20_10' has one resp value accounting for 65% of responses — possible mean imputation.,3120,20,156
+NAMPRB_Siwiak_2024_KOP20,name_charset,warn,"table name 'NAMPRB_Siwiak_2024_KOP20' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3120,20,156
+NAMPRB_Siwiak_2024_NEOFFI,name_charset,warn,"table name 'NAMPRB_Siwiak_2024_NEOFFI' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",16680,60,278
+NAMPRB_Siwiak_2024_SSUB,dup_id_item,warn,1200 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),19340,25,887
+NAMPRB_Siwiak_2024_SSUB,imputed_values*,warn,Item 'SSUB_NAB_12' has one resp value accounting for 64% of responses — possible mean imputation.,19340,25,887
+NAMPRB_Siwiak_2024_SSUB,name_charset,warn,"table name 'NAMPRB_Siwiak_2024_SSUB' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",19340,25,887
+NAMPRB_Siwiak_2024_SSUB,column_order,warn,"columns start ['id', 'wave', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",19340,25,887
+NARQing,imputed_values*,warn,Item 'narq_14' has one resp value accounting for 71% of responses — possible mean imputation.,49920,40,1248
+NARQing,multi_scale*,warn,"Item names suggest 3 subscales (['narq', 'meim', 'rse']) — IRW requires separate tables per construct.",49920,40,1248
+NARQing,resp_scale_mixed,warn,items span more than one response scale: 22 on 1.0-4.0 and 18 on ['1.0-6.0']. IRW requires one table per construct; split before submitting.,49920,40,1248
+NARQing,name_charset,warn,"table name 'NARQing' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",49920,40,1248
+NARQing,column_order,warn,"columns start ['id', 'ethnic_category', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",49920,40,1248
+NSR-FC_Youhasan_2021,imputed_values*,warn,Item 'Q9' has one resp value accounting for 63% of responses — possible mean imputation.,12424,35,355
+NSR-FC_Youhasan_2021,name_charset,warn,"table name 'NSR-FC_Youhasan_2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",12424,35,355
+NSR-FC_Youhasan_2021,column_order,warn,"columns start ['id', 'Academic_Year', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",12424,35,355
+OSCE_Hejri_2017,name_charset,warn,"table name 'OSCE_Hejri_2017' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2660,10,266
+OS_TBMWTFS_Schubert_2023_ACS,imputed_values*,warn,Item 'ACS_Item2_R' has one resp value accounting for 62% of responses — possible mean imputation.,4600,20,230
+OS_TBMWTFS_Schubert_2023_ACS,name_charset,warn,"table name 'OS_TBMWTFS_Schubert_2023_ACS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",4600,20,230
+OS_TBMWTFS_Schubert_2023_BMW3,name_charset,warn,"table name 'OS_TBMWTFS_Schubert_2023_BMW3' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",12456,12,1038
+OS_TBMWTFS_Schubert_2023_CERQ,multi_scale*,warn,"Item names suggest 2 subscales (['erq', 'rumination']) — IRW requires separate tables per construct.",2436,14,174
+OS_TBMWTFS_Schubert_2023_CERQ,name_charset,warn,"table name 'OS_TBMWTFS_Schubert_2023_CERQ' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2436,14,174
+OS_TBMWTFS_Schubert_2023_DMW,dup_id_item,error,704 duplicate id+item rows with no wave/timepoint/date column,1564,4,215
+OS_TBMWTFS_Schubert_2023_DMW,name_charset,warn,"table name 'OS_TBMWTFS_Schubert_2023_DMW' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1564,4,215
+OS_TBMWTFS_Schubert_2023_IPIP,dup_id_item,error,8800 duplicate id+item rows with no wave/timepoint/date column,19550,50,215
+OS_TBMWTFS_Schubert_2023_IPIP,name_charset,warn,"table name 'OS_TBMWTFS_Schubert_2023_IPIP' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",19550,50,215
+OS_TBMWTFS_Schubert_2023_MAAS,dup_id_item,error,2640 duplicate id+item rows with no wave/timepoint/date column,5865,15,215
+OS_TBMWTFS_Schubert_2023_MAAS,name_charset,warn,"table name 'OS_TBMWTFS_Schubert_2023_MAAS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",5865,15,215
+OS_TBMWTFS_Schubert_2023_SMW,dup_id_item,error,704 duplicate id+item rows with no wave/timepoint/date column,1564,4,215
+OS_TBMWTFS_Schubert_2023_SMW,name_charset,warn,"table name 'OS_TBMWTFS_Schubert_2023_SMW' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1564,4,215
+PBS_Surrain_2019_PoB,resp_na,warn,resp has 917 NAs,13049,23,741
+PBS_Surrain_2019_PoB,multi_scale*,warn,"Item names suggest 2 subscales (['pob', 'pobplus']) — IRW requires separate tables per construct.",13049,23,741
+PBS_Surrain_2019_PoB,name_charset,warn,"table name 'PBS_Surrain_2019_PoB' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",13049,23,741
+PBS_Surrain_2019_PoB,column_order,warn,"columns start ['id', 'age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",13049,23,741
+PEMAIW_Qiu_2020_BWSS,resp_na,warn,resp has 47 NAs,21493,20,955
+PEMAIW_Qiu_2020_BWSS,dup_id_item,error,2440 duplicate id+item rows with no wave/timepoint/date column,21493,20,955
+PEMAIW_Qiu_2020_BWSS,name_charset,warn,"table name 'PEMAIW_Qiu_2020_BWSS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",21493,20,955
+PEMAIW_Qiu_2020_DASS,resp_na,warn,resp has 22 NAs,22532,21,952
+PEMAIW_Qiu_2020_DASS,dup_id_item,error,2562 duplicate id+item rows with no wave/timepoint/date column,22532,21,952
+PEMAIW_Qiu_2020_DASS,imputed_values*,warn,Item 'DASS_15' has one resp value accounting for 62% of responses — possible mean imputation.,22532,21,952
+PEMAIW_Qiu_2020_DASS,name_charset,warn,"table name 'PEMAIW_Qiu_2020_DASS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",22532,21,952
+PEMAIW_Qiu_2020_FFMQ,resp_na,warn,resp has 322 NAs,45854,39,1057
+PEMAIW_Qiu_2020_FFMQ,dup_id_item,error,4953 duplicate id+item rows with no wave/timepoint/date column,45854,39,1057
+PEMAIW_Qiu_2020_FFMQ,name_charset,warn,"table name 'PEMAIW_Qiu_2020_FFMQ' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",45854,39,1057
+PEMAIW_Qiu_2020_MEQ,resp_na,warn,resp has 246 NAs,33264,30,992
+PEMAIW_Qiu_2020_MEQ,dup_id_item,error,3750 duplicate id+item rows with no wave/timepoint/date column,33264,30,992
+PEMAIW_Qiu_2020_MEQ,name_charset,warn,"table name 'PEMAIW_Qiu_2020_MEQ' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",33264,30,992
+PEMAIW_Qiu_2020_MLQ,resp_na,warn,resp has 32 NAs,10748,10,956
+PEMAIW_Qiu_2020_MLQ,dup_id_item,error,1220 duplicate id+item rows with no wave/timepoint/date column,10748,10,956
+PEMAIW_Qiu_2020_MLQ,name_charset,warn,"table name 'PEMAIW_Qiu_2020_MLQ' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",10748,10,956
+PEMAIW_Qiu_2020_PANAS,resp_na,warn,resp has 69 NAs,21611,20,960
+PEMAIW_Qiu_2020_PANAS,dup_id_item,error,2480 duplicate id+item rows with no wave/timepoint/date column,21611,20,960
+PEMAIW_Qiu_2020_PANAS,name_charset,warn,"table name 'PEMAIW_Qiu_2020_PANAS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",21611,20,960
+PEMAIW_Qiu_2020_SWLS,resp_na,warn,resp has 3 NAs,5457,5,968
+PEMAIW_Qiu_2020_SWLS,dup_id_item,error,620 duplicate id+item rows with no wave/timepoint/date column,5457,5,968
+PEMAIW_Qiu_2020_SWLS,name_charset,warn,"table name 'PEMAIW_Qiu_2020_SWLS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",5457,5,968
+PEPABAS2C_Kubicka_2024,resp_na,warn,resp has 5 NAs,4841,24,200
+PEPABAS2C_Kubicka_2024,dup_id_item,error,48 duplicate id+item rows with no wave/timepoint/date column,4841,24,200
+PEPABAS2C_Kubicka_2024,imputed_values*,warn,Item 'SPP12' has one resp value accounting for 63% of responses — possible mean imputation.,4841,24,200
+PEPABAS2C_Kubicka_2024,multi_scale*,warn,"Item names suggest 2 subscales (['spp', 'bas']) — IRW requires separate tables per construct.",4841,24,200
+PEPABAS2C_Kubicka_2024,resp_scale_mixed,warn,"items span more than one response scale: 12 on 1-4 and 12 on ['1-5', '1-6', '1-7']. IRW requires one table per construct; split before submitting.",4841,24,200
+PEPABAS2C_Kubicka_2024,name_charset,warn,"table name 'PEPABAS2C_Kubicka_2024' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",4841,24,200
+PMT_Trzcinska_2023_MVS,name_charset,warn,"table name 'PMT_Trzcinska_2023_MVS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",234,9,26
+PMT_Trzcinska_2023_MVS,sample_floor,warn,"26 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",234,9,26
+PMT_Trzcinska_2023_PMT,imputed_values*,warn,Item 'ONE11szPREZ_RYS' has one resp value accounting for 67% of responses — possible mean imputation.,7392,64,204
+PMT_Trzcinska_2023_PMT,multi_scale*,warn,"Item names suggest 2 subscales (['one', 'two']) — IRW requires separate tables per construct.",7392,64,204
+PMT_Trzcinska_2023_PMT,name_charset,warn,"table name 'PMT_Trzcinska_2023_PMT' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",7392,64,204
+PMT_Trzcinska_2023_finans,imputed_values*,warn,Item 'finans10' has one resp value accounting for 69% of responses — possible mean imputation.,364,14,26
+PMT_Trzcinska_2023_finans,resp_scale_mixed,warn,"items span more than one response scale: 7 on 3-4 and 7 on ['2-4', '1-4']. IRW requires one table per construct; split before submitting.",364,14,26
+PMT_Trzcinska_2023_finans,name_charset,warn,"table name 'PMT_Trzcinska_2023_finans' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",364,14,26
+PMT_Trzcinska_2023_finans,sample_floor,warn,"26 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",364,14,26
+PPPASBPNSSedaisw_Pedro_2022_EBSV,name_charset,warn,"table name 'PPPASBPNSSedaisw_Pedro_2022_EBSV' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",9888,6,1648
+PPPASBPNSSedaisw_Pedro_2022_NPBE,name_charset,warn,"table name 'PPPASBPNSSedaisw_Pedro_2022_NPBE' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",24720,15,1648
+PPPASBPNSSedaisw_Pedro_2022_PANAS,imputed_values*,warn,Item 'M2_PANAS_1' has one resp value accounting for 78% of responses — possible mean imputation.,32960,20,1648
+PPPASBPNSSedaisw_Pedro_2022_PANAS,name_charset,warn,"table name 'PPPASBPNSSedaisw_Pedro_2022_PANAS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",32960,20,1648
+PPPSSAPIS_Figlova_2021_PSS10,name_charset,warn,"table name 'PPPSSAPIS_Figlova_2021_PSS10' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1530,10,153
+PPSRS_Caliciuri_2024,imputed_values*,warn,Item 'SRS2' has one resp value accounting for 69% of responses — possible mean imputation.,3707,11,337
+PPSRS_Caliciuri_2024,name_charset,warn,"table name 'PPSRS_Caliciuri_2024' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3707,11,337
+PRCPSFFMQ_Lecuona_2017,name_charset,warn,"table name 'PRCPSFFMQ_Lecuona_2017' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",31200,39,800
+PROMISPFUE_2.0E_Gershon_2019_PROMIS,resp_na,warn,resp has 249 NAs,20151,34,600
+PROMISPFUE_2.0E_Gershon_2019_PROMIS,imputed_values*,warn,Item 'QFLEXB1' has one resp value accounting for 63% of responses — possible mean imputation.,20151,34,600
+PROMISPFUE_2.0E_Gershon_2019_PROMIS,multi_scale*,warn,"Item names suggest 3 subscales (['qflexe', 'qflexh', 'qflexm']) — IRW requires separate tables per construct.",20151,34,600
+PROMISPFUE_2.0E_Gershon_2019_PROMIS,name_charset,warn,"table name 'PROMISPFUE_2.0E_Gershon_2019_PROMIS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",20151,34,600
+PROMISPME_Forrest_2021_Family_Children,resp_na,warn,resp has 771 NAs,207827,113,1845
+PROMISPME_Forrest_2021_Family_Children,dup_id_item,error,113 duplicate id+item rows with no wave/timepoint/date column,207827,113,1845
+PROMISPME_Forrest_2021_Family_Children,imputed_values*,warn,Item 'FAM_FB_003' has one resp value accounting for 60% of responses — possible mean imputation.,207827,113,1845
+PROMISPME_Forrest_2021_Family_Children,name_charset,warn,"table name 'PROMISPME_Forrest_2021_Family_Children' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",207827,113,1845
+PROMISPME_Forrest_2021_Family_Proxy,resp_na,warn,resp has 771 NAs,207827,113,1845
+PROMISPME_Forrest_2021_Family_Proxy,dup_id_item,error,113 duplicate id+item rows with no wave/timepoint/date column,207827,113,1845
+PROMISPME_Forrest_2021_Family_Proxy,imputed_values*,warn,Item 'FAM_FB_003' has one resp value accounting for 60% of responses — possible mean imputation.,207827,113,1845
+PROMISPME_Forrest_2021_Family_Proxy,name_charset,warn,"table name 'PROMISPME_Forrest_2021_Family_Proxy' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",207827,113,1845
+PROMISPME_Forrest_2021_GHGlobal_Children,resp_na,warn,resp has 2 NAs,65428,18,3635
+PROMISPME_Forrest_2021_GHGlobal_Children,imputed_values*,warn,Item 'Global06' has one resp value accounting for 82% of responses — possible mean imputation.,65428,18,3635
+PROMISPME_Forrest_2021_GHGlobal_Children,multi_scale*,warn,"Item names suggest 2 subscales (['pedglobal', 'global']) — IRW requires separate tables per construct.",65428,18,3635
+PROMISPME_Forrest_2021_GHGlobal_Children,resp_scale_mixed,warn,items span more than one response scale: 15 on 1-5 and 3 on ['1-6']. IRW requires one table per construct; split before submitting.,65428,18,3635
+PROMISPME_Forrest_2021_GHGlobal_Children,name_charset,warn,"table name 'PROMISPME_Forrest_2021_GHGlobal_Children' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",65428,18,3635
+PROMISPME_Forrest_2021_GHGlobal_Proxy,resp_na,warn,resp has 1909 NAs,36038,21,1807
+PROMISPME_Forrest_2021_GHGlobal_Proxy,imputed_values*,warn,Item 'Global06_Proxy' has one resp value accounting for 82% of responses — possible mean imputation.,36038,21,1807
+PROMISPME_Forrest_2021_GHGlobal_Proxy,multi_scale*,warn,"Item names suggest 2 subscales (['pedglobal', 'global']) — IRW requires separate tables per construct.",36038,21,1807
+PROMISPME_Forrest_2021_GHGlobal_Proxy,item_scale_outlier,warn,"3 item(s) fall outside the table's 1-5 scale: ['PedGlobal10_Proxy', 'PedGlobal12_Proxy', 'PedGlobal9_Proxy']. An isolated out-of-range column is usually not an item -- check for an administrative or count field.",36038,21,1807
+PROMISPME_Forrest_2021_GHGlobal_Proxy,name_charset,warn,"table name 'PROMISPME_Forrest_2021_GHGlobal_Proxy' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",36038,21,1807
+PROMISPME_Forrest_2021_LS_Children,resp_na,warn,resp has 634 NAs,110974,56,1992
+PROMISPME_Forrest_2021_LS_Children,dup_id_item,error,56 duplicate id+item rows with no wave/timepoint/date column,110974,56,1992
+PROMISPME_Forrest_2021_LS_Children,imputed_values*,warn,Item 'SWB_LS_010' has one resp value accounting for 75% of responses — possible mean imputation.,110974,56,1992
+PROMISPME_Forrest_2021_LS_Children,name_charset,warn,"table name 'PROMISPME_Forrest_2021_LS_Children' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",110974,56,1992
+PROMISPME_Forrest_2021_LS_Proxy,resp_na,warn,resp has 115 NAs,53925,56,964
+PROMISPME_Forrest_2021_LS_Proxy,dup_id_item,error,56 duplicate id+item rows with no wave/timepoint/date column,53925,56,964
+PROMISPME_Forrest_2021_LS_Proxy,imputed_values*,warn,Item 'SWB_LS_010_PX' has one resp value accounting for 83% of responses — possible mean imputation.,53925,56,964
+PROMISPME_Forrest_2021_LS_Proxy,name_charset,warn,"table name 'PROMISPME_Forrest_2021_LS_Proxy' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",53925,56,964
+PROMISPME_Forrest_2021_MP_Children,resp_na,warn,resp has 308 NAs,103972,55,1895
+PROMISPME_Forrest_2021_MP_Children,dup_id_item,error,55 duplicate id+item rows with no wave/timepoint/date column,103972,55,1895
+PROMISPME_Forrest_2021_MP_Children,imputed_values*,warn,Item 'SWB_FO_007' has one resp value accounting for 75% of responses — possible mean imputation.,103972,55,1895
+PROMISPME_Forrest_2021_MP_Children,name_charset,warn,"table name 'PROMISPME_Forrest_2021_MP_Children' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",103972,55,1895
+PROMISPME_Forrest_2021_MP_Proxy,resp_na,warn,resp has 115 NAs,50925,55,927
+PROMISPME_Forrest_2021_MP_Proxy,dup_id_item,error,55 duplicate id+item rows with no wave/timepoint/date column,50925,55,927
+PROMISPME_Forrest_2021_MP_Proxy,imputed_values*,warn,Item 'SWB_FO_007_PX' has one resp value accounting for 73% of responses — possible mean imputation.,50925,55,927
+PROMISPME_Forrest_2021_MP_Proxy,name_charset,warn,"table name 'PROMISPME_Forrest_2021_MP_Proxy' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",50925,55,927
+PROMISPME_Forrest_2021_Physical_Children,resp_na,warn,resp has 1304 NAs,236893,122,3854
+PROMISPME_Forrest_2021_Physical_Children,dup_id_item,error,79 duplicate id+item rows with no wave/timepoint/date column,236893,122,3854
+PROMISPME_Forrest_2021_Physical_Children,imputed_values*,warn,Item 'EoS_S_026' has one resp value accounting for 76% of responses — possible mean imputation.,236893,122,3854
+PROMISPME_Forrest_2021_Physical_Children,multi_scale*,warn,"Item names suggest 2 subscales (['pac', 'eos']) — IRW requires separate tables per construct.",236893,122,3854
+PROMISPME_Forrest_2021_Physical_Children,item_scale_outlier,warn,"2 item(s) fall outside the table's 1-5 scale: ['PAC_M_016', 'PAC_M_019']. An isolated out-of-range column is usually not an item -- check for an administrative or count field.",236893,122,3854
+PROMISPME_Forrest_2021_Physical_Children,name_charset,warn,"table name 'PROMISPME_Forrest_2021_Physical_Children' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",236893,122,3854
+PROMISPME_Forrest_2021_Physical_Proxy,resp_na,warn,resp has 751 NAs,120667,122,1957
+PROMISPME_Forrest_2021_Physical_Proxy,dup_id_item,error,79 duplicate id+item rows with no wave/timepoint/date column,120667,122,1957
+PROMISPME_Forrest_2021_Physical_Proxy,imputed_values*,warn,Item 'EoS_S_011_PX' has one resp value accounting for 77% of responses — possible mean imputation.,120667,122,1957
+PROMISPME_Forrest_2021_Physical_Proxy,multi_scale*,warn,"Item names suggest 2 subscales (['pac', 'eos']) — IRW requires separate tables per construct.",120667,122,1957
+PROMISPME_Forrest_2021_Physical_Proxy,item_scale_outlier,warn,"2 item(s) fall outside the table's 1-5 scale: ['PAC_M_016_PX', 'PAC_M_019_PX']. An isolated out-of-range column is usually not an item -- check for an administrative or count field.",120667,122,1957
+PROMISPME_Forrest_2021_Physical_Proxy,name_charset,warn,"table name 'PROMISPME_Forrest_2021_Physical_Proxy' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",120667,122,1957
+PROMISPME_Forrest_2021_PosAff_Children,resp_na,warn,resp has 1186 NAs,98136,53,1869
+PROMISPME_Forrest_2021_PosAff_Children,imputed_values*,warn,Item 'SWB_P_018' has one resp value accounting for 68% of responses — possible mean imputation.,98136,53,1869
+PROMISPME_Forrest_2021_PosAff_Children,name_charset,warn,"table name 'PROMISPME_Forrest_2021_PosAff_Children' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",98136,53,1869
+PROMISPME_Forrest_2021_PosAff_Proxy,resp_na,warn,resp has 117 NAs,48060,53,909
+PROMISPME_Forrest_2021_PosAff_Proxy,imputed_values*,warn,Item 'SWB_P_018_PX' has one resp value accounting for 66% of responses — possible mean imputation.,48060,53,909
+PROMISPME_Forrest_2021_PosAff_Proxy,name_charset,warn,"table name 'PROMISPME_Forrest_2021_PosAff_Proxy' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",48060,53,909
+PROMISPME_Forrest_2021_Psych_Children,resp_na,warn,resp has 452 NAs,119484,64,1874
+PROMISPME_Forrest_2021_Psych_Children,imputed_values*,warn,Item 'EoS_P_015' has one resp value accounting for 70% of responses — possible mean imputation.,119484,64,1874
+PROMISPME_Forrest_2021_Psych_Children,name_charset,warn,"table name 'PROMISPME_Forrest_2021_Psych_Children' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",119484,64,1874
+PROMISPME_Forrest_2021_Psych_Proxy,resp_na,warn,resp has 230 NAs,58202,64,913
+PROMISPME_Forrest_2021_Psych_Proxy,imputed_values*,warn,Item 'EoS_P_002_PX' has one resp value accounting for 65% of responses — possible mean imputation.,58202,64,913
+PROMISPME_Forrest_2021_Psych_Proxy,name_charset,warn,"table name 'PROMISPME_Forrest_2021_Psych_Proxy' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",58202,64,913
+PROMISPME_Forrest_2021_Strength_Children,resp_na,warn,resp has 85 NAs,45540,25,1824
+PROMISPME_Forrest_2021_Strength_Children,dup_id_item,error,25 duplicate id+item rows with no wave/timepoint/date column,45540,25,1824
+PROMISPME_Forrest_2021_Strength_Children,imputed_values*,warn,Item 'PAC_S_005' has one resp value accounting for 61% of responses — possible mean imputation.,45540,25,1824
+PROMISPME_Forrest_2021_Strength_Children,name_charset,warn,"table name 'PROMISPME_Forrest_2021_Strength_Children' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",45540,25,1824
+PROMISPME_Forrest_2021_Strength_Proxy,resp_na,warn,resp has 41 NAs,22934,25,918
+PROMISPME_Forrest_2021_Strength_Proxy,dup_id_item,error,25 duplicate id+item rows with no wave/timepoint/date column,22934,25,918
+PROMISPME_Forrest_2021_Strength_Proxy,imputed_values*,warn,Item 'PAC_S_005_PX' has one resp value accounting for 72% of responses — possible mean imputation.,22934,25,918
+PROMISPME_Forrest_2021_Strength_Proxy,name_charset,warn,"table name 'PROMISPME_Forrest_2021_Strength_Proxy' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",22934,25,918
+PSR-P_Scale_Intimacy_Hakim_2018_Study2_PSI,resp_na,warn,resp has 2 NAs,2754,13,199
+PSR-P_Scale_Intimacy_Hakim_2018_Study2_PSI,dup_id_item,error,169 duplicate id+item rows with no wave/timepoint/date column,2754,13,199
+PSR-P_Scale_Intimacy_Hakim_2018_Study2_PSI,name_length,error,"table name is 42 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",2754,13,199
+PSR-P_Scale_Intimacy_Hakim_2018_Study2_PSI,name_charset,warn,"table name 'PSR-P_Scale_Intimacy_Hakim_2018_Study2_PSI' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2754,13,199
+PSR-P_Scale_Intimacy_Hakim_2018_Study2_PSI,column_order,warn,"columns start ['id', 'figure', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",2754,13,199
+PSR-P_Scale_Intimacy_Hakim_2018_Study2_PSR,resp_na,warn,resp has 3 NAs,1269,6,199
+PSR-P_Scale_Intimacy_Hakim_2018_Study2_PSR,dup_id_item,error,78 duplicate id+item rows with no wave/timepoint/date column,1269,6,199
+PSR-P_Scale_Intimacy_Hakim_2018_Study2_PSR,name_length,error,"table name is 42 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",1269,6,199
+PSR-P_Scale_Intimacy_Hakim_2018_Study2_PSR,name_charset,warn,"table name 'PSR-P_Scale_Intimacy_Hakim_2018_Study2_PSR' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1269,6,199
+PSR-P_Scale_Intimacy_Hakim_2018_Study2_PSR,column_order,warn,"columns start ['id', 'figure', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",1269,6,199
+PSR-P_Scale_Intimacy_Hakim_2018_Study3,resp_na,warn,resp has 95 NAs,21433,24,897
+PSR-P_Scale_Intimacy_Hakim_2018_Study3,multi_scale*,warn,"Item names suggest 6 subscales (['rwa', 'ba', 'elaborationpolitics', 'politicalefficacy']) — IRW requires separate tables per construct.",21433,24,897
+PSR-P_Scale_Intimacy_Hakim_2018_Study3,name_charset,warn,"table name 'PSR-P_Scale_Intimacy_Hakim_2018_Study3' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",21433,24,897
+PSR-P_Scale_Intimacy_Hakim_2018_Study3,column_order,warn,"columns start ['id', 'figure', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",21433,24,897
+PTAM_Kretzschmar_2017_MicroFIN,resp_na,warn,resp has 80 NAs,6904,24,253
+PTAM_Kretzschmar_2017_MicroFIN,dup_id_item,warn,912 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),6904,24,253
+PTAM_Kretzschmar_2017_MicroFIN,imputed_values*,warn,Item 'c7' has one resp value accounting for 67% of responses — possible mean imputation.,6904,24,253
+PTAM_Kretzschmar_2017_MicroFIN,multi_scale*,warn,"Item names suggest 4 subscales (['zi', 'iz', 'know', 'c']) — IRW requires separate tables per construct.",6904,24,253
+PTAM_Kretzschmar_2017_MicroFIN,name_charset,warn,"table name 'PTAM_Kretzschmar_2017_MicroFIN' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",6904,24,253
+PTAM_Kretzschmar_2017_Raven,imputed_values*,warn,Item 'rav1' has one resp value accounting for 94% of responses — possible mean imputation.,4760,20,238
+PTAM_Kretzschmar_2017_Raven,name_charset,warn,"table name 'PTAM_Kretzschmar_2017_Raven' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",4760,20,238
+PTAM_Kretzschmar_2017_Reasoning,resp_na,warn,resp has 616 NAs,7808,36,234
+PTAM_Kretzschmar_2017_Reasoning,imputed_values*,warn,Item 'qr10' has one resp value accounting for 62% of responses — possible mean imputation.,7808,36,234
+PTAM_Kretzschmar_2017_Reasoning,multi_scale*,warn,"Item names suggest 2 subscales (['verb', 'qr']) — IRW requires separate tables per construct.",7808,36,234
+PTAM_Kretzschmar_2017_Reasoning,name_charset,warn,"table name 'PTAM_Kretzschmar_2017_Reasoning' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",7808,36,234
+PTCI_Chinese_Zhan_2024,dup_id_item,error,38577 duplicate id+item rows with no wave/timepoint/date column,80388,33,1267
+PTCI_Chinese_Zhan_2024,imputed_values*,warn,Item 'ptci14' has one resp value accounting for 61% of responses — possible mean imputation.,80388,33,1267
+PTCI_Chinese_Zhan_2024,name_charset,warn,"table name 'PTCI_Chinese_Zhan_2024' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",80388,33,1267
+PeSCBCSCe_Novak_2020_SCBCS,name_charset,warn,"table name 'PeSCBCSCe_Novak_2020_SCBCS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2860,5,572
+PeSCBCSCe_Novak_2020_SPIRIT,name_charset,warn,"table name 'PeSCBCSCe_Novak_2020_SPIRIT' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2860,5,572
+PrEPAdherence_Zissette_2021,imputed_values*,warn,Item 'q_m_005_all' has one resp value accounting for 69% of responses — possible mean imputation.,18988,99,193
+PrEPAdherence_Zissette_2021,name_charset,warn,"table name 'PrEPAdherence_Zissette_2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",18988,99,193
+QADT_Kleka_2023,dup_id_item,warn,10872 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),16308,12,453
+QADT_Kleka_2023,imputed_values*,warn,Item 'ZR_11' has one resp value accounting for 69% of responses — possible mean imputation.,16308,12,453
+QADT_Kleka_2023,name_charset,warn,"table name 'QADT_Kleka_2023' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",16308,12,453
+QADT_Kleka_2023,column_order,warn,"columns start ['id', 'wave', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",16308,12,453
+QCDQES_Oliveira_2022,resp_na,warn,resp has 13 NAs,28841,42,687
+QCDQES_Oliveira_2022,imputed_values*,warn,Item 'OCDQ35' has one resp value accounting for 75% of responses — possible mean imputation.,28841,42,687
+QCDQES_Oliveira_2022,name_charset,warn,"table name 'QCDQES_Oliveira_2022' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",28841,42,687
+QaSLU_Prado_2024,imputed_values*,warn,Item 'Item12' has one resp value accounting for 66% of responses — possible mean imputation.,5310,45,118
+QaSLU_Prado_2024,name_charset,warn,"table name 'QaSLU_Prado_2024' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",5310,45,118
+QaSLu_lopez_2024,imputed_values*,warn,Item 'Item12' has one resp value accounting for 66% of responses — possible mean imputation.,5310,45,118
+QaSLu_lopez_2024,name_charset,warn,"table name 'QaSLu_lopez_2024' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",5310,45,118
+RD_EppSCQRK_Kipkemoi_2024_scq,dup_id_item,error,1000 duplicate id+item rows with no wave/timepoint/date column,10720,40,243
+RD_EppSCQRK_Kipkemoi_2024_scq,imputed_values*,warn,Item 'scq1' has one resp value accounting for 82% of responses — possible mean imputation.,10720,40,243
+RD_EppSCQRK_Kipkemoi_2024_scq,name_charset,warn,"table name 'RD_EppSCQRK_Kipkemoi_2024_scq' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",10720,40,243
+RD_PPCSEDSOF_Afable_2023,imputed_values*,warn,Item 'P1SD1_01' has one resp value accounting for 63% of responses — possible mean imputation.,57299,11,5209
+RD_PPCSEDSOF_Afable_2023,name_charset,warn,"table name 'RD_PPCSEDSOF_Afable_2023' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",57299,11,5209
+RD_PpCvDOS_PadcOnaCns_Jinbo_2019_DOS,resp_na,warn,resp has 66 NAs,10684,10,1075
+RD_PpCvDOS_PadcOnaCns_Jinbo_2019_DOS,imputed_values*,warn,Item 'DOS_7' has one resp value accounting for 69% of responses — possible mean imputation.,10684,10,1075
+RD_PpCvDOS_PadcOnaCns_Jinbo_2019_DOS,name_charset,warn,"table name 'RD_PpCvDOS_PadcOnaCns_Jinbo_2019_DOS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",10684,10,1075
+RD_PpSL7as_Ghasemy_2024_SL,imputed_values*,warn,Item 'SL3_T1' has one resp value accounting for 63% of responses — possible mean imputation.,2468,4,617
+RD_PpSL7as_Ghasemy_2024_SL,name_charset,warn,"table name 'RD_PpSL7as_Ghasemy_2024_SL' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2468,4,617
+RDatasets_gssabortion,resp_na,warn,resp has 152355 NAs,301343,7,45599
+RDatasets_gssabortion,imputed_values*,warn,Item 'abdefect' has one resp value accounting for 80% of responses — possible mean imputation.,301343,7,45599
+RDatasets_gssabortion,name_charset,warn,"table name 'RDatasets_gssabortion' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",301343,7,45599
+RDatasets_gssabortion,column_order,warn,"columns start ['id', 'year', 'sex']; datastandard.md step 7 writes [id, item, resp] + covariates.",301343,7,45599
+RLMS_MLCIRTwithin,resp_na,warn,resp has 117 NAs,5823,4,1474
+RLMS_MLCIRTwithin,name_charset,warn,"table name 'RLMS_MLCIRTwithin' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",5823,4,1474
+Resistance,imputed_values*,warn,Item 'AF_budget' has one resp value accounting for 60% of responses — possible mean imputation.,7084,14,506
+Resistance,multi_scale*,warn,"Item names suggest 2 subscales (['rc', 'af']) — IRW requires separate tables per construct.",7084,14,506
+Resistance,name_charset,warn,"table name 'Resistance' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",7084,14,506
+Resistance,column_order,warn,"columns start ['id', 'group', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",7084,14,506
+Rosenberg_fadplus_goto2021,name_charset,warn,"table name 'Rosenberg_fadplus_goto2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",8020,10,802
+Rosenberg_fadplus_goto2021,column_order,warn,"columns start ['id', 'age', 'gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",8020,10,802
+RvKDCS_Romiacg_Miroshnik_2020_BFI,name_charset,warn,"table name 'RvKDCS_Romiacg_Miroshnik_2020_BFI' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",60660,60,1011
+RvKDCS_Romiacg_Miroshnik_2020_CBI,imputed_values*,warn,Item 'CBI-10' has one resp value accounting for 82% of responses — possible mean imputation.,11121,11,1011
+RvKDCS_Romiacg_Miroshnik_2020_CBI,name_charset,warn,"table name 'RvKDCS_Romiacg_Miroshnik_2020_CBI' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",11121,11,1011
+RvKDCS_Romiacg_Miroshnik_2020_KDOCS,name_charset,warn,"table name 'RvKDCS_Romiacg_Miroshnik_2020_KDOCS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",50550,50,1011
+SABFI2_Gallardo_Pujol_2018_BFI,imputed_values*,warn,Item 'BFI19' has one resp value accounting for 61% of responses — possible mean imputation.,85140,60,1419
+SABFI2_Gallardo_Pujol_2018_BFI,name_charset,warn,"table name 'SABFI2_Gallardo_Pujol_2018_BFI' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",85140,60,1419
+SABFI2_Gallardo_Pujol_2018_Constru,name_charset,warn,"table name 'SABFI2_Gallardo_Pujol_2018_Constru' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",5447,13,419
+SABFI2_Gallardo_Pujol_2018_Honest,name_charset,warn,"table name 'SABFI2_Gallardo_Pujol_2018_Honest' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",4190,10,419
+SABFI2_Gallardo_Pujol_2018_IntHapp,imputed_values*,warn,Item 'IntHapp1' has one resp value accounting for 63% of responses — possible mean imputation.,3771,9,419
+SABFI2_Gallardo_Pujol_2018_IntHapp,name_charset,warn,"table name 'SABFI2_Gallardo_Pujol_2018_IntHapp' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3771,9,419
+SABFI2_Gallardo_Pujol_2018_LOT,name_charset,warn,"table name 'SABFI2_Gallardo_Pujol_2018_LOT' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2514,6,419
+SABFI2_Gallardo_Pujol_2018_Micro,name_charset,warn,"table name 'SABFI2_Gallardo_Pujol_2018_Micro' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2514,6,419
+SABFI2_Gallardo_Pujol_2018_Narq,name_charset,warn,"table name 'SABFI2_Gallardo_Pujol_2018_Narq' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2514,6,419
+SABFI2_Gallardo_Pujol_2018_ReligionScale,resp_na,warn,resp has 100 NAs,7023,17,419
+SABFI2_Gallardo_Pujol_2018_ReligionScale,name_charset,warn,"table name 'SABFI2_Gallardo_Pujol_2018_ReligionScale' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",7023,17,419
+SABFI2_Gallardo_Pujol_2018_SWB,name_charset,warn,"table name 'SABFI2_Gallardo_Pujol_2018_SWB' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1676,4,419
+SABFI2_Gallardo_Pujol_2018_Tight,name_charset,warn,"table name 'SABFI2_Gallardo_Pujol_2018_Tight' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2514,6,419
+SABFI2_Gallardo_Pujol_2018_Trust,name_charset,warn,"table name 'SABFI2_Gallardo_Pujol_2018_Trust' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2095,5,419
+SAS_Deters_2022,resp_na,warn,resp has 189 NAs,134635,19,1526
+SAS_Deters_2022,dup_id_item,error,105830 duplicate id+item rows with no wave/timepoint/date column,134635,19,1526
+SAS_Deters_2022,imputed_values*,warn,Item 'samb01' has one resp value accounting for 82% of responses — possible mean imputation.,134635,19,1526
+SAS_Deters_2022,name_charset,warn,"table name 'SAS_Deters_2022' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",134635,19,1526
+SBD_Smith_2020,resp_na,warn,resp has 23 NAs,6621,22,302
+SBD_Smith_2020,name_charset,warn,"table name 'SBD_Smith_2020' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",6621,22,302
+SCS_Lopez_2015,name_charset,warn,"table name 'SCS_Lopez_2015' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",39432,24,1643
+SCS_Suh_2023_BFNE,name_charset,warn,"table name 'SCS_Suh_2023_BFNE' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",7288,12,612
+SCS_Suh_2023_SCS,resp_na,warn,resp has 39 NAs,20391,30,680
+SCS_Suh_2023_SCS,name_charset,warn,"table name 'SCS_Suh_2023_SCS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",20391,30,680
+SCS_Suh_2023_SIAPS,resp_na,warn,resp has 130 NAs,4202,12,358
+SCS_Suh_2023_SIAPS,name_charset,warn,"table name 'SCS_Suh_2023_SIAPS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",4202,12,358
+SF12_MLCIRTwithin,resp_na,warn,resp has 379 NAs,7061,12,618
+SF12_MLCIRTwithin,name_charset,warn,"table name 'SF12_MLCIRTwithin' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",7061,12,618
+SPQVS_Barnby_2017_DSE,imputed_values*,warn,Item 'DSE1' has one resp value accounting for 62% of responses — possible mean imputation.,2865,15,191
+SPQVS_Barnby_2017_DSE,name_charset,warn,"table name 'SPQVS_Barnby_2017_DSE' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2865,15,191
+SPQVS_Barnby_2017_OEQ,imputed_values*,warn,Item 'OEQ1' has one resp value accounting for 81% of responses — possible mean imputation.,1146,6,191
+SPQVS_Barnby_2017_OEQ,name_charset,warn,"table name 'SPQVS_Barnby_2017_OEQ' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1146,6,191
+SPQVS_Barnby_2017_OLIFE,imputed_values*,warn,Item 'OLIFE1' has one resp value accounting for 61% of responses — possible mean imputation.,8022,42,191
+SPQVS_Barnby_2017_OLIFE,name_charset,warn,"table name 'SPQVS_Barnby_2017_OLIFE' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",8022,42,191
+SPQVS_Barnby_2017_SENPQ,imputed_values*,warn,Item 'SENPQ1' has one resp value accounting for 71% of responses — possible mean imputation.,3056,16,191
+SPQVS_Barnby_2017_SENPQ,name_charset,warn,"table name 'SPQVS_Barnby_2017_SENPQ' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3056,16,191
+SPQVS_Barnby_2017_SIAS,name_charset,warn,"table name 'SPQVS_Barnby_2017_SIAS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3820,20,191
+SPQVS_Barnby_2017_WHO,name_charset,warn,"table name 'SPQVS_Barnby_2017_WHO' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",955,5,191
+SV-MAIA2_Randelovic_2021_DASS,resp_na,warn,resp has 17 NAs,4288,21,205
+SV-MAIA2_Randelovic_2021_DASS,imputed_values*,warn,Item 'DASS_15' has one resp value accounting for 68% of responses — possible mean imputation.,4288,21,205
+SV-MAIA2_Randelovic_2021_DASS,name_charset,warn,"table name 'SV-MAIA2_Randelovic_2021_DASS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",4288,21,205
+SV-MAIA2_Randelovic_2021_DASS,column_order,warn,"columns start ['date', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",4288,21,205
+SV-MAIA2_Randelovic_2021_ERQ,name_charset,warn,"table name 'SV-MAIA2_Randelovic_2021_ERQ' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2030,10,203
+SV-MAIA2_Randelovic_2021_ERQ,column_order,warn,"columns start ['date', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",2030,10,203
+SV-MAIA2_Randelovic_2021_MAAS,name_charset,warn,"table name 'SV-MAIA2_Randelovic_2021_MAAS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3135,15,209
+SV-MAIA2_Randelovic_2021_MAAS,column_order,warn,"columns start ['date', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",3135,15,209
+SV-MAIA2_Randelovic_2021_MAIA,resp_na,warn,resp has 5846 NAs,19240,37,449
+SV-MAIA2_Randelovic_2021_MAIA,dup_id_item,warn,"8473 duplicate id+item rows (longitudinal column ['wave', 'date'] present — likely ok)",19240,37,449
+SV-MAIA2_Randelovic_2021_MAIA,date_numeric*,warn,date column is not numeric — IRW requires Unix seconds (or seconds since first observation),19240,37,449
+SV-MAIA2_Randelovic_2021_MAIA,name_charset,warn,"table name 'SV-MAIA2_Randelovic_2021_MAIA' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",19240,37,449
+SV-MAIA2_Randelovic_2021_MAIA,column_order,warn,"columns start ['date', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",19240,37,449
+SV-MAIA2_Randelovic_2021_SHS,resp_na,warn,resp has 64 NAs,2012,8,433
+SV-MAIA2_Randelovic_2021_SHS,date_numeric*,warn,date column is not numeric — IRW requires Unix seconds (or seconds since first observation),2012,8,433
+SV-MAIA2_Randelovic_2021_SHS,name_charset,warn,"table name 'SV-MAIA2_Randelovic_2021_SHS' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2012,8,433
+SV-MAIA2_Randelovic_2021_delta,imputed_values*,warn,Item 'Delta10' has one resp value accounting for 70% of responses — possible mean imputation.,26160,120,218
+SV-MAIA2_Randelovic_2021_delta,name_charset,warn,"table name 'SV-MAIA2_Randelovic_2021_delta' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",26160,120,218
+SV-MAIA2_Randelovic_2021_hexaco100,imputed_values*,warn,Item 'hexaco19' has one resp value accounting for 65% of responses — possible mean imputation.,21700,100,217
+SV-MAIA2_Randelovic_2021_hexaco100,name_charset,warn,"table name 'SV-MAIA2_Randelovic_2021_hexaco100' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",21700,100,217
+SV-MAIA2_Randelovic_2021_hexaco60,resp_na,warn,resp has 199 NAs,8081,60,138
+SV-MAIA2_Randelovic_2021_hexaco60,imputed_values*,warn,Item 'HEXACO_60_37' has one resp value accounting for 62% of responses — possible mean imputation.,8081,60,138
+SV-MAIA2_Randelovic_2021_hexaco60,name_charset,warn,"table name 'SV-MAIA2_Randelovic_2021_hexaco60' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",8081,60,138
+SV-MAIA2_Randelovic_2021_hexaco60,column_order,warn,"columns start ['date', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",8081,60,138
+VCISM_Polish_Trzcinska_2023,resp_na,warn,resp has 3 NAs,2067,12,104
+VCISM_Polish_Trzcinska_2023,dup_id_item,warn,822 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),2067,12,104
+VCISM_Polish_Trzcinska_2023,name_charset,warn,"table name 'VCISM_Polish_Trzcinska_2023' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2067,12,104
+VEI_Brazillian_Shiramizu_2018_EI,resp_na,warn,resp has 39 NAs,9733,14,697
+VEI_Brazillian_Shiramizu_2018_EI,imputed_values*,warn,Item 'Empathy_Item_3' has one resp value accounting for 63% of responses — possible mean imputation.,9733,14,697
+VEI_Brazillian_Shiramizu_2018_EI,multi_scale*,warn,"Item names suggest 2 subscales (['empathy', 'behavioral']) — IRW requires separate tables per construct.",9733,14,697
+VEI_Brazillian_Shiramizu_2018_EI,name_charset,warn,"table name 'VEI_Brazillian_Shiramizu_2018_EI' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",9733,14,697
+VEI_Brazillian_Shiramizu_2018_IRI,resp_na,warn,resp has 45 NAs,19499,28,698
+VEI_Brazillian_Shiramizu_2018_IRI,imputed_values*,warn,Item 'Concern_Item_2' has one resp value accounting for 67% of responses — possible mean imputation.,19499,28,698
+VEI_Brazillian_Shiramizu_2018_IRI,multi_scale*,warn,"Item names suggest 4 subscales (['fantasy', 'personal', 'concern', 'perspective']) — IRW requires separate tables per construct.",19499,28,698
+VEI_Brazillian_Shiramizu_2018_IRI,name_charset,warn,"table name 'VEI_Brazillian_Shiramizu_2018_IRI' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",19499,28,698
+VSOCFP_Sebo_2024,resp_na,warn,resp has 35 NAs,6317,8,794
+VSOCFP_Sebo_2024,name_charset,warn,"table name 'VSOCFP_Sebo_2024' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",6317,8,794
+Veterans.Affairs.SSVF.Survey.2016-17,dup_id_item,error,91043 duplicate id+item rows with no wave/timepoint/date column,340723,59,5809
+Veterans.Affairs.SSVF.Survey.2016-17,imputed_values*,warn,Item '2' has one resp value accounting for 75% of responses — possible mean imputation.,340723,59,5809
+Veterans.Affairs.SSVF.Survey.2016-17,resp_scale_mixed,warn,"items span more than one response scale: 37 on 1-2 and 21 on ['1-5', '1-4']. IRW requires one table per construct; split before submitting.",340723,59,5809
+Veterans.Affairs.SSVF.Survey.2016-17,name_charset,warn,"table name 'Veterans.Affairs.SSVF.Survey.2016-17' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",340723,59,5809
+Veterans.Affairs.SSVF.Survey.2018-20,resp_na,warn,resp has 476509 NAs,998860,53,26347
+Veterans.Affairs.SSVF.Survey.2018-20,imputed_values*,warn,Item '2' has one resp value accounting for 75% of responses — possible mean imputation.,998860,53,26347
+Veterans.Affairs.SSVF.Survey.2018-20,resp_scale_mixed,warn,"items span more than one response scale: 33 on 1-2 and 20 on ['1-5', '1-4']. IRW requires one table per construct; split before submitting.",998860,53,26347
+Veterans.Affairs.SSVF.Survey.2018-20,name_charset,warn,"table name 'Veterans.Affairs.SSVF.Survey.2018-20' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",998860,53,26347
+WMD_bartczuk_2023,resp_na,warn,resp has 44 NAs,12892,24,539
+WMD_bartczuk_2023,imputed_values*,warn,Item 'WMDS01' has one resp value accounting for 65% of responses — possible mean imputation.,12892,24,539
+WMD_bartczuk_2023,name_charset,warn,"table name 'WMD_bartczuk_2023' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",12892,24,539
+WMI_Read_Han,imputed_values*,warn,Item 'R1_3' has one resp value accounting for 85% of responses — possible mean imputation.,3960,15,264
+WMI_Read_Han,resp_scale_mixed,warn,"items span more than one response scale: 3 on 0-3 and 12 on ['0-4', '0-5', '0-6']. IRW requires one table per construct; split before submitting.",3960,15,264
+WMI_Read_Han,name_charset,warn,"table name 'WMI_Read_Han' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3960,15,264
+WMI_Rot_Han,imputed_values*,warn,Item 'Rot1_2' has one resp value accounting for 92% of responses — possible mean imputation.,3144,12,262
+WMI_Rot_Han,resp_scale_mixed,warn,"items span more than one response scale: 3 on 0-2 and 9 on ['0-3', '0-4', '0-5']. IRW requires one table per construct; split before submitting.",3144,12,262
+WMI_Rot_Han,name_charset,warn,"table name 'WMI_Rot_Han' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3144,12,262
+aappss_malpas_2019_scl,resp_na,warn,resp has 182 NAs,54808,90,611
+aappss_malpas_2019_scl,imputed_values*,warn,Item 'SCL07' has one resp value accounting for 77% of responses — possible mean imputation.,54808,90,611
+aappss_malpas_2019_scl,column_order,warn,"columns start ['id', 'cov_gender', 'cov_VEM_diagnosis_general']; datastandard.md step 7 writes [id, item, resp] + covariates.",54808,90,611
+abortion,imputed_values*,warn,Item 'item_3' has one resp value accounting for 64% of responses — possible mean imputation.,1516,4,379
+acl_mokken,imputed_values*,warn,Item 'apathetic*' has one resp value accounting for 61% of responses — possible mean imputation.,94394,218,433
+acl_mokken,column_order,warn,"columns start ['id', 'item', 'scale']; datastandard.md step 7 writes [id, item, resp] + covariates.",94394,218,433
+ada_boredom_bieleke2022,,ok,,6360,10,636
+aestheticfluency_cotter2023,resp_na,warn,resp has 15 NAs,89265,36,2480
+aestheticfluency_cotter2023,imputed_values*,warn,Item '1' has one resp value accounting for 87% of responses — possible mean imputation.,89265,36,2480
+afps_vangsness_2019,,ok,,2077,9,231
+aip_vangsness_2019,imputed_values*,warn,Item 'AIP_10' has one resp value accounting for 79% of responses — possible mean imputation.,2552,11,232
+alcoholresearch_sumscore,imputed_values*,warn,Item 'Q1' has one resp value accounting for 68% of responses — possible mean imputation.,4660,20,233
+alcoholstroop_jones2024,dup_id_item,error,21840 duplicate id+item rows with no wave/timepoint/date column,26208,28,156
+alcoholstroop_jones2024,imputed_values*,warn,Item 'ALCOHOL' has one resp value accounting for 95% of responses — possible mean imputation.,26208,28,156
+alcoholstroop_jones2024,column_order,warn,"columns start ['id', 'trialnum', 'stimulus']; datastandard.md step 7 writes [id, item, resp] + covariates.",26208,28,156
+american_multiracial_face,imputed_values*,warn,Item '131' has one resp value accounting for 61% of responses — possible mean imputation.,117880,2252,1145
+andrich_mudfold,imputed_values*,warn,Item 'CRIMDESERV' has one resp value accounting for 65% of responses — possible mean imputation.,432,8,54
+andrich_mudfold,sample_floor,warn,"54 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",432,8,54
+anxiety_gastro_symptoms,,ok,,5730,15,382
+anxiety_lordif,imputed_values*,warn,Item 'R1' has one resp value accounting for 68% of responses — possible mean imputation.,22214,29,766
+aps_vangsness_2019,,ok,,3710,16,232
+art,imputed_values*,warn,Item 'Anne McCaffrey' has one resp value accounting for 78% of responses — possible mean imputation.,70100,50,1402
+artistic_preferences,resp_na,warn,resp has 1291 NAs,1038909,56,18575
+artistic_preferences,imputed_values*,warn,Item '41' has one resp value accounting for 95% of responses — possible mean imputation.,1038909,56,18575
+artistic_preferences,rt_numeric*,warn,rt column is not numeric,1038909,56,18575
+artistic_preferences,resp_scale_mixed,warn,"items span more than one response scale: 30 on 1.0-5.0 and 26 on ['1.0-7.0', '0.0-1.0']. IRW requires one table per construct; split before submitting.",1038909,56,18575
+aslec_insomnia_wang2025,size_skipped,info,32 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+audit_BrummerHoffman_2021,imputed_values*,warn,Item 'audit_number_drinks' has one resp value accounting for 64% of responses — possible mean imputation.,5484,3,1828
+audit_BrummerHoffman_2021,name_charset,warn,"table name 'audit_BrummerHoffman_2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",5484,3,1828
+audit_BrummerHoffman_2021,column_order,warn,"columns start ['id', 'group', 'date']; datastandard.md step 7 writes [id, item, resp] + covariates.",5484,3,1828
+autonomysupport_mokken,dup_id_item,error,1715 duplicate id+item rows with no wave/timepoint/date column,1813,7,14
+autonomysupport_mokken,sample_floor,warn,"14 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",1813,7,14
+autonomysupport_mokken,column_order,warn,"columns start ['id', 'rater', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",1813,7,14
+bae_boredom_bieleke2022,multi_scale*,warn,"Item names suggest 2 subscales (['esc', 'avo']) — IRW requires separate tables per construct.",10812,17,636
+balance_mokken,imputed_values*,warn,Item 'CB1' has one resp value accounting for 67% of responses — possible mean imputation.,12100,25,484
+balance_mokken,multi_scale*,warn,"Item names suggest 5 subscales (['cb', 'cd', 'cw', 'd']) — IRW requires separate tables per construct.",12100,25,484
+beh_boredom_bieleke2022,imputed_values*,warn,Item 'beh_03' has one resp value accounting for 73% of responses — possible mean imputation.,12084,19,636
+bfi_goldberg_1992_agreeableness,resp_na,warn,resp has 10 NAs,197180,10,19718
+bfi_goldberg_1992_agreeableness,column_order,warn,"columns start ['id', 'cov_race', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",197180,10,19718
+bfi_goldberg_1992_agreeableness,cov_range,warn,"cov_age spans 13-1e+09, outside [0, 120] -- looks like a sentinel no-answer code (999/9999) or a birth year that was never converted. irw_filter() treats every value here as an age (#1779).",197180,10,19718
+bfi_goldberg_1992_conscientiousness,resp_na,warn,resp has 10 NAs,197180,10,19718
+bfi_goldberg_1992_conscientiousness,column_order,warn,"columns start ['id', 'cov_race', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",197180,10,19718
+bfi_goldberg_1992_conscientiousness,cov_range,warn,"cov_age spans 13-1e+09, outside [0, 120] -- looks like a sentinel no-answer code (999/9999) or a birth year that was never converted. irw_filter() treats every value here as an age (#1779).",197180,10,19718
+bfi_goldberg_1992_extraversion,resp_na,warn,resp has 10 NAs,197180,10,19718
+bfi_goldberg_1992_extraversion,column_order,warn,"columns start ['id', 'cov_race', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",197180,10,19718
+bfi_goldberg_1992_extraversion,cov_range,warn,"cov_age spans 13-1e+09, outside [0, 120] -- looks like a sentinel no-answer code (999/9999) or a birth year that was never converted. irw_filter() treats every value here as an age (#1779).",197180,10,19718
+bfi_goldberg_1992_neuroticism,resp_na,warn,resp has 10 NAs,197180,10,19718
+bfi_goldberg_1992_neuroticism,column_order,warn,"columns start ['id', 'cov_race', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",197180,10,19718
+bfi_goldberg_1992_neuroticism,cov_range,warn,"cov_age spans 13-1e+09, outside [0, 120] -- looks like a sentinel no-answer code (999/9999) or a birth year that was never converted. irw_filter() treats every value here as an age (#1779).",197180,10,19718
+bfi_goldberg_1992_openness_to_experience,resp_na,warn,resp has 10 NAs,197180,10,19718
+bfi_goldberg_1992_openness_to_experience,column_order,warn,"columns start ['id', 'cov_race', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",197180,10,19718
+bfi_goldberg_1992_openness_to_experience,cov_range,warn,"cov_age spans 13-1e+09, outside [0, 120] -- looks like a sentinel no-answer code (999/9999) or a birth year that was never converted. irw_filter() treats every value here as an age (#1779).",197180,10,19718
+bhs_floreskanter2021,imputed_values*,warn,Item 'BHS1' has one resp value accounting for 79% of responses — possible mean imputation.,51936,24,2164
+bhs_floreskanter2021,multi_scale*,warn,"Item names suggest 2 subscales (['bhs', 'si']) — IRW requires separate tables per construct.",51936,24,2164
+bhs_floreskanter2021,resp_scale_mixed,warn,items span more than one response scale: 20 on 0-1 and 4 on ['1-4']. IRW requires one table per construct; split before submitting.,51936,24,2164
+big5_sirt,imputed_values*,warn,Item 'A104' has one resp value accounting for 99% of responses — possible mean imputation.,120000,240,500
+big5_sirt,multi_scale*,warn,"Item names suggest 5 subscales (['n', 'e', 'o', 'a']) — IRW requires separate tables per construct.",120000,240,500
+boyd_prism_2024,imputed_values*,warn,Item 'Identification6' has one resp value accounting for 61% of responses — possible mean imputation.,13104,22,606
+boyd_prism_2024,multi_scale*,warn,"Item names suggest 4 subscales (['interest', 'identification', 'knowledge', 'interaction']) — IRW requires separate tables per construct.",13104,22,606
+bps_boredom_bieleke2022,,ok,,5088,8,636
+brain_hemisphere,resp_na,warn,resp has 2482 NAs,588398,20,29528
+brand_raffaelli_2024_familiarity_24,resp_na,warn,resp has 660 NAs,47602,59,813
+brand_raffaelli_2024_familiarity_24,column_order,warn,"columns start ['cov_age', 'cov_gender', 'id']; datastandard.md step 7 writes [id, item, resp] + covariates.",47602,59,813
+brand_raffaelli_2024_liking_20,imputed_values*,warn,Item '51_liking' has one resp value accounting for 83% of responses — possible mean imputation.,60150,51,1197
+brand_raffaelli_2024_liking_20,column_order,warn,"columns start ['id', 'cov_gender', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",60150,51,1197
+brand_raffaelli_2024_liking_24,resp_na,warn,resp has 660 NAs,47602,59,813
+brand_raffaelli_2024_liking_24,column_order,warn,"columns start ['cov_age', 'cov_gender', 'id']; datastandard.md step 7 writes [id, item, resp] + covariates.",47602,59,813
+brand_raffaelli_2024_recognition_20,column_order,warn,"columns start ['id', 'cov_gender', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",59200,101,592
+broadband_inventories,,ok,,365077,181,2017
+cavalini_mokken,imputed_values*,warn,Item 'Item16' has one resp value accounting for 61% of responses — possible mean imputation.,14076,17,828
+cbq_huczewska2022,resp_na,warn,resp has 54 NAs,175434,64,2742
+cbq_huczewska2022,imputed_values*,warn,Item 'p11' has one resp value accounting for 63% of responses — possible mean imputation.,175434,64,2742
+cbq_huczewska2022,multi_scale*,warn,"Item names suggest 2 subscales (['p', 'n']) — IRW requires separate tables per construct.",175434,64,2742
+cbq_huczewska2022,column_order,warn,"columns start ['id', 'cov_sex', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",175434,64,2742
+ccapsvtskhpacr_mercedes_2023_beck,imputed_values*,warn,Item 'beck1' has one resp value accounting for 71% of responses — possible mean imputation.,4074,21,194
+ccapsvtskhpacr_mercedes_2023_beck,column_order,warn,"columns start ['id', 'cov_sex', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",4074,21,194
+ccapsvtskhpacr_mercedes_2023_hada,imputed_values*,warn,Item 'hada1' has one resp value accounting for 63% of responses — possible mean imputation.,2716,14,194
+ccapsvtskhpacr_mercedes_2023_hada,multi_scale*,warn,"Item names suggest 2 subscales (['hada', 'hadd']) — IRW requires separate tables per construct.",2716,14,194
+ccapsvtskhpacr_mercedes_2023_hada,column_order,warn,"columns start ['id', 'cov_sex', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",2716,14,194
+ccapsvtskhpacr_mercedes_2023_physical,imputed_values*,warn,Item 'ablation' has one resp value accounting for 99% of responses — possible mean imputation.,5820,30,194
+ccapsvtskhpacr_mercedes_2023_physical,column_order,warn,"columns start ['id', 'cov_sex', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",5820,30,194
+ccapsvtskhpacr_mercedes_2023_sf,imputed_values*,warn,Item 'sf7' has one resp value accounting for 63% of responses — possible mean imputation.,2328,12,194
+ccapsvtskhpacr_mercedes_2023_sf,column_order,warn,"columns start ['id', 'cov_sex', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",2328,12,194
+ccapsvtskhpacr_mercedes_2023_tsk,dup_id_item,warn,2159 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),5457,17,194
+ccapsvtskhpacr_mercedes_2023_tsk,column_order,warn,"columns start ['id', 'cov_sex', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",5457,17,194
+cdm_ecpe,imputed_values*,warn,Item 'E1' has one resp value accounting for 80% of responses — possible mean imputation.,81816,28,2922
+cdm_ecpe,column_order,warn,"columns start ['item', 'id', 'resp']; datastandard.md step 7 writes [id, item, resp] + covariates.",81816,28,2922
+cdm_hr,imputed_values*,warn,Item 'Item1' has one resp value accounting for 74% of responses — possible mean imputation.,54250,35,1550
+cdm_hr,column_order,warn,"columns start ['item', 'id', 'resp']; datastandard.md step 7 writes [id, item, resp] + covariates.",54250,35,1550
+cdm_mentalhealth_tan_2023_bsi,imputed_values*,warn,Item 'absi01' has one resp value accounting for 69% of responses — possible mean imputation.,12223,17,719
+cdm_mentalhealth_tan_2023_rapi,imputed_values*,warn,Item 'arapi01' has one resp value accounting for 83% of responses — possible mean imputation.,16537,23,719
+cdm_pisa00R,imputed_values*,warn,Item 'R040Q02' has one resp value accounting for 61% of responses — possible mean imputation.,28470,26,1095
+cdm_pisa00R,item_scale_outlier,warn,"3 item(s) fall outside the table's 0.0-1.0 scale: ['R077Q03', 'R088Q03', 'R088Q04T']. An isolated out-of-range column is usually not an item -- check for an administrative or count field.",28470,26,1095
+cdm_pisa00R,name_charset,warn,"table name 'cdm_pisa00R' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",28470,26,1095
+cdm_pisa00R,column_order,warn,"columns start ['item', 'id', 'resp']; datastandard.md step 7 writes [id, item, resp] + covariates.",28470,26,1095
+cdm_timss03,imputed_values*,warn,Item 'M012002' has one resp value accounting for 72% of responses — possible mean imputation.,17411,23,757
+cdm_timss03,column_order,warn,"columns start ['item', 'id', 'resp']; datastandard.md step 7 writes [id, item, resp] + covariates.",17411,23,757
+cdm_timss07,imputed_values*,warn,Item 'M031172' has one resp value accounting for 64% of responses — possible mean imputation.,12494,25,698
+cdm_timss07,column_order,warn,"columns start ['item', 'id', 'resp']; datastandard.md step 7 writes [id, item, resp] + covariates.",12494,25,698
+cdm_timss11,imputed_values*,warn,Item 'M031004' has one resp value accounting for 66% of responses — possible mean imputation.,115983,174,4668
+cdm_timss11,column_order,warn,"columns start ['item', 'id', 'resp']; datastandard.md step 7 writes [id, item, resp] + covariates.",115983,174,4668
+chess_lnirt,resp_na,warn,resp has 120 NAs,10240,40,256
+chess_lnirt,imputed_values*,warn,Item 'Y1' has one resp value accounting for 95% of responses — possible mean imputation.,10240,40,256
+christiannationalism_davis2021,item_na,warn,item has 1378 NAs,8268,5,1378
+close_relationships,resp_na,warn,resp has 9534 NAs,1844142,36,51433
+concretewords,dup_id_item,error,1 duplicate id+item rows with no wave/timepoint/date column,691689,1831,66404
+concretewords,imputed_values*,warn,Item 'R_10Nx3eMV0Qg0daY' has one resp value accounting for 69% of responses — possible mean imputation.,691689,1831,66404
+concretewords,density*,warn,"very sparse (density=0.0057); fine for adaptive/booklet designs, else verify",691689,1831,66404
+consideration_future_consequences,resp_na,warn,resp has 351 NAs,180069,12,15028
+content_literacy_interention_g1,imputed_values*,warn,Item '1' has one resp value accounting for 64% of responses — possible mean imputation.,569316,116,5293
+content_literacy_interention_g1,resp_scale_mixed,warn,items span more than one response scale: 96 on 0.0-1.0 and 20 on ['1.0-3.0']. IRW requires one table per construct; split before submitting.,569316,116,5293
+content_literacy_interention_g1,column_order,warn,"columns start ['id', 'treatment', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",569316,116,5293
+credentialform_lnirt,resp_na,warn,resp has 32720 NAs,294480,200,1636
+credentialform_lnirt,imputed_values*,warn,Item 'iraw.1' has one resp value accounting for 89% of responses — possible mean imputation.,294480,200,1636
+criticalperiod_syntax,size_skipped,info,231 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+csft_ye_2025,imputed_values*,warn,Item 'X1' has one resp value accounting for 95% of responses — possible mean imputation.,3520,20,176
+csft_ye_2025,column_order,warn,"columns start ['id', 'item', 'itemcov_weight']; datastandard.md step 7 writes [id, item, resp] + covariates.",3520,20,176
+cub_relgoods,resp_na,warn,resp has 210 NAs,51429,21,2455
+cub_relgoods,imputed_values*,warn,Item 'Dog' has one resp value accounting for 67% of responses — possible mean imputation.,51429,21,2455
+cure_data,dup_id_item,error,22130 duplicate id+item rows with no wave/timepoint/date column,81934,54,1134
+cure_data,imputed_values*,warn,Item '1' has one resp value accounting for 88% of responses — possible mean imputation.,81934,54,1134
+cure_data,resp_scale_mixed,warn,items span more than one response scale: 23 on 1.0-5.0 and 22 on ['1.0-7.0']. IRW requires one table per construct; split before submitting.,81934,54,1134
+cure_data,column_order,warn,"columns start ['id', 'item', 'period']; datastandard.md step 7 writes [id, item, resp] + covariates.",81934,54,1134
+dass_Thiyagarajan2022,name_charset,warn,"table name 'dass_Thiyagarajan2022' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",20391,21,971
+dd_rotation,imputed_values*,warn,Item '1' has one resp value accounting for 85% of responses — possible mean imputation.,1178,10,121
+dd_rotation,column_order,warn,"columns start ['resp', 'rt', 'id']; datastandard.md step 7 writes [id, item, resp] + covariates.",1178,10,121
+deception_game,resp_na,warn,resp has 4 NAs,15260,24,635
+deception_game,dup_id_item,error,24 duplicate id+item rows with no wave/timepoint/date column,15260,24,635
+deception_game,resp_ordinal*,warn,"79 distinct resp values — confirm continuous, not mis-parsed",15260,24,635
+deception_game,imputed_values*,warn,Item '5' has one resp value accounting for 88% of responses — possible mean imputation.,15260,24,635
+deception_game,resp_scale_mixed,warn,"items span more than one response scale: 18 on 0.0-1.0 and 6 on ['0.0-100.0', '1.0-7.0', '0.0-3.0']. IRW requires one table per construct; split before submitting.",15260,24,635
+deception_professors,resp_na,warn,resp has 3262 NAs,8666,21,568
+deception_professors,resp_ordinal*,warn,"83 distinct resp values — confirm continuous, not mis-parsed",8666,21,568
+deception_professors,imputed_values*,warn,Item '4' has one resp value accounting for 88% of responses — possible mean imputation.,8666,21,568
+deception_professors,resp_scale_mixed,warn,"items span more than one response scale: 8 on 1.0-7.0 and 8 on ['0.0-100.0', '0.0-82.0', '0.0-91.0']. IRW requires one table per construct; split before submitting.",8666,21,568
+depression_anxiety_stress,resp_na,warn,resp has 5357 NAs,2699343,68,39775
+depression_anxiety_stress,imputed_values*,warn,Item '23' has one resp value accounting for 63% of responses — possible mean imputation.,2699343,68,39775
+depression_anxiety_stress,rt_numeric*,warn,rt column is not numeric,2699343,68,39775
+depression_anxiety_stress,resp_scale_mixed,warn,"items span more than one response scale: 42 on 1.0-4.0 and 26 on ['1.0-7.0', '0.0-1.0']. IRW requires one table per construct; split before submitting.",2699343,68,39775
+depression_hymcohort_tang2022,imputed_values*,warn,Item 'depression_bsi_11' has one resp value accounting for 72% of responses — possible mean imputation.,10752,24,448
+det_naismith_2023,dup_id_item,error,2292 duplicate id+item rows with no wave/timepoint/date column,3438,3,573
+det_naismith_2023,resp_ordinal*,warn,"1152 distinct resp values — confirm continuous, not mis-parsed",3438,3,573
+det_naismith_2023,column_order,warn,"columns start ['id', 'item', 'cov_gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",3438,3,573
+difNLR_msatb,imputed_values*,warn,Item 'Item1' has one resp value accounting for 67% of responses — possible mean imputation.,28140,20,1407
+difNLR_msatb,name_charset,warn,"table name 'difNLR_msatb' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",28140,20,1407
+ds14_mokken,resp_na,warn,resp has 10 NAs,7564,14,541
+ds14_mokken,multi_scale*,warn,"Item names suggest 2 subscales (['si', 'na']) — IRW requires separate tables per construct.",7564,14,541
+ds14_mokken,item_scale_outlier,warn,1 item(s) fall outside the table's 0.0-4.0 scale: ['Si1.']. An isolated out-of-range column is usually not an item -- check for an administrative or count field.,7564,14,541
+ds14_mokken,column_order,warn,"columns start ['id', 'item', 'age']; datastandard.md step 7 writes [id, item, resp] + covariates.",7564,14,541
+dumas_Organisciak_2022,resp_na,warn,resp has 178 NAs,21782,10,92
+dumas_Organisciak_2022,dup_id_item,error,21060 duplicate id+item rows with no wave/timepoint/date column,21782,10,92
+dumas_Organisciak_2022,name_charset,warn,"table name 'dumas_Organisciak_2022' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",21782,10,92
+dumas_Organisciak_2022,sample_floor,warn,"92 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",21782,10,92
+dumas_Organisciak_2022,column_order,warn,"columns start ['id', 'item', 'verbatim']; datastandard.md step 7 writes [id, item, resp] + covariates.",21782,10,92
+duolingo_en_es__listen,dup_id_item,error,51869 duplicate id+item rows with no wave/timepoint/date column,755856,116689,2579
+duolingo_en_es__listen,imputed_values*,warn,Item 'A ella la vi antes.__The' has one resp value accounting for 100% of responses — possible mean imputation.,755856,116689,2579
+duolingo_en_es__listen,rt_negative*,warn,rt has negative values,755856,116689,2579
+duolingo_en_es__listen,multi_scale*,warn,"Item names suggest 3597 subscales (['si tú quieres.', 'más pimienta, por favor.', 'mi clase es esta noche.', 'siete, ocho, nueve']) — IRW requires separate tables per construct.",755856,116689,2579
+duolingo_en_es__listen,resp_scale_mixed,warn,"items span more than one response scale: 71169 on 0-0 and 45520 on ['1-1', '0-1']. IRW requires one table per construct; split before submitting.",755856,116689,2579
+duolingo_en_es__listen,composite_items*,warn,"138/116689 item labels name computed scores (['Tengo dieciocho caballos.__sum', 'Mis últimos veinte años__sum', 'Cuarenta días__sum', 'Tengo diecinueve caballos.__sum']) — drop them, or confirm they are real items",755856,116689,2579
+duolingo_en_es__listen,density*,warn,"very sparse (density=0.0025); fine for adaptive/booklet designs, else verify",755856,116689,2579
+duolingo_en_es__reverse_tap,dup_id_item,error,48170 duplicate id+item rows with no wave/timepoint/date column,693857,13282,2168
+duolingo_en_es__reverse_tap,imputed_values*,warn,Item 'A ella la vi antes.__I' has one resp value accounting for 100% of responses — possible mean imputation.,693857,13282,2168
+duolingo_en_es__reverse_tap,multi_scale*,warn,"Item names suggest 2852 subscales (['¿crees en el amor a primera vista, o debo pasar de nuevo?', 'ella va a pensar que no la quiero.', 'la niña tiene los ojos del padre y la nariz de la madre.', '¿te gustaría ir a tomar un café?']) — IRW requires separate tables per construct.",693857,13282,2168
+duolingo_en_es__reverse_tap,resp_scale_mixed,warn,"items span more than one response scale: 9452 on 0-0 and 3830 on ['0-1', '1-1']. IRW requires one table per construct; split before submitting.",693857,13282,2168
+duolingo_en_es__reverse_tap,composite_items*,warn,"10/13282 item labels name computed scores (['La suma__sum', 'El promedio es diez.__average', 'El promedio es cuatro.__average', 'Somos ocho en total.__We']) — drop them, or confirm they are real items",693857,13282,2168
+duolingo_en_es__reverse_translate,size_skipped,info,12 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+duolingo_es_en__listen,size_skipped,info,8 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+duolingo_es_en__reverse_tap,dup_id_item,error,48924 duplicate id+item rows with no wave/timepoint/date column,540054,13148,2363
+duolingo_es_en__reverse_tap,imputed_values*,warn,Item 'A bad weed never dies.__Mala' has one resp value accounting for 67% of responses — possible mean imputation.,540054,13148,2363
+duolingo_es_en__reverse_tap,multi_scale*,warn,"Item names suggest 2874 subscales (['you write the letter.', 'i am the son of my parents.', 'i do not need to read your terms of service to accept you!', 'are you lost? heaven is far from here.']) — IRW requires separate tables per construct.",540054,13148,2363
+duolingo_es_en__reverse_tap,resp_scale_mixed,warn,"items span more than one response scale: 9161 on 0-0 and 3987 on ['0-1', '1-1']. IRW requires one table per construct; split before submitting.",540054,13148,2363
+duolingo_es_en__reverse_translate,dup_id_item,error,43980 duplicate id+item rows with no wave/timepoint/date column,575485,17161,2643
+duolingo_es_en__reverse_translate,imputed_values*,warn,Item 'A bad weed never dies.__Mala' has one resp value accounting for 71% of responses — possible mean imputation.,575485,17161,2643
+duolingo_es_en__reverse_translate,multi_scale*,warn,"Item names suggest 3636 subscales (['she started to produce with only one machine.', 'you are going to use the spoon.', 'your place or mine?', 'you write the letter.']) — IRW requires separate tables per construct.",575485,17161,2643
+duolingo_fr_en__listen,dup_id_item,error,8820 duplicate id+item rows with no wave/timepoint/date column,182041,50783,1205
+duolingo_fr_en__listen,imputed_values*,warn,Item 'A Friday in May__De' has one resp value accounting for 100% of responses — possible mean imputation.,182041,50783,1205
+duolingo_fr_en__listen,multi_scale*,warn,"Item names suggest 2461 subscales (['please!', 'the bear is orange!', 'i eat some baguettes.', 'the skirts']) — IRW requires separate tables per construct.",182041,50783,1205
+duolingo_fr_en__listen,resp_scale_mixed,warn,"items span more than one response scale: 30416 on 0-0 and 20367 on ['1-1', '0-1']. IRW requires one table per construct; split before submitting.",182041,50783,1205
+duolingo_fr_en__listen,composite_items*,warn,"14/50783 item labels name computed scores (['It is mean.__Le', 'It is mean.__garçon', 'It is mean.__est', 'It is mean.__drôle']) — drop them, or confirm they are real items",182041,50783,1205
+duolingo_fr_en__listen,density*,warn,"very sparse (density=0.003); fine for adaptive/booklet designs, else verify",182041,50783,1205
+duolingo_fr_en__reverse_tap,dup_id_item,error,38703 duplicate id+item rows with no wave/timepoint/date column,357601,12276,1053
+duolingo_fr_en__reverse_tap,imputed_values*,warn,Item 'A Saturday in June__Un' has one resp value accounting for 100% of responses — possible mean imputation.,357601,12276,1053
+duolingo_fr_en__reverse_tap,multi_scale*,warn,"Item names suggest 2596 subscales (['is it hot in here, or is that just you?', ""what's your name?"", 'do you have vegetables?', 'are you a model?']) — IRW requires separate tables per construct.",357601,12276,1053
+duolingo_fr_en__reverse_tap,resp_scale_mixed,warn,"items span more than one response scale: 8745 on 0-0 and 3531 on ['0-1', '1-1']. IRW requires one table per construct; split before submitting.",357601,12276,1053
+duolingo_fr_en__reverse_tap,composite_items*,warn,"21/12276 item labels name computed scores ([""What does that mean?__Qu'"", 'What does that mean?__est', 'What does that mean?__-', 'What does that mean?__ce']) — drop them, or confirm they are real items",357601,12276,1053
+duolingo_fr_en__reverse_translate,dup_id_item,error,38537 duplicate id+item rows with no wave/timepoint/date column,387004,15293,1213
+duolingo_fr_en__reverse_translate,imputed_values*,warn,Item 'A Friday in May__Un' has one resp value accounting for 100% of responses — possible mean imputation.,387004,15293,1213
+duolingo_fr_en__reverse_translate,multi_scale*,warn,"Item names suggest 3125 subscales (['do you want a child or a dog?', 'is it hot in here, or is that just you?', 'there are some nice things to eat, if you feel like it!', 'he is like his dog, he always has to bare his teeth.']) — IRW requires separate tables per construct.",387004,15293,1213
+duolingo_fr_en__reverse_translate,composite_items*,warn,"7/15293 item labels name computed scores ([""It is mean.__C'"", 'It is mean.__est', 'It is mean.__méchant', 'The total is good.__Le']) — drop them, or confirm they are real items",387004,15293,1213
+dvivdtws_ppmial_marcatto_2023_cwb,resp_na,warn,resp has 21 NAs,12145,22,553
+dvivdtws_ppmial_marcatto_2023_cwb,imputed_values*,warn,Item 'dtw11' has one resp value accounting for 69% of responses — possible mean imputation.,12145,22,553
+dvivdtws_ppmial_marcatto_2023_cwb,column_order,warn,"columns start ['id', 'cov_gender', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",12145,22,553
+dvivdtws_ppmial_marcatto_2023_dtw,resp_na,warn,resp has 21 NAs,12145,22,553
+dvivdtws_ppmial_marcatto_2023_dtw,imputed_values*,warn,Item 'dtw11' has one resp value accounting for 69% of responses — possible mean imputation.,12145,22,553
+dvivdtws_ppmial_marcatto_2023_dtw,column_order,warn,"columns start ['id', 'cov_gender', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",12145,22,553
+dvivdtws_ppmial_marcatto_2023_ocb,resp_na,warn,resp has 21 NAs,12145,22,553
+dvivdtws_ppmial_marcatto_2023_ocb,imputed_values*,warn,Item 'dtw11' has one resp value accounting for 69% of responses — possible mean imputation.,12145,22,553
+dvivdtws_ppmial_marcatto_2023_ocb,column_order,warn,"columns start ['id', 'cov_gender', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",12145,22,553
+dvivdtws_ppmial_marcatto_2023_ocs,resp_na,warn,resp has 21 NAs,12145,22,553
+dvivdtws_ppmial_marcatto_2023_ocs,imputed_values*,warn,Item 'dtw11' has one resp value accounting for 69% of responses — possible mean imputation.,12145,22,553
+dvivdtws_ppmial_marcatto_2023_ocs,column_order,warn,"columns start ['id', 'cov_gender', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",12145,22,553
+dvivdtws_ppmial_marcatto_2023_snaq,resp_na,warn,resp has 21 NAs,12145,22,553
+dvivdtws_ppmial_marcatto_2023_snaq,imputed_values*,warn,Item 'dtw11' has one resp value accounting for 69% of responses — possible mean imputation.,12145,22,553
+dvivdtws_ppmial_marcatto_2023_snaq,column_order,warn,"columns start ['id', 'cov_gender', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",12145,22,553
+ees_sarling_2024,multi_scale*,warn,"Item names suggest 2 subscales (['iu', 've']) — IRW requires separate tables per construct.",24150,30,805
+ees_sarling_2024,column_order,warn,"columns start ['id', 'cov_age', 'cov_gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",24150,30,805
+emotion_pcmrs,imputed_values*,warn,Item 'Stammer' has one resp value accounting for 67% of responses — possible mean imputation.,16256,8,2032
+empathizing_systemizing,resp_na,warn,resp has 7420 NAs,1583300,120,13254
+enem_2013_1mil_ch,size_skipped,info,25 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2013_1mil_cn,size_skipped,info,22 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2013_1mil_lc,size_skipped,info,23 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2013_1mil_mt,size_skipped,info,23 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2014_1mil_ch,size_skipped,info,22 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2014_1mil_cn,size_skipped,info,21 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2014_1mil_lc,size_skipped,info,24 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2014_1mil_mt,size_skipped,info,21 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2015_1mil_ch,size_skipped,info,26 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2015_1mil_cn,size_skipped,info,24 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2015_1mil_lc,size_skipped,info,21 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2015_1mil_mt,size_skipped,info,24 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2016_1mil_ch,size_skipped,info,27 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2016_1mil_cn,size_skipped,info,25 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2016_1mil_lc,size_skipped,info,21 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2016_1mil_mt,size_skipped,info,26 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2017_1mil_ch,size_skipped,info,25 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2017_1mil_cn,size_skipped,info,24 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2017_1mil_lc,size_skipped,info,28 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2017_1mil_mt,size_skipped,info,24 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2018_1mil_ch,size_skipped,info,24 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2018_1mil_cn,size_skipped,info,24 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2018_1mil_lc,size_skipped,info,21 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2018_1mil_mt,size_skipped,info,23 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2019_1mil_ch,size_skipped,info,26 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2019_1mil_cn,size_skipped,info,26 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2019_1mil_lc,size_skipped,info,24 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2019_1mil_mt,size_skipped,info,25 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2020_1mil_ch,size_skipped,info,29 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2020_1mil_cn,size_skipped,info,28 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2020_1mil_lc,size_skipped,info,22 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2020_1mil_mt,size_skipped,info,28 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2021_1mil_ch,size_skipped,info,27 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2021_1mil_cn,size_skipped,info,27 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2021_1mil_lc,size_skipped,info,22 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2021_1mil_mt,size_skipped,info,26 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2022_1mil_ch,size_skipped,info,27 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2022_1mil_cn,size_skipped,info,26 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2022_1mil_lc,size_skipped,info,25 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+enem_2022_1mil_mt,size_skipped,info,26 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+envirisk_lalot_2025,resp_na,warn,resp has 22 NAs,24038,12,2005
+envirisk_lalot_2025,multi_scale*,warn,"Item names suggest 3 subscales (['policy', 'bd', 'cc']) — IRW requires separate tables per construct.",24038,12,2005
+envirisk_lalot_2025,resp_scale_mixed,warn,items span more than one response scale: 10 on 1-7 and 2 on ['0-10']. IRW requires one table per construct; split before submitting.,24038,12,2005
+envirisk_lalot_2025,column_order,warn,"columns start ['id', 'cov_age', 'cov_gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",24038,12,2005
+environment_ltm,imputed_values*,warn,Item 'AirPollution' has one resp value accounting for 65% of responses — possible mean imputation.,1746,6,291
+erf_breuer_2017_dosp,resp_na,warn,resp has 513 NAs,3384,9,376
+erf_breuer_2017_dosp,imputed_values*,warn,Item 'DOSP3' has one resp value accounting for 66% of responses — possible mean imputation.,3384,9,376
+erf_breuer_2017_dosp,column_order,warn,"columns start ['id', 'cov_gender', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",3384,9,376
+erf_breuer_2017_frmfr,resp_na,warn,resp has 5750 NAs,5075,25,203
+erf_breuer_2017_frmfr,imputed_values*,warn,Item 'FRM_FR1' has one resp value accounting for 96% of responses — possible mean imputation.,5075,25,203
+erf_breuer_2017_frmfr,column_order,warn,"columns start ['id', 'cov_gender', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",5075,25,203
+erf_breuer_2017_frmmc,resp_na,warn,resp has 5075 NAs,5750,25,230
+erf_breuer_2017_frmmc,imputed_values*,warn,Item 'FRM_MC1' has one resp value accounting for 97% of responses — possible mean imputation.,5750,25,230
+erf_breuer_2017_frmmc,column_order,warn,"columns start ['id', 'cov_gender', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",5750,25,230
+erf_breuer_2017_tai,resp_na,warn,resp has 855 NAs,5640,15,376
+erf_breuer_2017_tai,column_order,warn,"columns start ['id', 'cov_gender', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",5640,15,376
+estcrm_epia,resp_ordinal*,warn,"111 distinct resp values — confirm continuous, not mis-parsed",5165,5,1033
+estcrm_selfeff,resp_ordinal*,warn,"161 distinct resp values — confirm continuous, not mis-parsed",3070,10,307
+estcrm_selfeff,resp_scale_mixed,warn,"items span more than one response scale: 1 on 3.5-10.9 and 9 on ['3.0-11.0', '4.9-10.95', '1.9-11.0']. IRW requires one table per construct; split before submitting.",3070,10,307
+eurpar2_mudfold,imputed_values*,warn,Item 'communists' has one resp value accounting for 80% of responses — possible mean imputation.,10716,6,1786
+evpromisi_stone_2021_cdiag,resp_na,warn,resp has 15 NAs,5817,12,483
+evpromisi_stone_2021_cdiag,dup_id_item,error,24 duplicate id+item rows with no wave/timepoint/date column,5817,12,483
+evpromisi_stone_2021_cdiag,imputed_values*,warn,Item 'cdiag01' has one resp value accounting for 91% of responses — possible mean imputation.,5817,12,483
+evpromisi_stone_2021_cdiag,column_order,warn,"columns start ['id', 'cov_age', 'cov_gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",5817,12,483
+evpromisi_stone_2021_ddedanx,resp_na,warn,resp has 34 NAs,33097,7,183
+evpromisi_stone_2021_ddedanx,dup_id_item,warn,31850 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),33097,7,183
+evpromisi_stone_2021_ddedanx,imputed_values*,warn,Item 'DDEDANX01' has one resp value accounting for 69% of responses — possible mean imputation.,33097,7,183
+evpromisi_stone_2021_ddedanx,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",33097,7,183
+evpromisi_stone_2021_ddeddep,dup_id_item,warn,57105 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),59369,8,283
+evpromisi_stone_2021_ddeddep,imputed_values*,warn,Item 'DDEDDEP04' has one resp value accounting for 80% of responses — possible mean imputation.,59369,8,283
+evpromisi_stone_2021_ddeddep,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",59369,8,283
+evpromisi_stone_2021_ddpainin,resp_na,warn,resp has 35 NAs,31501,6,200
+evpromisi_stone_2021_ddpainin,dup_id_item,warn,30336 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),31501,6,200
+evpromisi_stone_2021_ddpainin,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",31501,6,200
+evpromisi_stone_2021_global,resp_na,warn,resp has 13 NAs,4847,10,483
+evpromisi_stone_2021_global,dup_id_item,error,20 duplicate id+item rows with no wave/timepoint/date column,4847,10,483
+evpromisi_stone_2021_global,item_scale_outlier,warn,1 item(s) fall outside the table's 1-5 scale: ['Global07']. An isolated out-of-range column is usually not an item -- check for an administrative or count field.,4847,10,483
+evpromisi_stone_2021_global,column_order,warn,"columns start ['id', 'cov_age', 'cov_gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",4847,10,483
+experimental_iq,resp_na,warn,resp has 526 NAs,9474,25,399
+experimental_iq,imputed_values*,warn,Item '1' has one resp value accounting for 89% of responses — possible mean imputation.,9474,25,399
+face_memory_test,resp_na,warn,resp has 157566 NAs,151834,175,1768
+face_memory_test,imputed_values*,warn,Item '1' has one resp value accounting for 98% of responses — possible mean imputation.,151834,175,1768
+face_memory_test,rt_numeric*,warn,rt column is not numeric,151834,175,1768
+fad_dataset1,imputed_values*,warn,Item '18' has one resp value accounting for 64% of responses — possible mean imputation.,1512,27,56
+fad_dataset1,sample_floor,warn,"56 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",1512,27,56
+fad_dataset2,resp_na,warn,resp has 14702 NAs,19754,59,584
+fad_dataset2,imputed_values*,warn,Item '13' has one resp value accounting for 63% of responses — possible mean imputation.,19754,59,584
+famous_melodies,dup_id_item,error,42336 duplicate id+item rows with no wave/timepoint/date column,42876,5,109
+famous_melodies,imputed_values*,warn,Item 'naming' has one resp value accounting for 62% of responses — possible mean imputation.,42876,5,109
+famous_melodies,resp_scale_mixed,warn,items span more than one response scale: 3 on 0-4 and 1 on ['1-8']. IRW requires one table per construct; split before submitting.,42876,5,109
+famous_melodies,column_order,warn,"columns start ['id', 'rater', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",42876,5,109
+fcupanas_cffsdas_reyna_2018,resp_na,warn,resp has 1430 NAs,31290,40,805
+fcupanas_cffsdas_reyna_2018,dup_id_item,error,10980 duplicate id+item rows with no wave/timepoint/date column,31290,40,805
+fcupanas_cffsdas_reyna_2018,imputed_values*,warn,Item 'panas13' has one resp value accounting for 63% of responses — possible mean imputation.,31290,40,805
+fcupanas_cffsdas_reyna_2018,column_order,warn,"columns start ['id', 'cov_sex', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",31290,40,805
+feardriving_fisher2021,imputed_values*,warn,Item 'DCQ10' has one resp value accounting for 83% of responses — possible mean imputation.,20250,25,810
+feardriving_fisher2021,multi_scale*,warn,"Item names suggest 2 subscales (['dcq', 'isap']) — IRW requires separate tables per construct.",20250,25,810
+feminist_perspectives,resp_na,warn,resp has 14291 NAs,794329,60,13471
+feminist_perspectives,imputed_values*,warn,Item '1.0' has one resp value accounting for 77% of responses — possible mean imputation.,794329,60,13471
+ffm_AGR,size_skipped,info,52 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+ffm_CSN,size_skipped,info,52 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+ffm_EST,size_skipped,info,52 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+ffm_EXT,size_skipped,info,52 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+ffm_OPN,size_skipped,info,51 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+fictionexposure_wimmer,imputed_values*,warn,Item 'Business1' has one resp value accounting for 98% of responses — possible mean imputation.,66726,198,337
+fictionexposure_wimmer,multi_scale*,warn,"Item names suggest 11 subscales (['foils', 'scififantasy', 'domestic', 'romance']) — IRW requires separate tables per construct.",66726,198,337
+figure_skating,resp_ordinal*,warn,"1103 distinct resp values — confirm continuous, not mis-parsed",23077,663,1676
+figure_skating,imputed_values*,warn,Item '8' has one resp value accounting for 100% of responses — possible mean imputation.,23077,663,1676
+figure_skating,resp_scale_mixed,warn,"items span more than one response scale: 40 on 0.0-0.0 and 623 on ['2.13-4.7', '5.5-12.35', '11.6-14.19']. IRW requires one table per construct; split before submitting.",23077,663,1676
+figure_skating,column_order,warn,"columns start ['id', 'person_id', 'nation']; datastandard.md step 7 writes [id, item, resp] + covariates.",23077,663,1676
+fims_tam,imputed_values*,warn,Item 'M1PTI1' has one resp value accounting for 77% of responses — possible mean imputation.,89194,14,6371
+fims_tam,column_order,warn,"columns start ['id', 'item', 'country']; datastandard.md step 7 writes [id, item, resp] + covariates.",89194,14,6371
+firstborn_personality,resp_na,warn,resp has 19005 NAs,3160911,76,41841
+fisher_temperment,resp_na,warn,resp has 180 NAs,436916,88,4967
+fisher_temperment,imputed_values*,warn,Item '58' has one resp value accounting for 66% of responses — possible mean imputation.,436916,88,4967
+fisher_temperment,rt_numeric*,warn,rt column is not numeric,436916,88,4967
+fisher_temperment,resp_scale_mixed,warn,"items span more than one response scale: 56 on 1.0-4.0 and 26 on ['1.0-7.0', '0.0-1.0']. IRW requires one table per construct; split before submitting.",436916,88,4967
+florida_twins,imputed_values*,warn,Item '12' has one resp value accounting for 94% of responses — possible mean imputation.,1212066,1809,2314
+florida_twins,resp_scale_mixed,warn,"items span more than one response scale: 692 on 1.0-4.0 and 1113 on ['1.0-5.0', '0.0-1.0', '1.0-6.0']. IRW requires one table per construct; split before submitting.",1212066,1809,2314
+florida_twins,column_order,warn,"columns start ['person_id', 'id', 'family_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",1212066,1809,2314
+florida_twins_auth,dup_id_item,warn,37709 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),115306,100,1356
+florida_twins_auth,imputed_values*,warn,Item 'auth10a' has one resp value accounting for 90% of responses — possible mean imputation.,115306,100,1356
+florida_twins_auth,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",115306,100,1356
+florida_twins_behavior,imputed_values*,warn,Item '6' has one resp value accounting for 63% of responses — possible mean imputation.,743286,692,1388
+florida_twins_behavior,resp_scale_mixed,warn,items span more than one response scale: 514 on 1.0-4.0 and 176 on ['1.0-5.0']. IRW requires one table per construct; split before submitting.,743286,692,1388
+florida_twins_behavior,column_order,warn,"columns start ['id', 'family_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",743286,692,1388
+florida_twins_behavior_cads,dup_id_item,error,78146 duplicate id+item rows with no wave/timepoint/date column,156292,57,1378
+florida_twins_behavior_cads,imputed_values*,warn,Item 'cads_10' has one resp value accounting for 62% of responses — possible mean imputation.,156292,57,1378
+florida_twins_behavior_cadsyv,dup_id_item,error,48427 duplicate id+item rows with no wave/timepoint/date column,96854,57,861
+florida_twins_behavior_cadsyv,imputed_values*,warn,Item 'cadsyv2' has one resp value accounting for 64% of responses — possible mean imputation.,96854,57,861
+florida_twins_behavior_ecs,dup_id_item,error,53221 duplicate id+item rows with no wave/timepoint/date column,106442,48,1387
+florida_twins_behavior_ecs,imputed_values*,warn,Item 'ecs18' has one resp value accounting for 62% of responses — possible mean imputation.,106442,48,1387
+florida_twins_behavior_friends,dup_id_item,error,16193 duplicate id+item rows with no wave/timepoint/date column,32386,19,858
+florida_twins_behavior_friends,imputed_values*,warn,Item 'friends10' has one resp value accounting for 81% of responses — possible mean imputation.,32386,19,858
+florida_twins_behavior_panas,dup_id_item,error,44101 duplicate id+item rows with no wave/timepoint/date column,88202,40,1387
+florida_twins_behavior_panas,imputed_values*,warn,Item 'panas8' has one resp value accounting for 63% of responses — possible mean imputation.,88202,40,1387
+florida_twins_behavior_rcads,dup_id_item,error,104498 duplicate id+item rows with no wave/timepoint/date column,208996,94,1387
+florida_twins_behavior_rcads,imputed_values*,warn,Item 'rcads1' has one resp value accounting for 70% of responses — possible mean imputation.,208996,94,1387
+florida_twins_behavior_tas,dup_id_item,error,25681 duplicate id+item rows with no wave/timepoint/date column,51362,30,861
+florida_twins_behavior_tas,imputed_values*,warn,Item 'tas10' has one resp value accounting for 64% of responses — possible mean imputation.,51362,30,861
+florida_twins_cads,dup_id_item,warn,17901 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),89680,57,1272
+florida_twins_cads,imputed_values*,warn,Item 'cadsyv21' has one resp value accounting for 63% of responses — possible mean imputation.,89680,57,1272
+florida_twins_cads,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",89680,57,1272
+florida_twins_chaos,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",4806,6,808
+florida_twins_class,imputed_values*,warn,Item 'class5' has one resp value accounting for 63% of responses — possible mean imputation.,7994,10,806
+florida_twins_class,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",7994,10,806
+florida_twins_cqbar,imputed_values*,warn,Item 'cqbar1' has one resp value accounting for 94% of responses — possible mean imputation.,29100,50,767
+florida_twins_cqbar,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",29100,50,767
+florida_twins_dbi,imputed_values*,warn,Item 'dbi1' has one resp value accounting for 80% of responses — possible mean imputation.,21801,36,606
+florida_twins_dbi,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",21801,36,606
+florida_twins_dweck,dup_id_item,warn,3986 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),10997,8,879
+florida_twins_dweck,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",10997,8,879
+florida_twins_friends,dup_id_item,warn,15648 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),42374,21,1351
+florida_twins_friends,imputed_values*,warn,Item 'friends10' has one resp value accounting for 86% of responses — possible mean imputation.,42374,21,1351
+florida_twins_friends,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",42374,21,1351
+florida_twins_game,imputed_values*,warn,Item 'game1_genrecode' has one resp value accounting for 62% of responses — possible mean imputation.,2326,7,591
+florida_twins_game,resp_scale_mixed,warn,"items span more than one response scale: 3 on 1-6 and 4 on ['1-7', '0-1']. IRW requires one table per construct; split before submitting.",2326,7,591
+florida_twins_game,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",2326,7,591
+florida_twins_grades,dup_id_item,warn,3307 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),8685,4,1348
+florida_twins_grades,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",8685,4,1348
+florida_twins_grit,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",9257,12,782
+florida_twins_hwk,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",2405,4,602
+florida_twins_leq,imputed_values*,warn,Item 'leq10n' has one resp value accounting for 74% of responses — possible mean imputation.,15322,42,607
+florida_twins_leq,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",15322,42,607
+florida_twins_media,imputed_values*,warn,Item 'media4t' has one resp value accounting for 92% of responses — possible mean imputation.,6312,11,608
+florida_twins_media,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",6312,11,608
+florida_twins_nes,dup_id_item,warn,8297 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),21739,10,1353
+florida_twins_nes,imputed_values*,warn,Item 'nes10' has one resp value accounting for 95% of responses — possible mean imputation.,21739,10,1353
+florida_twins_nes,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",21739,10,1353
+florida_twins_pals,imputed_values*,warn,Item 'qpals13' has one resp value accounting for 70% of responses — possible mean imputation.,27879,36,784
+florida_twins_pals,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",27879,36,784
+florida_twins_panas,dup_id_item,warn,16415 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),43228,20,1351
+florida_twins_panas,imputed_values*,warn,Item 'panas13t' has one resp value accounting for 68% of responses — possible mean imputation.,43228,20,1351
+florida_twins_panas,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",43228,20,1351
+florida_twins_par,dup_id_item,warn,3887 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),31078,31,1353
+florida_twins_par,imputed_values*,warn,Item 'par1' has one resp value accounting for 89% of responses — possible mean imputation.,31078,31,1353
+florida_twins_par,resp_scale_mixed,warn,"items span more than one response scale: 11 on 1.0-2.0 and 20 on ['1.0-3.0', '1.0-5.0', '1.0-4.0']. IRW requires one table per construct; split before submitting.",31078,31,1353
+florida_twins_par,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",31078,31,1353
+florida_twins_read,imputed_values*,warn,Item 'read11' has one resp value accounting for 64% of responses — possible mean imputation.,43010,54,809
+florida_twins_read,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",43010,54,809
+florida_twins_sch,imputed_values*,warn,Item 'sch1' has one resp value accounting for 80% of responses — possible mean imputation.,15148,19,804
+florida_twins_sch,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",15148,19,804
+florida_twins_tech,imputed_values*,warn,Item 'tech10mf' has one resp value accounting for 76% of responses — possible mean imputation.,13198,22,608
+florida_twins_tech,column_order,warn,"columns start ['id', 'cov_age', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",13198,22,608
+frac20,imputed_values*,warn,Item 'item_10' has one resp value accounting for 62% of responses — possible mean imputation.,10720,20,536
+frac20,column_order,warn,"columns start ['item', 'id', 'resp']; datastandard.md step 7 writes [id, item, resp] + covariates.",10720,20,536
+fractals_rating,dup_id_item,error,68880 duplicate id+item rows with no wave/timepoint/date column,71680,7,400
+fractals_rating,column_order,warn,"columns start ['id', 'item', 'rater']; datastandard.md step 7 writes [id, item, resp] + covariates.",71680,7,400
+ftna_kasper_2022,size_skipped,info,10 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+fullscaleiq_memory,imputed_values*,warn,Item 'MQ1' has one resp value accounting for 71% of responses — possible mean imputation.,19164,6,3194
+fullscaleiq_memory,resp_scale_mixed,warn,"items span more than one response scale: 2 on -4-4 and 4 on ['-5-3', '-3-5', '-2-5']. IRW requires one table per construct; split before submitting.",19164,6,3194
+fullscaleiq_mentalrotation,resp_scale_mixed,warn,"items span more than one response scale: 2 on -4-4 and 4 on ['-5-3', '-2-5', '-3-5']. IRW requires one table per construct; split before submitting.",19164,6,3194
+fullscaleiq_vocab,resp_scale_mixed,warn,"items span more than one response scale: 2 on -1-4 and 5 on ['-2-3', '-2-4', '-3-4']. IRW requires one table per construct; split before submitting.",22358,7,3194
+g308_sirt,imputed_values*,warn,Item 'G30801' has one resp value accounting for 79% of responses — possible mean imputation.,14940,20,747
+g308_sirt,column_order,warn,"columns start ['id', 'item', 'testlet']; datastandard.md step 7 writes [id, item, resp] + covariates.",14940,20,747
+gad_BrummerHoffman_2021,resp_na,warn,resp has 45 NAs,63935,35,1828
+gad_BrummerHoffman_2021,name_charset,warn,"table name 'gad_BrummerHoffman_2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",63935,35,1828
+gad_BrummerHoffman_2021,column_order,warn,"columns start ['id', 'group', 'date']; datastandard.md step 7 writes [id, item, resp] + covariates.",63935,35,1828
+gcbs_brotherton_2013,cov_range,warn,"cov_age spans 13-33769, outside [0, 120] -- looks like a sentinel no-answer code (999/9999) or a birth year that was never converted. irw_filter() treats every value here as an age (#1779).",37425,15,2495
+gcbs_brotherton_2013_tipi,column_order,warn,"columns start ['id', 'cov_education', 'cov_urban']; datastandard.md step 7 writes [id, item, resp] + covariates.",24950,10,2495
+gcbs_brotherton_2013_tipi,cov_range,warn,"cov_age spans 13-33769, outside [0, 120] -- looks like a sentinel no-answer code (999/9999) or a birth year that was never converted. irw_filter() treats every value here as an age (#1779).",24950,10,2495
+gcbs_brotherton_2013_vcl,imputed_values*,warn,Item 'VCL1' has one resp value accounting for 97% of responses — possible mean imputation.,39920,16,2495
+gcbs_brotherton_2013_vcl,column_order,warn,"columns start ['id', 'cov_education', 'cov_urban']; datastandard.md step 7 writes [id, item, resp] + covariates.",39920,16,2495
+gcbs_brotherton_2013_vcl,cov_range,warn,"cov_age spans 13-33769, outside [0, 120] -- looks like a sentinel no-answer code (999/9999) or a birth year that was never converted. irw_filter() treats every value here as an age (#1779).",39920,16,2495
+geiser_tam,imputed_values*,warn,Item 'mrt10' has one resp value accounting for 83% of responses — possible mean imputation.,12456,24,519
+gender_roles,size_skipped,info,9 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+genpsych_russell_2024_gemma,resp_na,warn,resp has 306 NAs,27722,28,1000
+genpsych_russell_2024_gemma,column_order,warn,"columns start ['cov_age', 'cov_english', 'cov_hispanic']; datastandard.md step 7 writes [id, item, resp] + covariates.",27722,28,1000
+genpsych_russell_2024_gpt3.5,resp_na,warn,resp has 385 NAs,30646,31,1000
+genpsych_russell_2024_gpt3.5,column_order,warn,"columns start ['cov_age', 'cov_english', 'cov_hispanic']; datastandard.md step 7 writes [id, item, resp] + covariates.",30646,31,1000
+genpsych_russell_2024_gpt4o,resp_na,warn,resp has 362 NAs,34603,35,999
+genpsych_russell_2024_gpt4o,column_order,warn,"columns start ['cov_age', 'cov_english', 'cov_hispanic']; datastandard.md step 7 writes [id, item, resp] + covariates.",34603,35,999
+genpsych_russell_2024_llama3,resp_na,warn,resp has 351 NAs,29679,30,1001
+genpsych_russell_2024_llama3,column_order,warn,"columns start ['cov_age', 'cov_english', 'cov_hispanic']; datastandard.md step 7 writes [id, item, resp] + covariates.",29679,30,1001
+genpsych_russell_2024_mixtral,resp_na,warn,resp has 285 NAs,31651,32,998
+genpsych_russell_2024_mixtral,imputed_values*,warn,Item 'items_4' has one resp value accounting for 68% of responses — possible mean imputation.,31651,32,998
+genpsych_russell_2024_mixtral,column_order,warn,"columns start ['cov_age', 'cov_english', 'cov_hispanic']; datastandard.md step 7 writes [id, item, resp] + covariates.",31651,32,998
+geography,size_skipped,info,100 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+gilbert_meta_1,imputed_values*,warn,Item 's_read_11_0' has one resp value accounting for 75% of responses — possible mean imputation.,226809,30,7797
+gilbert_meta_1,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",226809,30,7797
+gilbert_meta_10,imputed_values*,warn,Item 's_mmrp1' has one resp value accounting for 64% of responses — possible mean imputation.,96688,20,4895
+gilbert_meta_10,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",96688,20,4895
+gilbert_meta_100,imputed_values*,warn,Item '1' has one resp value accounting for 61% of responses — possible mean imputation.,25416,12,2118
+gilbert_meta_100,column_order,warn,"columns start ['treat', 'std_baseline', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",25416,12,2118
+gilbert_meta_11,imputed_values*,warn,Item 'sci1' has one resp value accounting for 61% of responses — possible mean imputation.,59246,24,2588
+gilbert_meta_11,multi_scale*,warn,"Item names suggest 2 subscales (['ss', 'sci']) — IRW requires separate tables per construct.",59246,24,2588
+gilbert_meta_11,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",59246,24,2588
+gilbert_meta_12,imputed_values*,warn,Item 'sci1' has one resp value accounting for 71% of responses — possible mean imputation.,59005,24,2612
+gilbert_meta_12,multi_scale*,warn,"Item names suggest 2 subscales (['sci', 'ss']) — IRW requires separate tables per construct.",59005,24,2612
+gilbert_meta_12,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",59005,24,2612
+gilbert_meta_13,dup_id_item,warn,40572 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),176009,37,3780
+gilbert_meta_13,imputed_values*,warn,Item 'daysequence2' has one resp value accounting for 77% of responses — possible mean imputation.,176009,37,3780
+gilbert_meta_13,multi_scale*,warn,"Item names suggest 5 subscales (['listening', 'reading', 'objectid', 'preposition']) — IRW requires separate tables per construct.",176009,37,3780
+gilbert_meta_13,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",176009,37,3780
+gilbert_meta_14,dup_id_item,warn,135240 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),391755,69,3780
+gilbert_meta_14,imputed_values*,warn,Item 'addition_q1' has one resp value accounting for 75% of responses — possible mean imputation.,391755,69,3780
+gilbert_meta_14,multi_scale*,warn,"Item names suggest 9 subscales (['addition', 'division', 'multiplication', 'subtraction']) — IRW requires separate tables per construct.",391755,69,3780
+gilbert_meta_14,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",391755,69,3780
+gilbert_meta_15,imputed_values*,warn,Item 'raven_test10' has one resp value accounting for 79% of responses — possible mean imputation.,35100,10,3510
+gilbert_meta_15,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",35100,10,3510
+gilbert_meta_16,imputed_values*,warn,Item 'q1' has one resp value accounting for 85% of responses — possible mean imputation.,257458,71,4031
+gilbert_meta_16,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",257458,71,4031
+gilbert_meta_17,dup_id_item,warn,756093 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),1840581,21,51652
+gilbert_meta_17,imputed_values*,warn,Item 'math_s1_1' has one resp value accounting for 87% of responses — possible mean imputation.,1840581,21,51652
+gilbert_meta_17,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",1840581,21,51652
+gilbert_meta_18,dup_id_item,warn,725548 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),1809838,21,51652
+gilbert_meta_18,imputed_values*,warn,Item 'englang_s1_1' has one resp value accounting for 66% of responses — possible mean imputation.,1809838,21,51652
+gilbert_meta_18,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",1809838,21,51652
+gilbert_meta_19,dup_id_item,warn,690392 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),1774229,21,51612
+gilbert_meta_19,imputed_values*,warn,Item 'loclang_s1_1' has one resp value accounting for 78% of responses — possible mean imputation.,1774229,21,51612
+gilbert_meta_19,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",1774229,21,51612
+gilbert_meta_2,imputed_values*,warn,Item '1' has one resp value accounting for 83% of responses — possible mean imputation.,43480,20,2174
+gilbert_meta_2,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",43480,20,2174
+gilbert_meta_20,resp_na,warn,resp has 18 NAs,24162,93,186
+gilbert_meta_20,dup_id_item,warn,6882 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),24162,93,186
+gilbert_meta_20,imputed_values*,warn,Item 'procedures__q1a' has one resp value accounting for 70% of responses — possible mean imputation.,24162,93,186
+gilbert_meta_20,multi_scale*,warn,"Item names suggest 3 subscales (['tuf', 'trans', 'procedures']) — IRW requires separate tables per construct.",24162,93,186
+gilbert_meta_20,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",24162,93,186
+gilbert_meta_21,dup_id_item,warn,26933 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),135750,86,4084
+gilbert_meta_21,imputed_values*,warn,Item 'arithmetic.1' has one resp value accounting for 95% of responses — possible mean imputation.,135750,86,4084
+gilbert_meta_21,multi_scale*,warn,"Item names suggest 2 subscales (['arithmetic.', 'solve.']) — IRW requires separate tables per construct.",135750,86,4084
+gilbert_meta_21,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",135750,86,4084
+gilbert_meta_22,dup_id_item,warn,5245 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),90051,16,5364
+gilbert_meta_22,imputed_values*,warn,Item 'prfsavadultonly' has one resp value accounting for 69% of responses — possible mean imputation.,90051,16,5364
+gilbert_meta_22,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",90051,16,5364
+gilbert_meta_23,dup_id_item,warn,27464 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),63640,38,958
+gilbert_meta_23,imputed_values*,warn,Item '10code' has one resp value accounting for 70% of responses — possible mean imputation.,63640,38,958
+gilbert_meta_23,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",63640,38,958
+gilbert_meta_24,dup_id_item,warn,6004 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),14294,13,644
+gilbert_meta_24,imputed_values*,warn,Item 'breakfast' has one resp value accounting for 97% of responses — possible mean imputation.,14294,13,644
+gilbert_meta_24,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",14294,13,644
+gilbert_meta_25,dup_id_item,warn,11538 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),23222,15,779
+gilbert_meta_25,imputed_values*,warn,Item 'S11_10' has one resp value accounting for 66% of responses — possible mean imputation.,23222,15,779
+gilbert_meta_25,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",23222,15,779
+gilbert_meta_26,dup_id_item,warn,11625 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),23310,15,779
+gilbert_meta_26,imputed_values*,warn,Item 'S14_1' has one resp value accounting for 78% of responses — possible mean imputation.,23310,15,779
+gilbert_meta_26,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",23310,15,779
+gilbert_meta_27,dup_id_item,warn,115585 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),246834,18,8857
+gilbert_meta_27,imputed_values*,warn,Item 'maser_lang_chname' has one resp value accounting for 88% of responses — possible mean imputation.,246834,18,8857
+gilbert_meta_27,column_order,warn,"columns start ['block_id', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",246834,18,8857
+gilbert_meta_28,dup_id_item,warn,76653 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),185297,17,8857
+gilbert_meta_28,imputed_values*,warn,Item 'maser_math_add1' has one resp value accounting for 80% of responses — possible mean imputation.,185297,17,8857
+gilbert_meta_28,column_order,warn,"columns start ['block_id', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",185297,17,8857
+gilbert_meta_29,dup_id_item,warn,174705 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),358480,15,14576
+gilbert_meta_29,imputed_values*,warn,Item 'caser_lang_lttrs' has one resp value accounting for 74% of responses — possible mean imputation.,358480,15,14576
+gilbert_meta_29,column_order,warn,"columns start ['block_id', 'cluster_id', 'id']; datastandard.md step 7 writes [id, item, resp] + covariates.",358480,15,14576
+gilbert_meta_30,dup_id_item,warn,69541 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),164735,10,14576
+gilbert_meta_30,imputed_values*,warn,Item 'caser_math_add2' has one resp value accounting for 70% of responses — possible mean imputation.,164735,10,14576
+gilbert_meta_30,column_order,warn,"columns start ['block_id', 'cluster_id', 'id']; datastandard.md step 7 writes [id, item, resp] + covariates.",164735,10,14576
+gilbert_meta_31,dup_id_item,warn,71238 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),146583,6,12560
+gilbert_meta_31,imputed_values*,warn,Item 'aser_math_2' has one resp value accounting for 94% of responses — possible mean imputation.,146583,6,12560
+gilbert_meta_31,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",146583,6,12560
+gilbert_meta_31,cov_range,warn,"cov_age spans 0-219, outside [0, 120] -- looks like out of range for a human age in years. irw_filter() treats every value here as an age (#1779).",146583,6,12560
+gilbert_meta_32,dup_id_item,warn,72380 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),162640,20,4513
+gilbert_meta_32,imputed_values*,warn,Item '4' has one resp value accounting for 65% of responses — possible mean imputation.,162640,20,4513
+gilbert_meta_32,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",162640,20,4513
+gilbert_meta_33,dup_id_item,warn,21178 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),48773,18,1610
+gilbert_meta_33,imputed_values*,warn,Item 'o3b1_tr1' has one resp value accounting for 85% of responses — possible mean imputation.,48773,18,1610
+gilbert_meta_33,multi_scale*,warn,"Item names suggest 2 subscales (['o', 'i']) — IRW requires separate tables per construct.",48773,18,1610
+gilbert_meta_33,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",48773,18,1610
+gilbert_meta_34,dup_id_item,warn,31284 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),40284,9,1000
+gilbert_meta_34,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",40284,9,1000
+gilbert_meta_35,dup_id_item,warn,24626 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),41808,12,1438
+gilbert_meta_35,imputed_values*,warn,Item 'values_a' has one resp value accounting for 84% of responses — possible mean imputation.,41808,12,1438
+gilbert_meta_35,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",41808,12,1438
+gilbert_meta_36,dup_id_item,warn,10464 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),19740,7,1418
+gilbert_meta_36,imputed_values*,warn,Item 'knowledge_c' has one resp value accounting for 70% of responses — possible mean imputation.,19740,7,1418
+gilbert_meta_36,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",19740,7,1418
+gilbert_meta_37,imputed_values*,warn,Item 'aids_blood' has one resp value accounting for 77% of responses — possible mean imputation.,17619,21,839
+gilbert_meta_37,multi_scale*,warn,"Item names suggest 4 subscales (['aids', 'condom', 'nightblindness', 'wash']) — IRW requires separate tables per construct.",17619,21,839
+gilbert_meta_37,column_order,warn,"columns start ['id', 'block_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",17619,21,839
+gilbert_meta_38,imputed_values*,warn,Item 'aids_tested_self' has one resp value accounting for 93% of responses — possible mean imputation.,7551,9,839
+gilbert_meta_38,column_order,warn,"columns start ['id', 'block_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",7551,9,839
+gilbert_meta_39,imputed_values*,warn,Item 'f1_q801' has one resp value accounting for 96% of responses — possible mean imputation.,68035,10,6818
+gilbert_meta_39,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",68035,10,6818
+gilbert_meta_4,dup_id_item,warn,31694 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),51566,20,999
+gilbert_meta_4,imputed_values*,warn,Item 'badadvice_resc' has one resp value accounting for 67% of responses — possible mean imputation.,51566,20,999
+gilbert_meta_4,column_order,warn,"columns start ['id', 'block_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",51566,20,999
+gilbert_meta_40,imputed_values*,warn,Item 'b1_q1001' has one resp value accounting for 90% of responses — possible mean imputation.,207858,30,8217
+gilbert_meta_40,multi_scale*,warn,"Item names suggest 2 subscales (['f', 'b']) — IRW requires separate tables per construct.",207858,30,8217
+gilbert_meta_40,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",207858,30,8217
+gilbert_meta_41,imputed_values*,warn,Item 'LA_EFAL_comp_1' has one resp value accounting for 65% of responses — possible mean imputation.,1844584,1355,3230
+gilbert_meta_41,column_order,warn,"columns start ['cluster_id', 'block_id', 'id']; datastandard.md step 7 writes [id, item, resp] + covariates.",1844584,1355,3230
+gilbert_meta_42,dup_id_item,warn,14520 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),29040,20,726
+gilbert_meta_42,multi_scale*,warn,"Item names suggest 4 subscales (['phq', 'life', 'locus', 'stress']) — IRW requires separate tables per construct.",29040,20,726
+gilbert_meta_42,composite_items*,warn,"1/20 item labels name computed scores (['stress_a_index']) — drop them, or confirm they are real items",29040,20,726
+gilbert_meta_42,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",29040,20,726
+gilbert_meta_43,dup_id_item,warn,10284 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),22404,28,726
+gilbert_meta_43,imputed_values*,warn,Item 'digit_spanbackward_1a' has one resp value accounting for 95% of responses — possible mean imputation.,22404,28,726
+gilbert_meta_43,multi_scale*,warn,"Item names suggest 2 subscales (['digit', 'math']) — IRW requires separate tables per construct.",22404,28,726
+gilbert_meta_43,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",22404,28,726
+gilbert_meta_44,dup_id_item,warn,9383 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),14729,22,243
+gilbert_meta_44,imputed_values*,warn,Item 'GDS_1' has one resp value accounting for 93% of responses — possible mean imputation.,14729,22,243
+gilbert_meta_44,multi_scale*,warn,"Item names suggest 2 subscales (['gds', 'swemwbs']) — IRW requires separate tables per construct.",14729,22,243
+gilbert_meta_44,resp_scale_mixed,warn,items span more than one response scale: 15 on 0-1 and 7 on ['1-5']. IRW requires one table per construct; split before submitting.,14729,22,243
+gilbert_meta_44,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",14729,22,243
+gilbert_meta_45,dup_id_item,warn,16556 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),25636,37,249
+gilbert_meta_45,imputed_values*,warn,Item 'being_so_restless_that_it_is_hard_to_sit_still' has one resp value accounting for 71% of responses — possible mean imputation.,25636,37,249
+gilbert_meta_45,multi_scale*,warn,"Item names suggest 3 subscales (['i', 'feeling', 'trouble']) — IRW requires separate tables per construct.",25636,37,249
+gilbert_meta_45,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",25636,37,249
+gilbert_meta_46,dup_id_item,warn,4184 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),10498,42,156
+gilbert_meta_46,imputed_values*,warn,Item 'LetterSoundKnowledge1_a' has one resp value accounting for 73% of responses — possible mean imputation.,10498,42,156
+gilbert_meta_46,multi_scale*,warn,"Item names suggest 2 subscales (['lettersoundknowledge', 'sounddiscrimination']) — IRW requires separate tables per construct.",10498,42,156
+gilbert_meta_46,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",10498,42,156
+gilbert_meta_47,dup_id_item,warn,4828 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),11676,44,162
+gilbert_meta_47,imputed_values*,warn,Item 'GrootsteGetal1_2' has one resp value accounting for 91% of responses — possible mean imputation.,11676,44,162
+gilbert_meta_47,multi_scale*,warn,"Item names suggest 3 subscales (['grootstegetal', 'numberknowledge', 'stippenzijfer']) — IRW requires separate tables per construct.",11676,44,162
+gilbert_meta_47,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",11676,44,162
+gilbert_meta_48,dup_id_item,warn,72375 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),131864,30,1984
+gilbert_meta_48,imputed_values*,warn,Item 'COM_01_ASQ' has one resp value accounting for 82% of responses — possible mean imputation.,131864,30,1984
+gilbert_meta_48,multi_scale*,warn,"Item names suggest 5 subscales (['com', 'motf', 'motg', 'resp']) — IRW requires separate tables per construct.",131864,30,1984
+gilbert_meta_48,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",131864,30,1984
+gilbert_meta_49,dup_id_item,warn,5511 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),9511,20,200
+gilbert_meta_49,imputed_values*,warn,Item 'constant_fat' has one resp value accounting for 82% of responses — possible mean imputation.,9511,20,200
+gilbert_meta_49,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",9511,20,200
+gilbert_meta_5,dup_id_item,warn,17141 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),37584,7,2928
+gilbert_meta_5,imputed_values*,warn,Item 'fdadch' has one resp value accounting for 82% of responses — possible mean imputation.,37584,7,2928
+gilbert_meta_5,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",37584,7,2928
+gilbert_meta_50,dup_id_item,warn,1558 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),6497,11,449
+gilbert_meta_50,imputed_values*,warn,Item 'belief_able_play' has one resp value accounting for 67% of responses — possible mean imputation.,6497,11,449
+gilbert_meta_50,column_order,warn,"columns start ['cluster_id', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",6497,11,449
+gilbert_meta_51,dup_id_item,warn,3090 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),6675,8,449
+gilbert_meta_51,imputed_values*,warn,Item 'ch_dairy' has one resp value accounting for 64% of responses — possible mean imputation.,6675,8,449
+gilbert_meta_51,column_order,warn,"columns start ['cluster_id', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",6675,8,449
+gilbert_meta_52,dup_id_item,warn,1131603 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),2263206,11,102873
+gilbert_meta_52,imputed_values*,warn,Item 'sm_a_1' has one resp value accounting for 87% of responses — possible mean imputation.,2263206,11,102873
+gilbert_meta_52,column_order,warn,"columns start ['id', 'block_id', 'cluster_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",2263206,11,102873
+gilbert_meta_53,dup_id_item,warn,26320 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),52640,14,1880
+gilbert_meta_53,imputed_values*,warn,Item 'q515a' has one resp value accounting for 65% of responses — possible mean imputation.,52640,14,1880
+gilbert_meta_53,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",52640,14,1880
+gilbert_meta_54,dup_id_item,warn,11280 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),22560,6,1880
+gilbert_meta_54,imputed_values*,warn,Item 'q602a' has one resp value accounting for 72% of responses — possible mean imputation.,22560,6,1880
+gilbert_meta_54,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",22560,6,1880
+gilbert_meta_55,resp_na,warn,resp has 885 NAs,25560,15,1704
+gilbert_meta_55,imputed_values*,warn,Item 'e1_item1' has one resp value accounting for 92% of responses — possible mean imputation.,25560,15,1704
+gilbert_meta_55,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",25560,15,1704
+gilbert_meta_56,dup_id_item,warn,6921 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),17364,4,2712
+gilbert_meta_56,imputed_values*,warn,Item 'cvc_pass' has one resp value accounting for 98% of responses — possible mean imputation.,17364,4,2712
+gilbert_meta_56,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",17364,4,2712
+gilbert_meta_57,dup_id_item,warn,32454 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),42840,9,1154
+gilbert_meta_57,imputed_values*,warn,Item 'phq2' has one resp value accounting for 69% of responses — possible mean imputation.,42840,9,1154
+gilbert_meta_57,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",42840,9,1154
+gilbert_meta_58,dup_id_item,warn,54560 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),69429,13,1154
+gilbert_meta_58,imputed_values*,warn,Item 'scid10now' has one resp value accounting for 68% of responses — possible mean imputation.,69429,13,1154
+gilbert_meta_58,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",69429,13,1154
+gilbert_meta_59,dup_id_item,warn,45460 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),57000,10,1154
+gilbert_meta_59,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",57000,10,1154
+gilbert_meta_6,dup_id_item,warn,264055 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),589430,10,32950
+gilbert_meta_6,imputed_values*,warn,Item 'dumm_rp_50' has one resp value accounting for 65% of responses — possible mean imputation.,589430,10,32950
+gilbert_meta_6,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",589430,10,32950
+gilbert_meta_60,dup_id_item,warn,30186 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),53190,9,2558
+gilbert_meta_60,imputed_values*,warn,Item 'RR1' has one resp value accounting for 66% of responses — possible mean imputation.,53190,9,2558
+gilbert_meta_60,column_order,warn,"columns start ['id', 'block_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",53190,9,2558
+gilbert_meta_61,dup_id_item,warn,20173 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),35502,6,2559
+gilbert_meta_61,imputed_values*,warn,Item 'viojustunfairstate' has one resp value accounting for 81% of responses — possible mean imputation.,35502,6,2559
+gilbert_meta_61,resp_scale_mixed,warn,items span more than one response scale: 3 on 0-1 and 3 on ['0-3']. IRW requires one table per construct; split before submitting.,35502,6,2559
+gilbert_meta_61,column_order,warn,"columns start ['id', 'block_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",35502,6,2559
+gilbert_meta_62,dup_id_item,warn,5658 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),8622,4,741
+gilbert_meta_62,imputed_values*,warn,Item 'feeing_depressed' has one resp value accounting for 64% of responses — possible mean imputation.,8622,4,741
+gilbert_meta_62,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",8622,4,741
+gilbert_meta_63,dup_id_item,warn,35948 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),71900,4,8988
+gilbert_meta_63,imputed_values*,warn,Item 'any_debt' has one resp value accounting for 88% of responses — possible mean imputation.,71900,4,8988
+gilbert_meta_63,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",71900,4,8988
+gilbert_meta_64,imputed_values*,warn,Item 'end_emotion_7' has one resp value accounting for 71% of responses — possible mean imputation.,35861,9,4056
+gilbert_meta_64,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",35861,9,4056
+gilbert_meta_65,dup_id_item,warn,3895 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),7829,14,281
+gilbert_meta_65,imputed_values*,warn,Item 'bomhl_1' has one resp value accounting for 71% of responses — possible mean imputation.,7829,14,281
+gilbert_meta_65,multi_scale*,warn,"Item names suggest 2 subscales (['bomhl', 'romhl']) — IRW requires separate tables per construct.",7829,14,281
+gilbert_meta_65,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",7829,14,281
+gilbert_meta_66,dup_id_item,warn,2708 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),5518,10,281
+gilbert_meta_66,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",5518,10,281
+gilbert_meta_67,dup_id_item,warn,1091 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),2215,4,281
+gilbert_meta_67,resp_scale_mixed,warn,items span more than one response scale: 3 on 2-5 and 1 on ['1-5']. IRW requires one table per construct; split before submitting.,2215,4,281
+gilbert_meta_67,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",2215,4,281
+gilbert_meta_68,dup_id_item,warn,147574 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),439888,35,9413
+gilbert_meta_68,imputed_values*,warn,Item 'q10_1a' has one resp value accounting for 89% of responses — possible mean imputation.,439888,35,9413
+gilbert_meta_68,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",439888,35,9413
+gilbert_meta_69,dup_id_item,warn,132761 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),387718,30,9410
+gilbert_meta_69,imputed_values*,warn,Item 'q11' has one resp value accounting for 69% of responses — possible mean imputation.,387718,30,9410
+gilbert_meta_69,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",387718,30,9410
+gilbert_meta_7,imputed_values*,warn,Item 's_vocab_0_2021' has one resp value accounting for 73% of responses — possible mean imputation.,49259,36,1386
+gilbert_meta_7,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",49259,36,1386
+gilbert_meta_70,dup_id_item,warn,210263 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),395462,33,6391
+gilbert_meta_70,imputed_values*,warn,Item 'langwrit_std12_com_sen1' has one resp value accounting for 68% of responses — possible mean imputation.,395462,33,6391
+gilbert_meta_70,column_order,warn,"columns start ['cluster_id', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",395462,33,6391
+gilbert_meta_71,dup_id_item,warn,182467 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),310247,20,6389
+gilbert_meta_71,imputed_values*,warn,Item 'mathwrit_std12_add1d_a' has one resp value accounting for 78% of responses — possible mean imputation.,310247,20,6389
+gilbert_meta_71,column_order,warn,"columns start ['cluster_id', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",310247,20,6389
+gilbert_meta_72,dup_id_item,warn,201663 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),435609,53,5388
+gilbert_meta_72,imputed_values*,warn,Item 'langwrit_std35_com_sen71' has one resp value accounting for 74% of responses — possible mean imputation.,435609,53,5388
+gilbert_meta_72,column_order,warn,"columns start ['cluster_id', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",435609,53,5388
+gilbert_meta_73,dup_id_item,warn,180646 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),358304,36,5386
+gilbert_meta_73,imputed_values*,warn,Item 'mathwrit_std35_add3d_a' has one resp value accounting for 87% of responses — possible mean imputation.,358304,36,5386
+gilbert_meta_73,column_order,warn,"columns start ['cluster_id', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",358304,36,5386
+gilbert_meta_76,resp_na,warn,resp has 155 NAs,66613,78,428
+gilbert_meta_76,dup_id_item,warn,33384 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),66613,78,428
+gilbert_meta_76,imputed_values*,warn,Item '10' has one resp value accounting for 76% of responses — possible mean imputation.,66613,78,428
+gilbert_meta_76,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",66613,78,428
+gilbert_meta_77,dup_id_item,warn,27950 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),58838,26,1188
+gilbert_meta_77,imputed_values*,warn,Item 'celf_ss_01' has one resp value accounting for 84% of responses — possible mean imputation.,58838,26,1188
+gilbert_meta_77,column_order,warn,"columns start ['id', 'cov_grade', 'cov_teacher']; datastandard.md step 7 writes [id, item, resp] + covariates.",58838,26,1188
+gilbert_meta_78,dup_id_item,warn,69068 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),178930,189,1189
+gilbert_meta_78,imputed_values*,warn,Item 'ppvt_001' has one resp value accounting for 86% of responses — possible mean imputation.,178930,189,1189
+gilbert_meta_78,column_order,warn,"columns start ['id', 'cov_grade', 'cov_teacher']; datastandard.md step 7 writes [id, item, resp] + covariates.",178930,189,1189
+gilbert_meta_79,dup_id_item,warn,29932 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),64560,30,1189
+gilbert_meta_79,imputed_values*,warn,Item 'tnl1_2' has one resp value accounting for 77% of responses — possible mean imputation.,64560,30,1189
+gilbert_meta_79,column_order,warn,"columns start ['id', 'cov_grade', 'cov_teacher']; datastandard.md step 7 writes [id, item, resp] + covariates.",64560,30,1189
+gilbert_meta_8,imputed_values*,warn,Item 's_cc_15_2021' has one resp value accounting for 64% of responses — possible mean imputation.,37182,29,1335
+gilbert_meta_8,column_order,warn,"columns start ['id', 'cluster_id', 'block_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",37182,29,1335
+gilbert_meta_80,dup_id_item,warn,21695 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),50940,36,1189
+gilbert_meta_80,imputed_values*,warn,Item 'wj_pv_01' has one resp value accounting for 83% of responses — possible mean imputation.,50940,36,1189
+gilbert_meta_80,column_order,warn,"columns start ['id', 'cov_grade', 'cov_teacher']; datastandard.md step 7 writes [id, item, resp] + covariates.",50940,36,1189
+gilbert_meta_81,dup_id_item,warn,10624 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),25310,18,1188
+gilbert_meta_81,imputed_values*,warn,Item 'wj_sc_01' has one resp value accounting for 83% of responses — possible mean imputation.,25310,18,1188
+gilbert_meta_81,column_order,warn,"columns start ['id', 'cov_grade', 'cov_teacher']; datastandard.md step 7 writes [id, item, resp] + covariates.",25310,18,1188
+gilbert_meta_82,dup_id_item,warn,10435 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),25493,18,1188
+gilbert_meta_82,imputed_values*,warn,Item 'wj_ss_01' has one resp value accounting for 76% of responses — possible mean imputation.,25493,18,1188
+gilbert_meta_82,column_order,warn,"columns start ['id', 'cov_grade', 'cov_teacher']; datastandard.md step 7 writes [id, item, resp] + covariates.",25493,18,1188
+gilbert_meta_83,dup_id_item,warn,1233 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),4056,3,941
+gilbert_meta_83,column_order,warn,"columns start ['id', 'treat', 'tot']; datastandard.md step 7 writes [id, item, resp] + covariates.",4056,3,941
+gilbert_meta_84,dup_id_item,warn,1893 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),6326,5,917
+gilbert_meta_84,imputed_values*,warn,Item 'conspiracy_item3' has one resp value accounting for 68% of responses — possible mean imputation.,6326,5,917
+gilbert_meta_84,column_order,warn,"columns start ['id', 'treat', 'tot']; datastandard.md step 7 writes [id, item, resp] + covariates.",6326,5,917
+gilbert_meta_85,dup_id_item,warn,1233 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),4053,3,940
+gilbert_meta_85,column_order,warn,"columns start ['id', 'treat', 'tot']; datastandard.md step 7 writes [id, item, resp] + covariates.",4053,3,940
+gilbert_meta_86,resp_na,warn,resp has 1205 NAs,26005,15,1182
+gilbert_meta_86,dup_id_item,warn,8550 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),26005,15,1182
+gilbert_meta_86,imputed_values*,warn,Item 'norm_court' has one resp value accounting for 78% of responses — possible mean imputation.,26005,15,1182
+gilbert_meta_86,multi_scale*,warn,"Item names suggest 3 subscales (['norm', 'efficacy', 'media']) — IRW requires separate tables per construct.",26005,15,1182
+gilbert_meta_87,resp_na,warn,resp has 1051 NAs,18903,11,1163
+gilbert_meta_87,dup_id_item,warn,6270 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),18903,11,1163
+gilbert_meta_87,imputed_values*,warn,Item 'know_alford' has one resp value accounting for 91% of responses — possible mean imputation.,18903,11,1163
+gilbert_meta_88,dup_id_item,warn,22632 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),51828,12,2433
+gilbert_meta_88,imputed_values*,warn,Item 'fci_1a_3' has one resp value accounting for 69% of responses — possible mean imputation.,51828,12,2433
+gilbert_meta_88,column_order,warn,"columns start ['id', 'block_id', 'treat']; datastandard.md step 7 writes [id, item, resp] + covariates.",51828,12,2433
+gilbert_meta_89,dup_id_item,warn,657 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),84007,100,2433
+gilbert_meta_89,imputed_values*,warn,Item 'CREDI_B1' has one resp value accounting for 96% of responses — possible mean imputation.,84007,100,2433
+gilbert_meta_89,column_order,warn,"columns start ['id', 'block_id', 'treat']; datastandard.md step 7 writes [id, item, resp] + covariates.",84007,100,2433
+gilbert_meta_9,dup_id_item,warn,17976 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),48210,19,1646
+gilbert_meta_9,imputed_values*,warn,Item 't10' has one resp value accounting for 75% of responses — possible mean imputation.,48210,19,1646
+gilbert_meta_9,column_order,warn,"columns start ['id', 'cluster_id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",48210,19,1646
+gilbert_meta_90,imputed_values*,warn,Item 'kidi_1_a' has one resp value accounting for 75% of responses — possible mean imputation.,36383,21,1773
+gilbert_meta_90,column_order,warn,"columns start ['id', 'block_id', 'treat']; datastandard.md step 7 writes [id, item, resp] + covariates.",36383,21,1773
+gilbert_meta_91,imputed_values*,warn,Item 'topse_1' has one resp value accounting for 67% of responses — possible mean imputation.,27560,16,1729
+gilbert_meta_91,column_order,warn,"columns start ['id', 'block_id', 'treat']; datastandard.md step 7 writes [id, item, resp] + covariates.",27560,16,1729
+gilbert_meta_92,dup_id_item,warn,11952 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),28953,7,2433
+gilbert_meta_92,imputed_values*,warn,Item 'gad_1_b' has one resp value accounting for 69% of responses — possible mean imputation.,28953,7,2433
+gilbert_meta_92,column_order,warn,"columns start ['id', 'block_id', 'treat']; datastandard.md step 7 writes [id, item, resp] + covariates.",28953,7,2433
+gilbert_meta_93,dup_id_item,warn,41355 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),206612,119,2433
+gilbert_meta_93,imputed_values*,warn,Item 'vocab_aa' has one resp value accounting for 62% of responses — possible mean imputation.,206612,119,2433
+gilbert_meta_93,column_order,warn,"columns start ['id', 'block_id', 'treat']; datastandard.md step 7 writes [id, item, resp] + covariates.",206612,119,2433
+gilbert_meta_94,dup_id_item,warn,11760 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),18186,17,378
+gilbert_meta_94,imputed_values*,warn,Item 'WIC_clean' has one resp value accounting for 84% of responses — possible mean imputation.,18186,17,378
+gilbert_meta_94,column_order,warn,"columns start ['id', 'treat', 'cov_hhsize']; datastandard.md step 7 writes [id, item, resp] + covariates.",18186,17,378
+gilbert_meta_95,dup_id_item,warn,1380 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),2760,12,115
+gilbert_meta_95,resp_ordinal*,warn,"63 distinct resp values — confirm continuous, not mis-parsed",2760,12,115
+gilbert_meta_95,multi_scale*,warn,"Item names suggest 3 subscales (['complicated', 'pyelonephritis', 'uncomplicated']) — IRW requires separate tables per construct.",2760,12,115
+gilbert_meta_95,column_order,warn,"columns start ['id', 'treat', 'cov_male']; datastandard.md step 7 writes [id, item, resp] + covariates.",2760,12,115
+gilbert_meta_96,dup_id_item,warn,516 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),1032,6,86
+gilbert_meta_96,resp_scale_mixed,warn,items span more than one response scale: 3 on 1-6 and 3 on ['1-7']. IRW requires one table per construct; split before submitting.,1032,6,86
+gilbert_meta_96,sample_floor,warn,"86 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",1032,6,86
+gilbert_meta_96,column_order,warn,"columns start ['id', 'treat', 'cov_male']; datastandard.md step 7 writes [id, item, resp] + covariates.",1032,6,86
+gilbert_meta_97,dup_id_item,warn,77167 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),180471,12,8609
+gilbert_meta_97,multi_scale*,warn,"Item names suggest 4 subscales (['psye', 'psyh', 'psyo', 'psyr']) — IRW requires separate tables per construct.",180471,12,8609
+gilbert_meta_97,column_order,warn,"columns start ['id', 'treat', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",180471,12,8609
+gilbert_meta_98,dup_id_item,warn,38556 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),90204,6,8608
+gilbert_meta_98,column_order,warn,"columns start ['id', 'treat', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",90204,6,8608
+gilbert_meta_99,dup_id_item,warn,56108 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),99825,7,6737
+gilbert_meta_99,imputed_values*,warn,Item 'o1a_importance_KLPS' has one resp value accounting for 95% of responses — possible mean imputation.,99825,7,6737
+gilbert_meta_99,resp_scale_mixed,warn,items span more than one response scale: 5 on 0-1 and 2 on ['1-3']. IRW requires one table per construct; split before submitting.,99825,7,6737
+gilbert_meta_99,column_order,warn,"columns start ['id', 'cluster_id', 'treat']; datastandard.md step 7 writes [id, item, resp] + covariates.",99825,7,6737
+gps_vangsness_2019,,ok,,3695,16,231
+gpt4mcq_young_2025,imputed_values*,warn,Item 'AIQ1' has one resp value accounting for 92% of responses — possible mean imputation.,3800,20,190
+graphmapping_study1,dup_id_item,error,5220 duplicate id+item rows with no wave/timepoint/date column,6318,18,61
+graphmapping_study1,imputed_values*,warn,Item '3--direct--crossed' has one resp value accounting for 73% of responses — possible mean imputation.,6318,18,61
+graphmapping_study1,sample_floor,warn,"61 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",6318,18,61
+graphmapping_study1,column_order,warn,"columns start ['id', 'order', 'rt']; datastandard.md step 7 writes [id, item, resp] + covariates.",6318,18,61
+grit,resp_na,warn,resp has 113 NAs,37831,12,3158
+grit_BrummerHoffman_2021,name_charset,warn,"table name 'grit_BrummerHoffman_2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",14624,8,1828
+grit_BrummerHoffman_2021,column_order,warn,"columns start ['id', 'group', 'date']; datastandard.md step 7 writes [id, item, resp] + covariates.",14624,8,1828
+hads_multilcirt,,ok,,2814,14,201
+hexaco_ashton_2014_a,resp_na,warn,resp has 24 NAs,911416,40,22786
+hexaco_ashton_2014_a,multi_scale*,warn,"Item names suggest 4 subscales (['aforg', 'agent', 'aflex', 'apati']) — IRW requires separate tables per construct.",911416,40,22786
+hexaco_ashton_2014_a,column_order,warn,"columns start ['cov_country', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",911416,40,22786
+hexaco_ashton_2014_c,resp_na,warn,resp has 27 NAs,911413,40,22786
+hexaco_ashton_2014_c,multi_scale*,warn,"Item names suggest 4 subscales (['corga', 'cdili', 'cperf', 'cprud']) — IRW requires separate tables per construct.",911413,40,22786
+hexaco_ashton_2014_c,column_order,warn,"columns start ['cov_country', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",911413,40,22786
+hexaco_ashton_2014_e,resp_na,warn,resp has 28 NAs,911412,40,22786
+hexaco_ashton_2014_e,multi_scale*,warn,"Item names suggest 4 subscales (['efear', 'eanxi', 'edepe', 'esent']) — IRW requires separate tables per construct.",911412,40,22786
+hexaco_ashton_2014_e,column_order,warn,"columns start ['cov_country', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",911412,40,22786
+hexaco_ashton_2014_h,resp_na,warn,resp has 22 NAs,911418,40,22786
+hexaco_ashton_2014_h,multi_scale*,warn,"Item names suggest 4 subscales (['hsinc', 'hfair', 'hgree', 'hmode']) — IRW requires separate tables per construct.",911418,40,22786
+hexaco_ashton_2014_h,column_order,warn,"columns start ['cov_country', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",911418,40,22786
+hexaco_ashton_2014_o,resp_na,warn,resp has 15 NAs,911425,40,22786
+hexaco_ashton_2014_o,imputed_values*,warn,Item 'OAesA6' has one resp value accounting for 66% of responses — possible mean imputation.,911425,40,22786
+hexaco_ashton_2014_o,multi_scale*,warn,"Item names suggest 4 subscales (['oaesa', 'oinqu', 'ocrea', 'ounco']) — IRW requires separate tables per construct.",911425,40,22786
+hexaco_ashton_2014_o,column_order,warn,"columns start ['cov_country', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",911425,40,22786
+hexaco_ashton_2014_x,resp_na,warn,resp has 13 NAs,911427,40,22786
+hexaco_ashton_2014_x,multi_scale*,warn,"Item names suggest 4 subscales (['xexpr', 'xsocb', 'xsoci', 'xlive']) — IRW requires separate tables per construct.",911427,40,22786
+hexaco_ashton_2014_x,column_order,warn,"columns start ['cov_country', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",911427,40,22786
+hmcdm_spatialreasoning,imputed_values*,warn,Item 'item1' has one resp value accounting for 88% of responses — possible mean imputation.,3500,50,350
+hmcdm_spatialreasoning,column_order,warn,"columns start ['item', 'id', 'rt']; datastandard.md step 7 writes [id, item, resp] + covariates.",3500,50,350
+hpwt_bayona_2025_jobperformance,column_order,warn,"columns start ['id', 'cov_gender', 'cov_education']; datastandard.md step 7 writes [id, item, resp] + covariates.",2016,4,504
+hpwt_bayona_2025_jobsatisfaction,resp_na,warn,resp has 10 NAs,2510,5,503
+hpwt_bayona_2025_jobsatisfaction,imputed_values*,warn,Item 'JS4T1' has one resp value accounting for 64% of responses — possible mean imputation.,2510,5,503
+hpwt_bayona_2025_jobsatisfaction,column_order,warn,"columns start ['id', 'cov_gender', 'cov_education']; datastandard.md step 7 writes [id, item, resp] + covariates.",2510,5,503
+hpwt_bayona_2025_workcharacteristics,resp_na,warn,resp has 168 NAs,38640,77,504
+hpwt_bayona_2025_workcharacteristics,imputed_values*,warn,Item 'TaskID4T1' has one resp value accounting for 60% of responses — possible mean imputation.,38640,77,504
+hpwt_bayona_2025_workcharacteristics,multi_scale*,warn,"Item names suggest 18 subscales (['auto', 'socsupp', 'interdp', 'wrkcond']) — IRW requires separate tables per construct.",38640,77,504
+hpwt_bayona_2025_workcharacteristics,column_order,warn,"columns start ['id', 'cov_gender', 'cov_education']; datastandard.md step 7 writes [id, item, resp] + covariates.",38640,77,504
+humor_styles,resp_na,warn,resp has 162 NAs,34110,32,1070
+humor_styles,imputed_values*,warn,Item '13' has one resp value accounting for 62% of responses — possible mean imputation.,34110,32,1070
+hypersensitive_narcissism,resp_na,warn,resp has 6170 NAs,1181412,22,53956
+iat_difference,imputed_values*,warn,Item 'uo15' has one resp value accounting for 60% of responses — possible mean imputation.,392451,20,19925
+iat_difference,column_order,warn,"columns start ['id', 'race', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",392451,20,19925
+iat_poverty,column_order,warn,"columns start ['id', 'race', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",234602,12,19811
+icar_sapa,imputed_values*,warn,Item 'LN.01' has one resp value accounting for 79% of responses — possible mean imputation.,1199896,60,95236
+icar_sapa,multi_scale*,warn,"Item names suggest 4 subscales (['r', 'vr.', 'mr.', 'ln.']) — IRW requires separate tables per construct.",1199896,60,95236
+idas_machado2024,imputed_values*,warn,Item 'IDAS22' has one resp value accounting for 77% of responses — possible mean imputation.,240279,101,2379
+idcr_martinez_2023_Story Recall 1,resp_na,warn,resp has 3 NAs,9386,42,236
+idcr_martinez_2023_Story Recall 1,imputed_values*,warn,Item 'the.bike_a.parent.and.their.child' has one resp value accounting for 100% of responses — possible mean imputation.,9386,42,236
+idcr_martinez_2023_Story Recall 1,multi_scale*,warn,"Item names suggest 3 subscales (['the.early.riser', 'the.nurse', 'the.bike']) — IRW requires separate tables per construct.",9386,42,236
+idcr_martinez_2023_Story Recall 1,name_charset,warn,"table name 'idcr_martinez_2023_Story Recall 1' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",9386,42,236
+idcr_martinez_2023_Story Recall 2,resp_na,warn,resp has 20 NAs,10525,48,235
+idcr_martinez_2023_Story Recall 2,imputed_values*,warn,Item 'the.balloon_adult.gets.it.back' has one resp value accounting for 92% of responses — possible mean imputation.,10525,48,235
+idcr_martinez_2023_Story Recall 2,multi_scale*,warn,"Item names suggest 3 subscales (['the.messenger', 'the.balloon', 'the.squeezer']) — IRW requires separate tables per construct.",10525,48,235
+idcr_martinez_2023_Story Recall 2,name_charset,warn,"table name 'idcr_martinez_2023_Story Recall 2' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",10525,48,235
+idcr_martinez_2023_Story Recall 3,resp_na,warn,resp has 4 NAs,7146,32,235
+idcr_martinez_2023_Story Recall 3,imputed_values*,warn,Item 'the.dog_apples' has one resp value accounting for 70% of responses — possible mean imputation.,7146,32,235
+idcr_martinez_2023_Story Recall 3,multi_scale*,warn,"Item names suggest 3 subscales (['the.dog', 'the.fox', 'the.hen']) — IRW requires separate tables per construct.",7146,32,235
+idcr_martinez_2023_Story Recall 3,name_charset,warn,"table name 'idcr_martinez_2023_Story Recall 3' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",7146,32,235
+idcr_martinez_2023_analogies,imputed_values*,warn,Item 'X1' has one resp value accounting for 96% of responses — possible mean imputation.,4230,18,235
+idcr_martinez_2023_info,imputed_values*,warn,Item 'X1' has one resp value accounting for 98% of responses — possible mean imputation.,9400,40,235
+idcr_martinez_2023_lns,resp_na,warn,resp has 1 NAs,1610,18,230
+idcr_martinez_2023_lns,imputed_values*,warn,Item 'X0' has one resp value accounting for 98% of responses — possible mean imputation.,1610,18,230
+idcr_martinez_2023_matches,resp_na,warn,resp has 2 NAs,2338,10,234
+idcr_martinez_2023_matches,imputed_values*,warn,Item 'X1_0' has one resp value accounting for 87% of responses — possible mean imputation.,2338,10,234
+idcr_martinez_2023_numSeries,imputed_values*,warn,Item 'X10' has one resp value accounting for 73% of responses — possible mean imputation.,3525,15,235
+idcr_martinez_2023_numSeries,name_charset,warn,"table name 'idcr_martinez_2023_numSeries' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",3525,15,235
+idcr_martinez_2023_ps,resp_na,warn,resp has 2 NAs,4210,18,234
+idcr_martinez_2023_ps,imputed_values*,warn,Item 'X1' has one resp value accounting for 99% of responses — possible mean imputation.,4210,18,234
+idcr_martinez_2023_raco,imputed_values*,warn,Item 'X10' has one resp value accounting for 86% of responses — possible mean imputation.,1721,12,233
+idcr_martinez_2023_ravens,imputed_values*,warn,Item 'S2P1' has one resp value accounting for 93% of responses — possible mean imputation.,4230,18,235
+idcr_martinez_2023_vocab,imputed_values*,warn,Item 'apathetic' has one resp value accounting for 73% of responses — possible mean imputation.,11280,48,235
+ieswriting_molloy_2022,resp_scale_mixed,warn,"items span more than one response scale: 28 on 1-5 and 22 on ['0-10', '1-10', '3-10']. IRW requires one table per construct; split before submitting.",28250,50,565
+ieswriting_molloy_2022,column_order,warn,"columns start ['id', 'cov_participating_course_grade', 'cov_sat_total']; datastandard.md step 7 writes [id, item, resp] + covariates.",28250,50,565
+ilearnathome_regalado_2025,imputed_values*,warn,Item 'Q1' has one resp value accounting for 91% of responses — possible mean imputation.,13635,15,909
+ilearnathome_regalado_2025,column_order,warn,"columns start ['id', 'cov_educators', 'cov_loc_of_educ_institution']; datastandard.md step 7 writes [id, item, resp] + covariates.",13635,15,909
+immer09_immer,imputed_values*,warn,Item '5' has one resp value accounting for 67% of responses — possible mean imputation.,128,20,57
+immer09_immer,sample_floor,warn,"57 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",128,20,57
+immer10_immer,imputed_values*,warn,Item 'R10' has one resp value accounting for 62% of responses — possible mean imputation.,793,13,61
+immer10_immer,sample_floor,warn,"61 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",793,13,61
+immer10_immer,column_order,warn,"columns start ['id', 'item', 'difficulty']; datastandard.md step 7 writes [id, item, resp] + covariates.",793,13,61
+immer12_immer,dup_id_item,error,640 duplicate id+item rows with no wave/timepoint/date column,720,4,20
+immer12_immer,sample_floor,warn,"20 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",720,4,20
+immer12_immer,column_order,warn,"columns start ['id', 'item', 'rater']; datastandard.md step 7 writes [id, item, resp] + covariates.",720,4,20
+imos_1984,imputed_values*,warn,Item 'problem3' has one resp value accounting for 63% of responses — possible mean imputation.,1152,6,192
+imos_1984,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",1152,6,192
+imos_1985,imputed_values*,warn,Item 'problem3' has one resp value accounting for 73% of responses — possible mean imputation.,1254,6,209
+imos_1985,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",1254,6,209
+imos_1986,imputed_values*,warn,Item 'problem3' has one resp value accounting for 69% of responses — possible mean imputation.,1260,6,210
+imos_1986,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",1260,6,210
+imos_1987,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",1422,6,237
+imos_1988,imputed_values*,warn,Item 'problem6' has one resp value accounting for 71% of responses — possible mean imputation.,1608,6,268
+imos_1988,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",1608,6,268
+imos_1989,imputed_values*,warn,Item 'problem3' has one resp value accounting for 65% of responses — possible mean imputation.,1746,6,291
+imos_1989,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",1746,6,291
+imos_1990,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",1848,6,308
+imos_1991,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",1872,6,312
+imos_1992,imputed_values*,warn,Item 'problem5' has one resp value accounting for 72% of responses — possible mean imputation.,2100,6,350
+imos_1992,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",2100,6,350
+imos_1993,imputed_values*,warn,Item 'problem3' has one resp value accounting for 71% of responses — possible mean imputation.,2478,6,413
+imos_1993,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",2478,6,413
+imos_1994,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",2310,6,385
+imos_1995,imputed_values*,warn,Item 'problem2' has one resp value accounting for 73% of responses — possible mean imputation.,2472,6,412
+imos_1995,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",2472,6,412
+imos_1996,imputed_values*,warn,Item 'problem5' has one resp value accounting for 73% of responses — possible mean imputation.,2544,6,424
+imos_1996,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",2544,6,424
+imos_1997,imputed_values*,warn,Item 'problem6' has one resp value accounting for 74% of responses — possible mean imputation.,2760,6,460
+imos_1997,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",2760,6,460
+imos_1998,imputed_values*,warn,Item 'problem6' has one resp value accounting for 81% of responses — possible mean imputation.,2514,6,419
+imos_1998,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",2514,6,419
+imos_1999,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",2700,6,450
+imos_2000,imputed_values*,warn,Item 'problem3' has one resp value accounting for 73% of responses — possible mean imputation.,2766,6,461
+imos_2000,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",2766,6,461
+imos_2001,imputed_values*,warn,Item 'problem2' has one resp value accounting for 66% of responses — possible mean imputation.,2838,6,473
+imos_2001,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",2838,6,473
+imos_2002,imputed_values*,warn,Item 'problem3' has one resp value accounting for 65% of responses — possible mean imputation.,2874,6,479
+imos_2002,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",2874,6,479
+imos_2003,imputed_values*,warn,Item 'problem3' has one resp value accounting for 93% of responses — possible mean imputation.,2742,6,457
+imos_2003,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",2742,6,457
+imos_2004,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",2916,6,486
+imos_2005,imputed_values*,warn,Item 'problem3' has one resp value accounting for 82% of responses — possible mean imputation.,3078,6,513
+imos_2005,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",3078,6,513
+imos_2006,imputed_values*,warn,Item 'problem1' has one resp value accounting for 72% of responses — possible mean imputation.,2988,6,498
+imos_2006,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",2988,6,498
+imos_2007,imputed_values*,warn,Item 'problem3' has one resp value accounting for 84% of responses — possible mean imputation.,3120,6,520
+imos_2007,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",3120,6,520
+imos_2008,imputed_values*,warn,Item 'problem3' has one resp value accounting for 82% of responses — possible mean imputation.,3210,6,535
+imos_2008,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",3210,6,535
+imos_2009,imputed_values*,warn,Item 'problem3' has one resp value accounting for 63% of responses — possible mean imputation.,3390,6,565
+imos_2009,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",3390,6,565
+imos_2010,imputed_values*,warn,Item 'problem3' has one resp value accounting for 83% of responses — possible mean imputation.,3096,6,516
+imos_2010,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",3096,6,516
+imos_2011,imputed_values*,warn,Item 'problem1' has one resp value accounting for 63% of responses — possible mean imputation.,3378,6,563
+imos_2011,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",3378,6,563
+imos_2012,imputed_values*,warn,Item 'problem1' has one resp value accounting for 73% of responses — possible mean imputation.,3282,6,547
+imos_2012,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",3282,6,547
+imos_2013,imputed_values*,warn,Item 'problem3' has one resp value accounting for 83% of responses — possible mean imputation.,3162,6,527
+imos_2013,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",3162,6,527
+imos_2014,imputed_values*,warn,Item 'problem1' has one resp value accounting for 66% of responses — possible mean imputation.,3360,6,560
+imos_2014,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",3360,6,560
+imos_2015,imputed_values*,warn,Item 'problem3' has one resp value accounting for 71% of responses — possible mean imputation.,3462,6,577
+imos_2015,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",3462,6,577
+imos_2016,imputed_values*,warn,Item 'problem1' has one resp value accounting for 65% of responses — possible mean imputation.,3612,6,602
+imos_2016,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",3612,6,602
+imos_2017,imputed_values*,warn,Item 'problem1' has one resp value accounting for 73% of responses — possible mean imputation.,3690,6,615
+imos_2017,column_order,warn,"columns start ['id', 'cov_country', 'cov_rank']; datastandard.md step 7 writes [id, item, resp] + covariates.",3690,6,615
+introversion_extroversion,,ok,,654108,91,7188
+iowa_gambling_task,imputed_values*,warn,Item '2' has one resp value accounting for 67% of responses — possible mean imputation.,65291,339,617
+ipip_openpsychometrics_ad,column_order,warn,"columns start ['id', 'cov_age', 'cov_gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",9977,10,1000
+ipip_openpsychometrics_as,column_order,warn,"columns start ['id', 'cov_age', 'cov_gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",9988,10,1004
+ipip_openpsychometrics_do,column_order,warn,"columns start ['id', 'cov_age', 'cov_gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",9981,10,1001
+ipip_openpsychometrics_sc,column_order,warn,"columns start ['id', 'cov_age', 'cov_gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",9973,10,1001
+ips_vangsness_2019,,ok,,2094,9,233
+isi_insomnia_wang2025,size_skipped,info,10 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+janssen2_tam,imputed_values*,warn,Item 'IST01' has one resp value accounting for 75% of responses — possible mean imputation.,6920,20,346
+joreskog_moustaki_2001,imputed_values*,warn,Item 'item1' has one resp value accounting for 70% of responses — possible mean imputation.,4290,6,715
+kfcovid_Li2020,imputed_values*,warn,Item '1' has one resp value accounting for 99% of responses — possible mean imputation.,1320,12,110
+kfcovid_Li2020,name_charset,warn,"table name 'kfcovid_Li2020' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1320,12,110
+kfcovid_fear_Li2020,imputed_values*,warn,Item '103' has one resp value accounting for 96% of responses — possible mean imputation.,770,7,110
+kfcovid_fear_Li2020,resp_scale_mixed,warn,"items span more than one response scale: 3 on 1-3 and 4 on ['1-5', '1-4']. IRW requires one table per construct; split before submitting.",770,7,110
+kfcovid_fear_Li2020,name_charset,warn,"table name 'kfcovid_fear_Li2020' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",770,7,110
+kfcovid_pss_Li2020,name_charset,warn,"table name 'kfcovid_pss_Li2020' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",440,4,110
+lessR_Mach4,name_charset,warn,"table name 'lessR_Mach4' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",7020,20,351
+loneliness_mudfold,imputed_values*,warn,Item 'A' has one resp value accounting for 80% of responses — possible mean imputation.,43857,11,3987
+lsat,imputed_values*,warn,Item 'item_1' has one resp value accounting for 92% of responses — possible mean imputation.,5000,5,1000
+machivallianism_test_main,imputed_values*,warn,Item 'Q19' has one resp value accounting for 66% of responses — possible mean imputation.,1469720,20,73486
+machivallianism_test_main,rt_negative*,warn,rt has negative values,1469720,20,73486
+machivallianism_test_main,column_order,warn,"columns start ['id', 'cov_country', 'cov_education']; datastandard.md step 7 writes [id, item, resp] + covariates.",1469720,20,73486
+machivallianism_test_main,cov_range,warn,"cov_age spans 13-9.00001e+06, outside [0, 120] -- looks like a sentinel no-answer code (999/9999) or a birth year that was never converted. irw_filter() treats every value here as an age (#1779).",1469720,20,73486
+machivallianism_test_tipi,column_order,warn,"columns start ['id', 'cov_country', 'cov_education']; datastandard.md step 7 writes [id, item, resp] + covariates.",728729,10,73264
+machivallianism_test_tipi,cov_range,warn,"cov_age spans 13-9.00001e+06, outside [0, 120] -- looks like a sentinel no-answer code (999/9999) or a birth year that was never converted. irw_filter() treats every value here as an age (#1779).",728729,10,73264
+machivallianism_test_vcl,imputed_values*,warn,Item 'VCL1' has one resp value accounting for 93% of responses — possible mean imputation.,1175824,16,73489
+machivallianism_test_vcl,column_order,warn,"columns start ['id', 'cov_country', 'cov_education']; datastandard.md step 7 writes [id, item, resp] + covariates.",1175824,16,73489
+machivallianism_test_vcl,cov_range,warn,"cov_age spans 13-9.00001e+06, outside [0, 120] -- looks like a sentinel no-answer code (999/9999) or a birth year that was never converted. irw_filter() treats every value here as an age (#1779).",1175824,16,73489
+mbft_anunciacao_2024,size_skipped,info,31 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+mbps_vangsness_2019,,ok,,3017,13,233
+mcmi_mokken,imputed_values*,warn,Item 'item.15' has one resp value accounting for 62% of responses — possible mean imputation.,53152,44,1208
+mcmi_mokken,column_order,warn,"columns start ['item', 'id', 'resp']; datastandard.md step 7 writes [id, item, resp] + covariates.",53152,44,1208
+mental_health_malawi,imputed_values*,warn,Item '19' has one resp value accounting for 68% of responses — possible mean imputation.,35111,40,984
+mental_health_malawi,resp_scale_mixed,warn,items span more than one response scale: 20 on 1.0-5.0 and 20 on ['0.0-1.0']. IRW requires one table per construct; split before submitting.,35111,40,984
+metacogmonitoring_double2025,imputed_values*,warn,Item 'Q6_5' has one resp value accounting for 99% of responses — possible mean imputation.,20100,67,300
+metacogmonitoring_double2025,column_order,warn,"columns start ['id', 'cov_age', 'cov_sex']; datastandard.md step 7 writes [id, item, resp] + covariates.",20100,67,300
+mft_validationandreplication,resp_na,warn,resp has 299 NAs,29761,36,830
+mgkt,imputed_values*,warn,Item 'Q14' has one resp value accounting for 65% of responses — possible mean imputation.,614976,32,19218
+mgkt,rt_negative*,warn,rt has negative values,614976,32,19218
+mgkt,column_order,warn,"columns start ['id', 'cov_age', 'cov_gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",614976,32,19218
+mgkt,cov_range,warn,"cov_age spans 13-67998, outside [0, 120] -- looks like a sentinel no-answer code (999/9999) or a birth year that was never converted. irw_filter() treats every value here as an age (#1779).",614976,32,19218
+mhscdc_fried_2020_anger,imputed_values*,warn,Item 'Pre53' has one resp value accounting for 72% of responses — possible mean imputation.,560,7,80
+mhscdc_fried_2020_anger,resp_scale_mixed,warn,items span more than one response scale: 3 on 1-4 and 3 on ['1-5']. IRW requires one table per construct; split before submitting.,560,7,80
+mhscdc_fried_2020_anger,composite_items*,warn,"every item label names a computed score (['Pre52', 'Pre53', 'Pre54', 'Pre55']) — this looks like a summary/aggregate table, not raw item-level responses",560,7,80
+mhscdc_fried_2020_anger,sample_floor,warn,"80 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",560,7,80
+mhscdc_fried_2020_anger,column_order,warn,"columns start ['id', 'cov_Gender', 'cov_Age']; datastandard.md step 7 writes [id, item, resp] + covariates.",560,7,80
+mhscdc_fried_2020_conscientiousness,imputed_values*,warn,Item 'Pre46' has one resp value accounting for 62% of responses — possible mean imputation.,960,12,80
+mhscdc_fried_2020_conscientiousness,composite_items*,warn,"every item label names a computed score (['Pre39', 'Pre40', 'Pre41', 'Pre42']) — this looks like a summary/aggregate table, not raw item-level responses",960,12,80
+mhscdc_fried_2020_conscientiousness,sample_floor,warn,"80 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",960,12,80
+mhscdc_fried_2020_conscientiousness,column_order,warn,"columns start ['id', 'cov_Gender', 'cov_Age']; datastandard.md step 7 writes [id, item, resp] + covariates.",960,12,80
+mhscdc_fried_2020_dass,imputed_values*,warn,Item 'Pre17' has one resp value accounting for 68% of responses — possible mean imputation.,1680,21,80
+mhscdc_fried_2020_dass,composite_items*,warn,"every item label names a computed score (['Pre17', 'Pre18', 'Pre19', 'Pre20']) — this looks like a summary/aggregate table, not raw item-level responses",1680,21,80
+mhscdc_fried_2020_dass,sample_floor,warn,"80 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",1680,21,80
+mhscdc_fried_2020_dass,column_order,warn,"columns start ['id', 'cov_Gender', 'cov_Age']; datastandard.md step 7 writes [id, item, resp] + covariates.",1680,21,80
+mhscdc_fried_2020_ema,resp_na,warn,resp has 7738 NAs,70958,18,79
+mhscdc_fried_2020_ema,dup_id_item,warn,"77274 duplicate id+item rows (longitudinal column ['wave', 'date'] present — likely ok)",70958,18,79
+mhscdc_fried_2020_ema,imputed_values*,warn,Item 'Q10' has one resp value accounting for 77% of responses — possible mean imputation.,70958,18,79
+mhscdc_fried_2020_ema,sample_floor,warn,"79 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",70958,18,79
+mhscdc_fried_2020_ema,column_order,warn,"columns start ['id', 'date', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",70958,18,79
+mhscdc_fried_2020_loneliness,composite_items*,warn,"every item label names a computed score (['Pre41', 'Pre42', 'Pre43', 'Pre44']) — this looks like a summary/aggregate table, not raw item-level responses",400,5,80
+mhscdc_fried_2020_loneliness,sample_floor,warn,"80 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",400,5,80
+mhscdc_fried_2020_loneliness,column_order,warn,"columns start ['id', 'cov_Gender', 'cov_Age']; datastandard.md step 7 writes [id, item, resp] + covariates.",400,5,80
+mhscdc_fried_2020_mindfullness,composite_items*,warn,"every item label names a computed score (['Pre56', 'Pre57', 'Pre58', 'Pre59']) — this looks like a summary/aggregate table, not raw item-level responses",960,12,80
+mhscdc_fried_2020_mindfullness,sample_floor,warn,"80 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",960,12,80
+mhscdc_fried_2020_mindfullness,column_order,warn,"columns start ['id', 'cov_Gender', 'cov_Age']; datastandard.md step 7 writes [id, item, resp] + covariates.",960,12,80
+mhscdc_fried_2020_motivation,composite_items*,warn,"14/16 item labels name computed scores (['Pre86', 'Pre87', 'Pre88', 'Pre89']) — drop them, or confirm they are real items",1280,16,80
+mhscdc_fried_2020_motivation,sample_floor,warn,"80 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",1280,16,80
+mhscdc_fried_2020_motivation,column_order,warn,"columns start ['id', 'cov_Gender', 'cov_Age']; datastandard.md step 7 writes [id, item, resp] + covariates.",1280,16,80
+mhscdc_fried_2020_ps,composite_items*,warn,"every item label names a computed score (['Pre68', 'Pre69', 'Pre70', 'Pre71']) — this looks like a summary/aggregate table, not raw item-level responses",800,10,80
+mhscdc_fried_2020_ps,sample_floor,warn,"80 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",800,10,80
+mhscdc_fried_2020_ps,column_order,warn,"columns start ['id', 'cov_Gender', 'cov_Age']; datastandard.md step 7 writes [id, item, resp] + covariates.",800,10,80
+mhscdc_fried_2020_se,imputed_values*,warn,Item 'Pre46' has one resp value accounting for 62% of responses — possible mean imputation.,800,10,80
+mhscdc_fried_2020_se,composite_items*,warn,"every item label names a computed score (['Pre46', 'Pre47', 'Pre48', 'Pre49']) — this looks like a summary/aggregate table, not raw item-level responses",800,10,80
+mhscdc_fried_2020_se,sample_floor,warn,"80 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",800,10,80
+mhscdc_fried_2020_se,column_order,warn,"columns start ['id', 'cov_Gender', 'cov_Age']; datastandard.md step 7 writes [id, item, resp] + covariates.",800,10,80
+mhscdc_fried_2020_smartphone,item_scale_outlier,warn,1 item(s) fall outside the table's 1-6 scale: ['Pre115']. An isolated out-of-range column is usually not an item -- check for an administrative or count field.,1120,14,80
+mhscdc_fried_2020_smartphone,sample_floor,warn,"80 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",1120,14,80
+mhscdc_fried_2020_smartphone,column_order,warn,"columns start ['id', 'cov_Gender', 'cov_Age']; datastandard.md step 7 writes [id, item, resp] + covariates.",1120,14,80
+mhscdc_fried_2020_tired,imputed_values*,warn,Item 'Pre83' has one resp value accounting for 61% of responses — possible mean imputation.,640,8,80
+mhscdc_fried_2020_tired,composite_items*,warn,"every item label names a computed score (['Pre78', 'Pre79', 'Pre80', 'Pre81']) — this looks like a summary/aggregate table, not raw item-level responses",640,8,80
+mhscdc_fried_2020_tired,sample_floor,warn,"80 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",640,8,80
+mhscdc_fried_2020_tired,column_order,warn,"columns start ['id', 'cov_Gender', 'cov_Age']; datastandard.md step 7 writes [id, item, resp] + covariates.",640,8,80
+mindfulness_assessment,resp_na,warn,resp has 139 NAs,23300,39,601
+mindfulness_assessment,column_order,warn,"columns start ['age', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",23300,39,601
+ml_harper_2015,size_skipped,info,75 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+mobility,imputed_values*,warn,Item 'item_1' has one resp value accounting for 80% of responses — possible mean imputation.,67560,8,8445
+motion,dup_id_item,error,28620 duplicate id+item rows with no wave/timepoint/date column,31800,30,106
+motion,imputed_values*,warn,Item '1 100' has one resp value accounting for 80% of responses — possible mean imputation.,31800,30,106
+motion,column_order,warn,"columns start ['id', 'resp', 'rt']; datastandard.md step 7 writes [id, item, resp] + covariates.",31800,30,106
+movac_pakpour2022,,ok,,72096,12,6008
+mpsycho_Rmotivation,resp_na,warn,resp has 985 NAs,29687,36,852
+mpsycho_Rmotivation,imputed_values*,warn,Item 'ext10' has one resp value accounting for 73% of responses — possible mean imputation.,29687,36,852
+mpsycho_Rmotivation,multi_scale*,warn,"Item names suggest 3 subscales (['hyb', 'ext', 'int']) — IRW requires separate tables per construct.",29687,36,852
+mpsycho_Rmotivation,name_charset,warn,"table name 'mpsycho_Rmotivation' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",29687,36,852
+mpsycho_Rogers,imputed_values*,warn,Item 'decappetite' has one resp value accounting for 63% of responses — possible mean imputation.,10608,26,408
+mpsycho_Rogers,resp_scale_mixed,warn,items span more than one response scale: 16 on 0-3 and 10 on ['0-4']. IRW requires one table per construct; split before submitting.,10608,26,408
+mpsycho_Rogers,name_charset,warn,"table name 'mpsycho_Rogers' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",10608,26,408
+mpsycho_Rogers_adolescent,imputed_values*,warn,Item 'decappetite' has one resp value accounting for 67% of responses — possible mean imputation.,2262,26,87
+mpsycho_Rogers_adolescent,resp_scale_mixed,warn,"items span more than one response scale: 15 on 0-3 and 10 on ['0-4', '1-4', '2-4']. IRW requires one table per construct; split before submitting.",2262,26,87
+mpsycho_Rogers_adolescent,name_charset,warn,"table name 'mpsycho_Rogers_adolescent' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",2262,26,87
+mpsycho_Rogers_adolescent,sample_floor,warn,"87 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",2262,26,87
+mpsycho_YouthDep,imputed_values*,warn,Item 'CDI1' has one resp value accounting for 88% of responses — possible mean imputation.,59540,26,2290
+mpsycho_YouthDep,name_charset,warn,"table name 'mpsycho_YouthDep' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",59540,26,2290
+mpsycho_asti,resp_scale_mixed,warn,items span more than one response scale: 13 on 0.0-2.0 and 12 on ['0.0-3.0']. IRW requires one table per construct; split before submitting.,28225,25,1129
+mpsycho_avlancheprep,imputed_values*,warn,Item 'decision' has one resp value accounting for 92% of responses — possible mean imputation.,5420,4,1355
+mpsycho_avlancheprep,resp_scale_mixed,warn,items span more than one response scale: 2 on 1.0-4.0 and 1 on ['1.0-5.0']. IRW requires one table per construct; split before submitting.,5420,4,1355
+mpsycho_bsss,,ok,,13008,8,1626
+mpsycho_ceaq,imputed_values*,warn,Item 'ceaq1' has one resp value accounting for 71% of responses — possible mean imputation.,3328,16,208
+mpsycho_condom,imputed_values*,warn,Item 'Put' has one resp value accounting for 62% of responses — possible mean imputation.,3000,6,500
+mpsycho_lakes,resp_na,warn,resp has 62 NAs,15458,16,194
+mpsycho_lakes,dup_id_item,error,12416 duplicate id+item rows with no wave/timepoint/date column,15458,16,194
+mpsycho_lakes,multi_scale*,warn,"Item names suggest 3 subscales (['aff', 'cog', 'phy']) — IRW requires separate tables per construct.",15458,16,194
+mpsycho_lakes,column_order,warn,"columns start ['id', 'rater', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",15458,16,194
+mpsycho_learnemo,imputed_values*,warn,Item 'pc1_2' has one resp value accounting for 67% of responses — possible mean imputation.,1110,10,111
+mpsycho_rwdq,resp_na,warn,resp has 2492 NAs,16498,18,1049
+mpsycho_rwdq,imputed_values*,warn,Item 'wdq_22' has one resp value accounting for 76% of responses — possible mean imputation.,16498,18,1049
+mpsycho_wenchuan,resp_na,warn,resp has 22 NAs,6132,17,362
+mpsycho_wilmer,imputed_values*,warn,Item 'vpmt13' has one resp value accounting for 63% of responses — possible mean imputation.,36775,25,1471
+mpsycho_wilpat,imputed_values*,warn,Item 'BirthControl' has one resp value accounting for 84% of responses — possible mean imputation.,36984,46,804
+mpsycho_wilpat,column_order,warn,"columns start ['item', 'resp', 'id']; datastandard.md step 7 writes [id, item, resp] + covariates.",36984,46,804
+mpsycho_zareki,imputed_values*,warn,Item 'addit1' has one resp value accounting for 95% of responses — possible mean imputation.,5456,16,341
+mpsycho_zareki,multi_scale*,warn,"Item names suggest 2 subscales (['addit', 'subtr']) — IRW requires separate tables per construct.",5456,16,341
+mq_supremecourt,imputed_values*,warn,Item '1937-006' has one resp value accounting for 89% of responses — possible mean imputation.,53245,6108,48
+mq_supremecourt,sample_floor,warn,"48 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",53245,6108,48
+mq_supremecourt,column_order,warn,"columns start ['id', 'item', 'term']; datastandard.md step 7 writes [id, item, resp] + covariates.",53245,6108,48
+mturkddm_by,resp_na,warn,resp has 230 NAs,132570,20,166
+mturkddm_by,dup_id_item,error,129480 duplicate id+item rows with no wave/timepoint/date column,132570,20,166
+mturkddm_by,imputed_values*,warn,Item '10 20' has one resp value accounting for 70% of responses — possible mean imputation.,132570,20,166
+mturkddm_by,column_order,warn,"columns start ['id', 'block', 'order']; datastandard.md step 7 writes [id, item, resp] + covariates.",132570,20,166
+mturkddm_lexical,resp_na,warn,resp has 136 NAs,68024,4588,142
+mturkddm_lexical,dup_id_item,error,20 duplicate id+item rows with no wave/timepoint/date column,68024,4588,142
+mturkddm_lexical,imputed_values*,warn,Item 'abdominal' has one resp value accounting for 100% of responses — possible mean imputation.,68024,4588,142
+mturkddm_lexical,composite_items*,warn,"9/4588 item labels name computed scores (['preen', 'preci', 'total', 'post']) — drop them, or confirm they are real items",68024,4588,142
+mturkddm_lexical,column_order,warn,"columns start ['id', 'block', 'order']; datastandard.md step 7 writes [id, item, resp] + covariates.",68024,4588,142
+mturkddm_recognition,resp_na,warn,resp has 284 NAs,76624,2202,142
+mturkddm_recognition,dup_id_item,error,12 duplicate id+item rows with no wave/timepoint/date column,76624,2202,142
+mturkddm_recognition,imputed_values*,warn,Item 'abdominal' has one resp value accounting for 85% of responses — possible mean imputation.,76624,2202,142
+mturkddm_recognition,composite_items*,warn,"7/2202 item labels name computed scores (['mean', 'index', 'post', 'poster']) — drop them, or confirm they are real items",76624,2202,142
+mturkddm_recognition,column_order,warn,"columns start ['id', 'block', 'order']; datastandard.md step 7 writes [id, item, resp] + covariates.",76624,2202,142
+mturkddm_y25,resp_na,warn,resp has 55 NAs,127433,12,166
+mturkddm_y25,dup_id_item,error,125496 duplicate id+item rows with no wave/timepoint/date column,127433,12,166
+mturkddm_y25,imputed_values*,warn,Item '10 1' has one resp value accounting for 88% of responses — possible mean imputation.,127433,12,166
+mturkddm_y25,column_order,warn,"columns start ['id', 'block', 'order']; datastandard.md step 7 writes [id, item, resp] + covariates.",127433,12,166
+much_tte_2025_actionorientation,imputed_values*,warn,Item 'AO01' has one resp value accounting for 75% of responses — possible mean imputation.,14928,12,1244
+much_tte_2025_actionorientation,column_order,warn,"columns start ['id', 'group', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",14928,12,1244
+much_tte_2025_concentrationtask,resp_na,warn,resp has 1 NAs,11195,9,1244
+much_tte_2025_concentrationtask,imputed_values*,warn,Item 'CT01' has one resp value accounting for 74% of responses — possible mean imputation.,11195,9,1244
+much_tte_2025_concentrationtask,column_order,warn,"columns start ['id', 'group', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",11195,9,1244
+much_tte_2025_currentmotivation,dup_id_item,warn,7464 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),11196,3,1244
+much_tte_2025_currentmotivation,resp_ordinal*,warn,"101 distinct resp values — confirm continuous, not mis-parsed",11196,3,1244
+much_tte_2025_currentmotivation,imputed_values*,warn,Item 'CM01' has one resp value accounting for 63% of responses — possible mean imputation.,11196,3,1244
+much_tte_2025_currentmotivation,column_order,warn,"columns start ['id', 'group', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",11196,3,1244
+much_tte_2025_effort,dup_id_item,warn,6220 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),12440,5,1244
+much_tte_2025_effort,imputed_values*,warn,Item 'EF01' has one resp value accounting for 79% of responses — possible mean imputation.,12440,5,1244
+much_tte_2025_effort,column_order,warn,"columns start ['id', 'group', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",12440,5,1244
+much_tte_2025_matrixreasoning,resp_na,warn,resp has 143 NAs,24737,20,1243
+much_tte_2025_matrixreasoning,imputed_values*,warn,Item 'MR01' has one resp value accounting for 74% of responses — possible mean imputation.,24737,20,1243
+much_tte_2025_matrixreasoning,column_order,warn,"columns start ['id', 'group', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",24737,20,1243
+naep_multilcirt,imputed_values*,warn,Item 'Item1' has one resp value accounting for 74% of responses — possible mean imputation.,18120,12,1510
+narcissistic_personality_inventory,imputed_values*,warn,Item 'Q1' has one resp value accounting for 61% of responses — possible mean imputation.,448298,40,11241
+narcissistic_personality_inventory,column_order,warn,"columns start ['id', 'cov_gender', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",448298,40,11241
+narcissistic_personality_inventory,cov_range,warn,"cov_age spans 0-509, outside [0, 120] -- looks like out of range for a human age in years. irw_filter() treats every value here as an age (#1779).",448298,40,11241
+nas_rogoza_2024_study1,imputed_values*,warn,Item 'abusive' has one resp value accounting for 80% of responses — possible mean imputation.,11070,30,369
+nas_rogoza_2024_study1,resp_scale_mixed,warn,items span more than one response scale: 17 on 1-6 and 11 on ['1-7']. IRW requires one table per construct; split before submitting.,11070,30,369
+nas_rogoza_2024_study1,column_order,warn,"columns start ['id', 'cov_age', 'cov_gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",11070,30,369
+nas_rogoza_2024_study2_nas,imputed_values*,warn,Item 'NAS1' has one resp value accounting for 78% of responses — possible mean imputation.,6354,18,353
+nas_rogoza_2024_study2_nas,column_order,warn,"columns start ['id', 'cov_age', 'cov_gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",6354,18,353
+nas_rogoza_2024_study2_ngs,imputed_values*,warn,Item 'NGS4' has one resp value accounting for 71% of responses — possible mean imputation.,4589,13,353
+nas_rogoza_2024_study2_ngs,column_order,warn,"columns start ['id', 'cov_age', 'cov_gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",4589,13,353
+nas_rogoza_2024_study2_nvs,column_order,warn,"columns start ['id', 'cov_age', 'cov_gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",3883,11,353
+nas_rogoza_2024_study5_nas,resp_na,warn,resp has 5208 NAs,32832,4,317
+nas_rogoza_2024_study5_nas,dup_id_item,warn,36772 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),32832,4,317
+nas_rogoza_2024_study5_nas,resp_ordinal*,warn,"101 distinct resp values — confirm continuous, not mis-parsed",32832,4,317
+nas_rogoza_2024_study5_nas,column_order,warn,"columns start ['id', 'wave', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",32832,4,317
+nas_rogoza_2024_study5_ngs,resp_na,warn,resp has 5257 NAs,32783,4,317
+nas_rogoza_2024_study5_ngs,dup_id_item,warn,36772 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),32783,4,317
+nas_rogoza_2024_study5_ngs,resp_ordinal*,warn,"101 distinct resp values — confirm continuous, not mis-parsed",32783,4,317
+nas_rogoza_2024_study5_ngs,column_order,warn,"columns start ['id', 'wave', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",32783,4,317
+nas_rogoza_2024_study5_nvs,resp_na,warn,resp has 5172 NAs,32868,4,317
+nas_rogoza_2024_study5_nvs,dup_id_item,warn,36772 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),32868,4,317
+nas_rogoza_2024_study5_nvs,resp_ordinal*,warn,"101 distinct resp values — confirm continuous, not mis-parsed",32868,4,317
+nas_rogoza_2024_study5_nvs,column_order,warn,"columns start ['id', 'wave', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",32868,4,317
+nature_relatedness,resp_na,warn,resp has 155 NAs,48549,32,1522
+nature_relatedness,imputed_values*,warn,Item '4' has one resp value accounting for 69% of responses — possible mean imputation.,48549,32,1522
+nature_relatedness,rt_numeric*,warn,rt column is not numeric,48549,32,1522
+nature_relatedness,resp_scale_mixed,warn,"items span more than one response scale: 16 on 0.0-1.0 and 16 on ['1.0-5.0', '1.0-7.0']. IRW requires one table per construct; split before submitting.",48549,32,1522
+nerdy_personality,resp_na,warn,resp has 1917 NAs,775743,52,14955
+nerdy_personality,imputed_values*,warn,Item '37' has one resp value accounting for 96% of responses — possible mean imputation.,775743,52,14955
+nerdy_personality,resp_scale_mixed,warn,"items span more than one response scale: 26 on 1.0-5.0 and 26 on ['1.0-7.0', '0.0-1.0']. IRW requires one table per construct; split before submitting.",775743,52,14955
+neurips_2020,size_skipped,info,68 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+neurips_2022,resp_na,warn,resp has 37648 NAs,472309,5730,6468
+neurips_2022,dup_id_item,warn,167542 duplicate id+item rows (longitudinal column ['date'] present — likely ok),472309,5730,6468
+neurips_2022,imputed_values*,warn,Item '1' has one resp value accounting for 66% of responses — possible mean imputation.,472309,5730,6468
+neurips_2022,column_order,warn,"columns start ['id', 'date', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",472309,5730,6468
+nomt_hooper_2024_study1,imputed_values*,warn,Item '101' has one resp value accounting for 92% of responses — possible mean imputation.,25704,216,119
+nomt_hooper_2024_study2,imputed_values*,warn,Item '12' has one resp value accounting for 96% of responses — possible mean imputation.,56592,144,393
+nomt_hooper_2024_study2,rt_negative*,warn,rt has negative values,56592,144,393
+nomt_hooper_2024_study2,column_order,warn,"columns start ['group', 'id', 'cov_gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",56592,144,393
+non_parametric_mixture_modeling_exp1_Cleaned,dup_id_item,error,44900 duplicate id+item rows with no wave/timepoint/date column,44957,2,56
+non_parametric_mixture_modeling_exp1_Cleaned,imputed_values*,warn,Item 'A' has one resp value accounting for 75% of responses — possible mean imputation.,44957,2,56
+non_parametric_mixture_modeling_exp1_Cleaned,name_length,error,"table name is 44 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",44957,2,56
+non_parametric_mixture_modeling_exp1_Cleaned,name_charset,warn,"table name 'non_parametric_mixture_modeling_exp1_Cleaned' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",44957,2,56
+non_parametric_mixture_modeling_exp1_Cleaned,sample_floor,warn,"56 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",44957,2,56
+non_parametric_mixture_modeling_exp1_Cleaned,column_order,warn,"columns start ['id', 'item', 'rt']; datastandard.md step 7 writes [id, item, resp] + covariates.",44957,2,56
+nonverbal_immediacy,size_skipped,info,16 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+novelobjectmatching,imputed_values*,warn,Item 'FaceM_01' has one resp value accounting for 89% of responses — possible mean imputation.,47840,320,299
+novelobjectmatching,multi_scale*,warn,"Item names suggest 5 subscales (['npmt', 'facem', 'facen', 'fingerprintm']) — IRW requires separate tables per construct.",47840,320,299
+number_pattern_game,dup_id_item,error,263611 duplicate id+item rows with no wave/timepoint/date column,272700,255,606
+number_pattern_game,imputed_values*,warn,Item '1' has one resp value accounting for 60% of responses — possible mean imputation.,272700,255,606
+offlinefriend_bigfive,,ok,,35288,44,802
+offlinefriend_dospert,imputed_values*,warn,Item 'T1_DOSPERT_10' has one resp value accounting for 72% of responses — possible mean imputation.,22140,30,800
+offlinefriend_ofaq,imputed_values*,warn,Item 'T1_OFAQ_20' has one resp value accounting for 61% of responses — possible mean imputation.,29674,37,802
+orev_bohn2024,imputed_values*,warn,Item 'ant' has one resp value accounting for 99% of responses — possible mean imputation.,30212,52,581
+orev_bohn2024,column_order,warn,"columns start ['id', 'item', 'rt']; datastandard.md step 7 writes [id, item, resp] + covariates.",30212,52,581
+oxfordcovid_xue_2024_at,dup_id_item,warn,134082 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),179937,44,1518
+oxfordcovid_xue_2024_at,imputed_values*,warn,Item 'media_playing' has one resp value accounting for 69% of responses — possible mean imputation.,179937,44,1518
+oxfordcovid_xue_2024_at,multi_scale*,warn,"Item names suggest 2 subscales (['media', 'activity']) — IRW requires separate tables per construct.",179937,44,1518
+oxfordcovid_xue_2024_at,resp_scale_mixed,warn,items span more than one response scale: 36 on 1-5 and 8 on ['0-5']. IRW requires one table per construct; split before submitting.,179937,44,1518
+oxfordcovid_xue_2024_at,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",179937,44,1518
+oxfordcovid_xue_2024_bfi,dup_id_item,warn,5569 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),32848,15,1826
+oxfordcovid_xue_2024_bfi,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",32848,15,1826
+oxfordcovid_xue_2024_bfi,cov_range,warn,"cov_age spans 3-342, outside [0, 120] -- looks like out of range for a human age in years. irw_filter() treats every value here as an age (#1779).",32848,15,1826
+oxfordcovid_xue_2024_brs,dup_id_item,warn,5256 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),10344,6,851
+oxfordcovid_xue_2024_brs,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",10344,6,851
+oxfordcovid_xue_2024_edeq,dup_id_item,warn,72490 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),90858,12,1534
+oxfordcovid_xue_2024_edeq,imputed_values*,warn,Item 'edeq_10' has one resp value accounting for 81% of responses — possible mean imputation.,90858,12,1534
+oxfordcovid_xue_2024_edeq,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",90858,12,1534
+oxfordcovid_xue_2024_gad,dup_id_item,warn,43201 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),54210,7,1574
+oxfordcovid_xue_2024_gad,imputed_values*,warn,Item 'gad_5' has one resp value accounting for 66% of responses — possible mean imputation.,54210,7,1574
+oxfordcovid_xue_2024_gad,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",54210,7,1574
+oxfordcovid_xue_2024_iusc,dup_id_item,warn,9213 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),53656,27,1662
+oxfordcovid_xue_2024_iusc,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",53656,27,1662
+oxfordcovid_xue_2024_iusc,cov_range,warn,"cov_age spans 3-342, outside [0, 120] -- looks like out of range for a human age in years. irw_filter() treats every value here as an age (#1779).",53656,27,1662
+oxfordcovid_xue_2024_mfq,dup_id_item,warn,6570 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),37431,20,1555
+oxfordcovid_xue_2024_mfq,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",37431,20,1555
+oxfordcovid_xue_2024_mfq,cov_range,warn,"cov_age spans 11-342, outside [0, 120] -- looks like out of range for a human age in years. irw_filter() treats every value here as an age (#1779).",37431,20,1555
+oxfordcovid_xue_2024_mh,dup_id_item,warn,6120 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),39840,15,2248
+oxfordcovid_xue_2024_mh,imputed_values*,warn,Item 'mental_health___1' has one resp value accounting for 89% of responses — possible mean imputation.,39840,15,2248
+oxfordcovid_xue_2024_mh,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",39840,15,2248
+oxfordcovid_xue_2024_mh,cov_range,warn,"cov_age spans 3-342, outside [0, 120] -- looks like out of range for a human age in years. irw_filter() treats every value here as an age (#1779).",39840,15,2248
+oxfordcovid_xue_2024_pas,dup_id_item,warn,57725 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),72379,9,1632
+oxfordcovid_xue_2024_pas,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",72379,9,1632
+oxfordcovid_xue_2024_pas,cov_range,warn,"cov_age spans 11-342, outside [0, 120] -- looks like out of range for a human age in years. irw_filter() treats every value here as an age (#1779).",72379,9,1632
+oxfordcovid_xue_2024_phq,dup_id_item,warn,55865 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),70077,9,1582
+oxfordcovid_xue_2024_phq,imputed_values*,warn,Item 'phq_8' has one resp value accounting for 78% of responses — possible mean imputation.,70077,9,1582
+oxfordcovid_xue_2024_phq,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",70077,9,1582
+oxfordcovid_xue_2024_phq,cov_range,warn,"cov_age spans 11-342, outside [0, 120] -- looks like out of range for a human age in years. irw_filter() treats every value here as an age (#1779).",70077,9,1582
+oxfordcovid_xue_2024_pss,dup_id_item,warn,25160 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),31555,4,1600
+oxfordcovid_xue_2024_pss,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",31555,4,1600
+oxfordcovid_xue_2024_pss,cov_range,warn,"cov_age spans 11-342, outside [0, 120] -- looks like out of range for a human age in years. irw_filter() treats every value here as an age (#1779).",31555,4,1600
+oxfordcovid_xue_2024_pswq_a,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",8072,16,506
+oxfordcovid_xue_2024_pswq_a,cov_range,warn,"cov_age spans 13-342, outside [0, 120] -- looks like out of range for a human age in years. irw_filter() treats every value here as an age (#1779).",8072,16,506
+oxfordcovid_xue_2024_pswq_c,imputed_values*,warn,Item 'pswq_c_9' has one resp value accounting for 76% of responses — possible mean imputation.,17629,14,1264
+oxfordcovid_xue_2024_pswq_c,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",17629,14,1264
+oxfordcovid_xue_2024_rse,dup_id_item,warn,3255 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),18535,10,1534
+oxfordcovid_xue_2024_rse,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",18535,10,1534
+oxfordcovid_xue_2024_rse,cov_range,warn,"cov_age spans 11-342, outside [0, 120] -- looks like out of range for a human age in years. irw_filter() treats every value here as an age (#1779).",18535,10,1534
+oxfordcovid_xue_2024_school,imputed_values*,warn,Item 'school_1' has one resp value accounting for 93% of responses — possible mean imputation.,3158,19,173
+oxfordcovid_xue_2024_school,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",3158,19,173
+oxfordcovid_xue_2024_swemws,dup_id_item,warn,41705 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),52126,7,1491
+oxfordcovid_xue_2024_swemws,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",52126,7,1491
+oxfordcovid_xue_2024_ua,imputed_values*,warn,Item 'university_1' has one resp value accounting for 64% of responses — possible mean imputation.,2020,4,1308
+oxfordcovid_xue_2024_ua,resp_scale_mixed,warn,items span more than one response scale: 2 on 1-4 and 1 on ['1-6']. IRW requires one table per construct; split before submitting.,2020,4,1308
+oxfordcovid_xue_2024_ua,column_order,warn,"columns start ['id', 'wave', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",2020,4,1308
+oxfordcovid_xue_2024_ua,cov_range,warn,"cov_age spans 3-342, outside [0, 120] -- looks like out of range for a human age in years. irw_filter() treats every value here as an age (#1779).",2020,4,1308
+paampsmartsud_saba_2023_amps,resp_na,warn,resp has 1552 NAs,4448,15,93
+paampsmartsud_saba_2023_amps,dup_id_item,warn,4500 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),4448,15,93
+paampsmartsud_saba_2023_amps,column_order,warn,"columns start ['id', 'cov_NUMBER_MH_DIAGNOSES', 'cov_AUD_SUD_DIAGNOSES']; datastandard.md step 7 writes [id, item, resp] + covariates.",4448,15,93
+paampsmartsud_saba_2023_attendance,imputed_values*,warn,Item 'ATTENDANCE_S1' has one resp value accounting for 100% of responses — possible mean imputation.,1200,12,100
+paampsmartsud_saba_2023_attendance,column_order,warn,"columns start ['id', 'cov_NUMBER_MH_DIAGNOSES', 'cov_AUD_SUD_DIAGNOSES']; datastandard.md step 7 writes [id, item, resp] + covariates.",1200,12,100
+paampsmartsud_saba_2023_ders,resp_na,warn,resp has 740 NAs,6660,37,90
+paampsmartsud_saba_2023_ders,dup_id_item,warn,3700 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),6660,37,90
+paampsmartsud_saba_2023_ders,imputed_values*,warn,Item 'DERS_14_POST' has one resp value accounting for 77% of responses — possible mean imputation.,6660,37,90
+paampsmartsud_saba_2023_ders,column_order,warn,"columns start ['id', 'cov_NUMBER_MH_DIAGNOSES', 'cov_AUD_SUD_DIAGNOSES']; datastandard.md step 7 writes [id, item, resp] + covariates.",6660,37,90
+paampsmartsud_saba_2023_ffmq,resp_na,warn,resp has 480 NAs,4320,24,90
+paampsmartsud_saba_2023_ffmq,dup_id_item,warn,2400 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),4320,24,90
+paampsmartsud_saba_2023_ffmq,column_order,warn,"columns start ['id', 'cov_NUMBER_MH_DIAGNOSES', 'cov_AUD_SUD_DIAGNOSES']; datastandard.md step 7 writes [id, item, resp] + covariates.",4320,24,90
+paampsmartsud_saba_2023_pacs,resp_na,warn,resp has 100 NAs,900,5,90
+paampsmartsud_saba_2023_pacs,dup_id_item,warn,500 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),900,5,90
+paampsmartsud_saba_2023_pacs,column_order,warn,"columns start ['id', 'cov_NUMBER_MH_DIAGNOSES', 'cov_AUD_SUD_DIAGNOSES']; datastandard.md step 7 writes [id, item, resp] + covariates.",900,5,90
+paampsmartsud_saba_2023_pss,resp_na,warn,resp has 200 NAs,1800,10,90
+paampsmartsud_saba_2023_pss,dup_id_item,warn,1000 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),1800,10,90
+paampsmartsud_saba_2023_pss,column_order,warn,"columns start ['id', 'cov_NUMBER_MH_DIAGNOSES', 'cov_AUD_SUD_DIAGNOSES']; datastandard.md step 7 writes [id, item, resp] + covariates.",1800,10,90
+pact_project,dup_id_item,error,171719 duplicate id+item rows with no wave/timepoint/date column,1018383,850,4002
+pact_project,imputed_values*,warn,Item '1' has one resp value accounting for 81% of responses — possible mean imputation.,1018383,850,4002
+pact_project,item_scale_outlier,warn,"89 item(s) fall outside the table's 0.0-1.0 scale: [67, 68, 69, 70]. An isolated out-of-range column is usually not an item -- check for an administrative or count field.",1018383,850,4002
+pact_project,column_order,warn,"columns start ['id', 'treatment', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",1018383,850,4002
+papp_silva-martins2023,imputed_values*,warn,Item 'IIi23' has one resp value accounting for 70% of responses — possible mean imputation.,19233,62,503
+papp_silva-martins2023,multi_scale*,warn,"Item names suggest 2 subscales (['i', 'iii']) — IRW requires separate tables per construct.",19233,62,503
+papp_silva-martins2023,name_charset,warn,"table name 'papp_silva-martins2023' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",19233,62,503
+parental_text_intervention,imputed_values*,warn,Item '3' has one resp value accounting for 72% of responses — possible mean imputation.,52809,19,3870
+parental_text_intervention,resp_scale_mixed,warn,"items span more than one response scale: 15 on 1.0-4.0 and 4 on ['0.0-1.0', '0.0-6.0', '0.0-10.0']. IRW requires one table per construct; split before submitting.",52809,19,3870
+pass20_klosowska_2025_csq_online,id_na,warn,id has 6 NAs,2508,6,414
+pass20_klosowska_2025_csq_online,dup_id_item,error,18 duplicate id+item rows with no wave/timepoint/date column,2508,6,414
+pass20_klosowska_2025_csq_online,column_order,warn,"columns start ['id', 'cov_age', 'cov_sex']; datastandard.md step 7 writes [id, item, resp] + covariates.",2508,6,414
+pass20_klosowska_2025_dass_online,id_na,warn,id has 21 NAs,8778,21,414
+pass20_klosowska_2025_dass_online,dup_id_item,error,63 duplicate id+item rows with no wave/timepoint/date column,8778,21,414
+pass20_klosowska_2025_dass_online,column_order,warn,"columns start ['id', 'cov_age', 'cov_sex']; datastandard.md step 7 writes [id, item, resp] + covariates.",8778,21,414
+pass20_klosowska_2025_pass_hospital,column_order,warn,"columns start ['id', 'cov_age', 'cov_sex']; datastandard.md step 7 writes [id, item, resp] + covariates.",2813,20,141
+pass20_klosowska_2025_pass_online,id_na,warn,id has 40 NAs,14960,20,414
+pass20_klosowska_2025_pass_online,dup_id_item,warn,6660 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),14960,20,414
+pass20_klosowska_2025_pass_online,column_order,warn,"columns start ['id', 'cov_age', 'cov_sex']; datastandard.md step 7 writes [id, item, resp] + covariates.",14960,20,414
+pass20_klosowska_2025_staix_online,id_na,warn,id has 20 NAs,8360,20,414
+pass20_klosowska_2025_staix_online,dup_id_item,error,60 duplicate id+item rows with no wave/timepoint/date column,8360,20,414
+pass20_klosowska_2025_staix_online,column_order,warn,"columns start ['id', 'cov_age', 'cov_sex']; datastandard.md step 7 writes [id, item, resp] + covariates.",8360,20,414
+pass_vangsness_2019,,ok,,2768,12,231
+pechorro_impulsivity_2021_bes,column_order,warn,"columns start ['id', 'cov_sex', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",3003,7,429
+pechorro_impulsivity_2021_iid,imputed_values*,warn,Item 'iid_15' has one resp value accounting for 77% of responses — possible mean imputation.,9866,23,429
+pechorro_impulsivity_2021_iid,column_order,warn,"columns start ['id', 'cov_sex', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",9866,23,429
+pechorro_impulsivity_2021_rpq,imputed_values*,warn,Item 'rpq_1' has one resp value accounting for 66% of responses — possible mean imputation.,9866,23,429
+pechorro_impulsivity_2021_rpq,column_order,warn,"columns start ['id', 'cov_sex', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",9866,23,429
+pechorro_impulsivity_2021_ypitris,resp_na,warn,resp has 2 NAs,9007,21,429
+pechorro_impulsivity_2021_ypitris,imputed_values*,warn,Item 'ypitris_15' has one resp value accounting for 70% of responses — possible mean imputation.,9007,21,429
+pechorro_impulsivity_2021_ypitris,column_order,warn,"columns start ['id', 'cov_sex', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",9007,21,429
+perceived_injustice_mourin,resp_na,warn,resp has 1 NAs,4198,19,221
+phq_BrummerHoffman_2021,resp_na,warn,resp has 54 NAs,82206,45,1828
+phq_BrummerHoffman_2021,imputed_values*,warn,Item 'phq_suicide_ability' has one resp value accounting for 69% of responses — possible mean imputation.,82206,45,1828
+phq_BrummerHoffman_2021,name_charset,warn,"table name 'phq_BrummerHoffman_2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",82206,45,1828
+phq_BrummerHoffman_2021,column_order,warn,"columns start ['id', 'group', 'date']; datastandard.md step 7 writes [id, item, resp] + covariates.",82206,45,1828
+phq_insomnia_wang2025,size_skipped,info,12 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+pirlsmissing_sirt,resp_na,warn,resp has 11003 NAs,110797,35,3480
+pirlsmissing_sirt,imputed_values*,warn,Item 'R31G01M' has one resp value accounting for 82% of responses — possible mean imputation.,110797,35,3480
+pisa2000_math,id_na,error,id is entirely NA,0,0,0
+pisa2000_math,item_na,error,item is entirely NA,0,0,0
+pisa2000_math,resp_na,error,resp is entirely NA,0,0,0
+pisa2000_math,resp_variation*,error,resp has no variation (1 unique value),0,0,0
+pisa2000_math,density*,warn,"very sparse (density=0); fine for adaptive/booklet designs, else verify",0,0,0
+pisa2000_math,sample_floor,warn,"0 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",0,0,0
+pisa2000_read,id_na,error,id is entirely NA,0,0,0
+pisa2000_read,item_na,error,item is entirely NA,0,0,0
+pisa2000_read,resp_na,error,resp is entirely NA,0,0,0
+pisa2000_read,resp_variation*,error,resp has no variation (1 unique value),0,0,0
+pisa2000_read,density*,warn,"very sparse (density=0); fine for adaptive/booklet designs, else verify",0,0,0
+pisa2000_read,sample_floor,warn,"0 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",0,0,0
+pisa2000_science,id_na,error,id is entirely NA,0,0,0
+pisa2000_science,item_na,error,item is entirely NA,0,0,0
+pisa2000_science,resp_na,error,resp is entirely NA,0,0,0
+pisa2000_science,resp_variation*,error,resp has no variation (1 unique value),0,0,0
+pisa2000_science,density*,warn,"very sparse (density=0); fine for adaptive/booklet designs, else verify",0,0,0
+pisa2000_science,sample_floor,warn,"0 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",0,0,0
+pisa2003_math,id_na,error,id is entirely NA,0,0,0
+pisa2003_math,item_na,error,item is entirely NA,0,0,0
+pisa2003_math,resp_na,error,resp is entirely NA,0,0,0
+pisa2003_math,resp_variation*,error,resp has no variation (1 unique value),0,0,0
+pisa2003_math,density*,warn,"very sparse (density=0); fine for adaptive/booklet designs, else verify",0,0,0
+pisa2003_math,sample_floor,warn,"0 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",0,0,0
+pisa2003_problem_solving,id_na,error,id is entirely NA,0,0,0
+pisa2003_problem_solving,item_na,error,item is entirely NA,0,0,0
+pisa2003_problem_solving,resp_na,error,resp is entirely NA,0,0,0
+pisa2003_problem_solving,resp_variation*,error,resp has no variation (1 unique value),0,0,0
+pisa2003_problem_solving,density*,warn,"very sparse (density=0); fine for adaptive/booklet designs, else verify",0,0,0
+pisa2003_problem_solving,sample_floor,warn,"0 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",0,0,0
+pisa2003_read,id_na,error,id is entirely NA,0,0,0
+pisa2003_read,item_na,error,item is entirely NA,0,0,0
+pisa2003_read,resp_na,error,resp is entirely NA,0,0,0
+pisa2003_read,resp_variation*,error,resp has no variation (1 unique value),0,0,0
+pisa2003_read,density*,warn,"very sparse (density=0); fine for adaptive/booklet designs, else verify",0,0,0
+pisa2003_read,sample_floor,warn,"0 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",0,0,0
+pisa2003_science,id_na,error,id is entirely NA,0,0,0
+pisa2003_science,item_na,error,item is entirely NA,0,0,0
+pisa2003_science,resp_na,error,resp is entirely NA,0,0,0
+pisa2003_science,resp_variation*,error,resp has no variation (1 unique value),0,0,0
+pisa2003_science,density*,warn,"very sparse (density=0); fine for adaptive/booklet designs, else verify",0,0,0
+pisa2003_science,sample_floor,warn,"0 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",0,0,0
+pisa2006_math,id_na,error,id is entirely NA,0,0,0
+pisa2006_math,item_na,error,item is entirely NA,0,0,0
+pisa2006_math,resp_na,error,resp is entirely NA,0,0,0
+pisa2006_math,resp_variation*,error,resp has no variation (1 unique value),0,0,0
+pisa2006_math,density*,warn,"very sparse (density=0); fine for adaptive/booklet designs, else verify",0,0,0
+pisa2006_math,sample_floor,warn,"0 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",0,0,0
+pisa2006_read,id_na,error,id is entirely NA,0,0,0
+pisa2006_read,item_na,error,item is entirely NA,0,0,0
+pisa2006_read,resp_na,error,resp is entirely NA,0,0,0
+pisa2006_read,resp_variation*,error,resp has no variation (1 unique value),0,0,0
+pisa2006_read,density*,warn,"very sparse (density=0); fine for adaptive/booklet designs, else verify",0,0,0
+pisa2006_read,sample_floor,warn,"0 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",0,0,0
+pisa2006_science,id_na,error,id is entirely NA,0,0,0
+pisa2006_science,item_na,error,item is entirely NA,0,0,0
+pisa2006_science,resp_na,error,resp is entirely NA,0,0,0
+pisa2006_science,resp_variation*,error,resp has no variation (1 unique value),0,0,0
+pisa2006_science,density*,warn,"very sparse (density=0); fine for adaptive/booklet designs, else verify",0,0,0
+pisa2006_science,sample_floor,warn,"0 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",0,0,0
+pisa2009_math,id_na,error,id is entirely NA,0,0,0
+pisa2009_math,item_na,error,item is entirely NA,0,0,0
+pisa2009_math,resp_na,error,resp is entirely NA,0,0,0
+pisa2009_math,resp_variation*,error,resp has no variation (1 unique value),0,0,0
+pisa2009_math,density*,warn,"very sparse (density=0); fine for adaptive/booklet designs, else verify",0,0,0
+pisa2009_math,sample_floor,warn,"0 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",0,0,0
+pisa2009_read,id_na,error,id is entirely NA,0,0,0
+pisa2009_read,item_na,error,item is entirely NA,0,0,0
+pisa2009_read,resp_na,error,resp is entirely NA,0,0,0
+pisa2009_read,resp_variation*,error,resp has no variation (1 unique value),0,0,0
+pisa2009_read,density*,warn,"very sparse (density=0); fine for adaptive/booklet designs, else verify",0,0,0
+pisa2009_read,sample_floor,warn,"0 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",0,0,0
+pisa2009_science,id_na,error,id is entirely NA,0,0,0
+pisa2009_science,item_na,error,item is entirely NA,0,0,0
+pisa2009_science,resp_na,error,resp is entirely NA,0,0,0
+pisa2009_science,resp_variation*,error,resp has no variation (1 unique value),0,0,0
+pisa2009_science,density*,warn,"very sparse (density=0); fine for adaptive/booklet designs, else verify",0,0,0
+pisa2009_science,sample_floor,warn,"0 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",0,0,0
+pisa2012_math,id_na,error,id is entirely NA,0,0,0
+pisa2012_math,item_na,error,item is entirely NA,0,0,0
+pisa2012_math,resp_na,error,resp is entirely NA,0,0,0
+pisa2012_math,resp_variation*,error,resp has no variation (1 unique value),0,0,0
+pisa2012_math,density*,warn,"very sparse (density=0); fine for adaptive/booklet designs, else verify",0,0,0
+pisa2012_math,sample_floor,warn,"0 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",0,0,0
+pisa2012_read,id_na,error,id is entirely NA,0,0,0
+pisa2012_read,item_na,error,item is entirely NA,0,0,0
+pisa2012_read,resp_na,error,resp is entirely NA,0,0,0
+pisa2012_read,resp_variation*,error,resp has no variation (1 unique value),0,0,0
+pisa2012_read,density*,warn,"very sparse (density=0); fine for adaptive/booklet designs, else verify",0,0,0
+pisa2012_read,sample_floor,warn,"0 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",0,0,0
+pisa2012_science,id_na,error,id is entirely NA,0,0,0
+pisa2012_science,item_na,error,item is entirely NA,0,0,0
+pisa2012_science,resp_na,error,resp is entirely NA,0,0,0
+pisa2012_science,resp_variation*,error,resp has no variation (1 unique value),0,0,0
+pisa2012_science,density*,warn,"very sparse (density=0); fine for adaptive/booklet designs, else verify",0,0,0
+pisa2012_science,sample_floor,warn,"0 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",0,0,0
+pisa2015_math,size_skipped,info,37 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+pisa2015_read,size_skipped,info,46 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+pisa2015_science,size_skipped,info,130 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+pisa2018_gc,size_skipped,info,24 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+pisa2018_math,size_skipped,info,58 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+pisa2018_read,size_skipped,info,196 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+pisa2018_science,size_skipped,info,94 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+pisa2022_math,size_skipped,info,166 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+pisa2022_read,size_skipped,info,122 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+pisa2022_science,size_skipped,info,94 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+pks_probability,resp_na,warn,resp has 1908 NAs,10188,24,504
+pks_probability,imputed_values*,warn,Item 'b101' has one resp value accounting for 81% of responses — possible mean imputation.,10188,24,504
+polca_carcinoma,imputed_values*,warn,Item 'B' has one resp value accounting for 67% of responses — possible mean imputation.,826,7,118
+polca_cheating,imputed_values*,warn,Item 'COPYEXAM' has one resp value accounting for 79% of responses — possible mean imputation.,1276,4,319
+polca_election,resp_na,warn,resp has 1292 NAs,20128,12,1785
+polca_values,imputed_values*,warn,Item 'A' has one resp value accounting for 79% of responses — possible mean imputation.,864,4,216
+political_psychology,resp_na,warn,resp has 107733 NAs,296862,37,552
+political_psychology,dup_id_item,warn,384171 duplicate id+item rows (longitudinal column ['date'] present — likely ok),296862,37,552
+political_psychology,imputed_values*,warn,Item '10' has one resp value accounting for 62% of responses — possible mean imputation.,296862,37,552
+pps_vangsness_2019,,ok,,2783,12,232
+preference_inventory,,ok,,162024,12,13502
+preschool_sel_akt,imputed_values*,warn,Item 'akt1_1s_t1' has one resp value accounting for 71% of responses — possible mean imputation.,14506,17,883
+preschool_sel_box,imputed_values*,warn,Item 'box1_10_t1' has one resp value accounting for 62% of responses — possible mean imputation.,14234,20,735
+preschool_sel_dn,,ok,,11472,14,878
+preschool_sel_emt,imputed_values*,warn,Item 'emta1_1s_t1' has one resp value accounting for 60% of responses — possible mean imputation.,21016,48,898
+preschool_sel_emt,multi_scale*,warn,"Item names suggest 2 subscales (['emta', 'emtb']) — IRW requires separate tables per construct.",21016,48,898
+preschool_sel_htks,imputed_values*,warn,Item 'htks1_10_t1' has one resp value accounting for 80% of responses — possible mean imputation.,8320,10,847
+preschool_sel_pl,imputed_values*,warn,Item 'pl_as10_t1' has one resp value accounting for 81% of responses — possible mean imputation.,19036,39,965
+preschool_sel_pl,multi_scale*,warn,"Item names suggest 2 subscales (['pl', 'plsp']) — IRW requires separate tables per construct.",19036,39,965
+preschool_sel_wj,imputed_values*,warn,Item 'wj_ap11_t1' has one resp value accounting for 79% of responses — possible mean imputation.,28320,78,897
+previc_bohn2023,imputed_values*,warn,Item '1' has one resp value accounting for 100% of responses — possible mean imputation.,451010,379,1190
+previc_bohn2023,column_order,warn,"columns start ['word', 'resp', 'word_type']; datastandard.md step 7 writes [id, item, resp] + covariates.",451010,379,1190
+project_kids_ctopp,dup_id_item,warn,14065 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),62554,58,1421
+project_kids_ctopp,imputed_values*,warn,Item 'ctopp_blend_10a' has one resp value accounting for 68% of responses — possible mean imputation.,62554,58,1421
+project_kids_ctopp,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",62554,58,1421
+project_kids_kbit,imputed_values*,warn,Item 'kbit_s10_matrices' has one resp value accounting for 76% of responses — possible mean imputation.,80865,125,1287
+project_kids_kbit,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",80865,125,1287
+project_kids_told_grade,imputed_values*,warn,Item 'told_gc_10a' has one resp value accounting for 87% of responses — possible mean imputation.,15220,28,593
+project_kids_told_grade,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",15220,28,593
+project_kids_told_wave,dup_id_item,warn,4193 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),51602,58,1386
+project_kids_told_wave,imputed_values*,warn,Item 'told_gc_19a' has one resp value accounting for 63% of responses — possible mean imputation.,51602,58,1386
+project_kids_told_wave,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",51602,58,1386
+project_kids_topel,imputed_values*,warn,Item 'topela_10a' has one resp value accounting for 82% of responses — possible mean imputation.,36388,36,1066
+project_kids_topel,multi_scale*,warn,"Item names suggest 3 subscales (['topelc', 'topela', 'topelb']) — IRW requires separate tables per construct.",36388,36,1066
+project_kids_topel,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",36388,36,1066
+project_kids_tosrec,imputed_values*,warn,Item 'tosrec_post_score_1' has one resp value accounting for 96% of responses — possible mean imputation.,39683,168,961
+project_kids_tosrec,composite_items*,warn,"every item label names a computed score (['tosrec_score_1', 'tosrec_score_10', 'tosrec_score_11', 'tosrec_score_12']) — this looks like a summary/aggregate table, not raw item-level responses",39683,168,961
+project_kids_tosrec,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",39683,168,961
+project_kids_wj_ak_grade,imputed_values*,warn,Item 'wj_aka_10s' has one resp value accounting for 94% of responses — possible mean imputation.,3709,13,348
+project_kids_wj_ak_grade,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",3709,13,348
+project_kids_wj_ak_wave,dup_id_item,warn,85692 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),204310,65,3319
+project_kids_wj_ak_wave,imputed_values*,warn,Item 'wj_aka_10s' has one resp value accounting for 92% of responses — possible mean imputation.,204310,65,3319
+project_kids_wj_ak_wave,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",204310,65,3319
+project_kids_wj_ap,dup_id_item,warn,24503 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),42253,39,511
+project_kids_wj_ap,imputed_values*,warn,Item 'wj_ap_10s' has one resp value accounting for 97% of responses — possible mean imputation.,42253,39,511
+project_kids_wj_ap,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",42253,39,511
+project_kids_wj_lwid_grade,dup_id_item,warn,14434 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),54680,71,852
+project_kids_wj_lwid_grade,imputed_values*,warn,Item 'wj_lw_10s' has one resp value accounting for 100% of responses — possible mean imputation.,54680,71,852
+project_kids_wj_lwid_grade,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",54680,71,852
+project_kids_wj_lwid_wave,dup_id_item,warn,279910 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),470335,76,3962
+project_kids_wj_lwid_wave,imputed_values*,warn,Item 'wj_lw_10s' has one resp value accounting for 95% of responses — possible mean imputation.,470335,76,3962
+project_kids_wj_lwid_wave,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",470335,76,3962
+project_kids_wj_mf,dup_id_item,warn,22412 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),43430,80,510
+project_kids_wj_mf,imputed_values*,warn,Item 'wj_mf_1_1' has one resp value accounting for 73% of responses — possible mean imputation.,43430,80,510
+project_kids_wj_mf,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",43430,80,510
+project_kids_wj_pc_grade,dup_id_item,warn,11645 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),39371,41,849
+project_kids_wj_pc_grade,imputed_values*,warn,Item 'wj_pc_10s' has one resp value accounting for 93% of responses — possible mean imputation.,39371,41,849
+project_kids_wj_pc_grade,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",39371,41,849
+project_kids_wj_pc_wave,dup_id_item,warn,117307 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),226884,44,3770
+project_kids_wj_pc_wave,imputed_values*,warn,Item 'wj_pc_10s' has one resp value accounting for 70% of responses — possible mean imputation.,226884,44,3770
+project_kids_wj_pc_wave,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",226884,44,3770
+project_kids_wj_pv_grade,dup_id_item,warn,9942 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),33220,34,846
+project_kids_wj_pv_grade,imputed_values*,warn,Item 'wj_pv_10s' has one resp value accounting for 93% of responses — possible mean imputation.,33220,34,846
+project_kids_wj_pv_grade,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",33220,34,846
+project_kids_wj_pv_wave,dup_id_item,warn,200973 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),331616,43,3960
+project_kids_wj_pv_wave,imputed_values*,warn,Item 'wj_pv_10s' has one resp value accounting for 96% of responses — possible mean imputation.,331616,43,3960
+project_kids_wj_pv_wave,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",331616,43,3960
+project_kids_wj_qc,imputed_values*,warn,Item 'wj_qca_10s' has one resp value accounting for 83% of responses — possible mean imputation.,1793,26,76
+project_kids_wj_qc,sample_floor,warn,"76 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",1793,26,76
+project_kids_wj_qc,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",1793,26,76
+project_kids_wj_sa,dup_id_item,warn,51400 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),120449,45,1574
+project_kids_wj_sa,imputed_values*,warn,Item 'wj_saa_10s' has one resp value accounting for 84% of responses — possible mean imputation.,120449,45,1574
+project_kids_wj_sa,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",120449,45,1574
+project_kids_wj_spell_grade,dup_id_item,warn,10531 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),37753,47,847
+project_kids_wj_spell_grade,imputed_values*,warn,Item 'wj_spell_10s' has one resp value accounting for 99% of responses — possible mean imputation.,37753,47,847
+project_kids_wj_spell_grade,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",37753,47,847
+project_kids_wj_spell_wave,dup_id_item,warn,7086 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),27696,47,733
+project_kids_wj_spell_wave,imputed_values*,warn,Item 'wj_spell_10s' has one resp value accounting for 96% of responses — possible mean imputation.,27696,47,733
+project_kids_wj_spell_wave,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",27696,47,733
+project_kids_wj_wa_grade,dup_id_item,warn,9564 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),32468,32,842
+project_kids_wj_wa_grade,imputed_values*,warn,Item 'wj_wa_11s' has one resp value accounting for 64% of responses — possible mean imputation.,32468,32,842
+project_kids_wj_wa_grade,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",32468,32,842
+project_kids_wj_wa_wave,dup_id_item,warn,42957 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),106473,32,2760
+project_kids_wj_wa_wave,imputed_values*,warn,Item 'wj_wa_14s' has one resp value accounting for 63% of responses — possible mean imputation.,106473,32,2760
+project_kids_wj_wa_wave,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",106473,32,2760
+project_kids_wj_wf,dup_id_item,warn,7181 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),22512,30,1470
+project_kids_wj_wf,imputed_values*,warn,Item 'wj_wf_10s' has one resp value accounting for 77% of responses — possible mean imputation.,22512,30,1470
+project_kids_wj_wf,column_order,warn,"columns start ['id', 'item', 'wave']; datastandard.md step 7 writes [id, item, resp] + covariates.",22512,30,1470
+promis1wave1_anger,imputed_values*,warn,Item 'EDANG07' has one resp value accounting for 74% of responses — possible mean imputation.,149758,56,15043
+promis1wave1_anxiety,imputed_values*,warn,Item 'EDANX01' has one resp value accounting for 62% of responses — possible mean imputation.,144194,56,14909
+promis1wave1_cesd,imputed_values*,warn,Item 'CESD1' has one resp value accounting for 78% of responses — possible mean imputation.,15471,20,778
+promis1wave1_depression,imputed_values*,warn,Item 'EDDEP04' has one resp value accounting for 68% of responses — possible mean imputation.,143840,56,14909
+promis1wave1_fatigue,imputed_values*,warn,Item 'FATIMP21' has one resp value accounting for 63% of responses — possible mean imputation.,290044,112,15053
+promis1wave1_fatigue,multi_scale*,warn,"Item names suggest 2 subscales (['fatexp', 'fatimp']) — IRW requires separate tables per construct.",290044,112,15053
+promis1wave1_haq,imputed_values*,warn,Item 'HAQ10' has one resp value accounting for 97% of responses — possible mean imputation.,37677,24,1590
+promis1wave1_pain,imputed_values*,warn,Item 'PAINBE40' has one resp value accounting for 64% of responses — possible mean imputation.,434103,168,15961
+promis1wave1_pain,multi_scale*,warn,"Item names suggest 3 subscales (['painin', 'painqu', 'painbe']) — IRW requires separate tables per construct.",434103,168,15961
+promis1wave1_physicalfunction,imputed_values*,warn,Item 'PFC1' has one resp value accounting for 63% of responses — possible mean imputation.,140837,56,14954
+promis1wave1_social,imputed_values*,warn,Item 'SRPSAT14' has one resp value accounting for 65% of responses — possible mean imputation.,292014,112,15045
+promis1wave1_social,multi_scale*,warn,"Item names suggest 2 subscales (['srpper', 'srpsat']) — IRW requires separate tables per construct.",292014,112,15045
+promis_BrummerHoffman_2021,resp_na,warn,resp has 8 NAs,109594,80,1828
+promis_BrummerHoffman_2021,name_charset,warn,"table name 'promis_BrummerHoffman_2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",109594,80,1828
+promis_BrummerHoffman_2021,column_order,warn,"columns start ['id', 'group', 'date']; datastandard.md step 7 writes [id, item, resp] + covariates.",109594,80,1828
+protestant_workethic,resp_na,warn,resp has 114 NAs,60636,45,1350
+protestant_workethic,imputed_values*,warn,Item '30' has one resp value accounting for 97% of responses — possible mean imputation.,60636,45,1350
+protestant_workethic,rt_numeric*,warn,rt column is not numeric,60636,45,1350
+protestant_workethic,resp_scale_mixed,warn,"items span more than one response scale: 19 on 1.0-5.0 and 26 on ['1.0-7.0', '0.0-1.0']. IRW requires one table per construct; split before submitting.",60636,45,1350
+psiq_woelk2022,multi_scale*,warn,"Item names suggest 7 subscales (['visueel', 'geluid', 'geur', 'smaak']) — IRW requires separate tables per construct.",25725,35,735
+psiq_woelk2022,column_order,warn,"columns start ['id', 'study', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",25725,35,735
+psychoneurotic_inventory,resp_na,warn,resp has 6334 NAs,691870,116,6016
+psychoneurotic_inventory,imputed_values*,warn,Item '1.0' has one resp value accounting for 61% of responses — possible mean imputation.,691870,116,6016
+psychotools_conspiracist,resp_na,warn,resp has 106 NAs,36629,15,2449
+psychotools_gratitude,resp_na,warn,resp has 175 NAs,34950,25,1405
+psychotools_gratitude,multi_scale*,warn,"Item names suggest 5 subscales (['gq', 'losd', 'sa', 'ao']) — IRW requires separate tables per construct.",34950,25,1405
+psychotools_mathexam,imputed_values*,warn,Item 'annuity' has one resp value accounting for 65% of responses — possible mean imputation.,9477,13,729
+psychtools_Athenstaedt,imputed_values*,warn,Item 'V61' has one resp value accounting for 66% of responses — possible mean imputation.,42624,74,576
+psychtools_Athenstaedt,name_charset,warn,"table name 'psychtools_Athenstaedt' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",42624,74,576
+psychtools_Athenstaedt,column_order,warn,"columns start ['id', 'item', 'gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",42624,74,576
+psychtools_ability,resp_na,warn,resp has 1143 NAs,23257,16,1509
+psychtools_ability,imputed_values*,warn,Item 'letter.33' has one resp value accounting for 61% of responses — possible mean imputation.,23257,16,1509
+psychtools_ability,multi_scale*,warn,"Item names suggest 4 subscales (['reason.', 'letter.', 'matrix.', 'rotate.']) — IRW requires separate tables per construct.",23257,16,1509
+psychtools_bfi,resp_na,warn,resp has 508 NAs,69492,25,2800
+psychtools_bfi,multi_scale*,warn,"Item names suggest 5 subscales (['a', 'c', 'e', 'n']) — IRW requires separate tables per construct.",69492,25,2800
+psychtools_blot,imputed_values*,warn,Item 'V1' has one resp value accounting for 87% of responses — possible mean imputation.,5250,35,150
+psychtools_epi,resp_na,warn,resp has 4746 NAs,198744,57,3516
+psychtools_epi,imputed_values*,warn,Item 'V1' has one resp value accounting for 72% of responses — possible mean imputation.,198744,57,3516
+psychtools_geras,imputed_values*,warn,Item 'V48' has one resp value accounting for 63% of responses — possible mean imputation.,23550,50,471
+psychtools_geras,column_order,warn,"columns start ['id', 'item', 'gender']; datastandard.md step 7 writes [id, item, resp] + covariates.",23550,50,471
+psychtools_msq,resp_na,warn,resp has 16283 NAs,275842,75,3892
+psychtools_msq,imputed_values*,warn,Item 'afraid' has one resp value accounting for 91% of responses — possible mean imputation.,275842,75,3892
+psychtools_sai,resp_na,warn,resp has 1449 NAs,106111,20,3023
+psychtools_sai,dup_id_item,error,47020 duplicate id+item rows with no wave/timepoint/date column,106111,20,3023
+psychtools_sai,imputed_values*,warn,Item 'high.strung' has one resp value accounting for 68% of responses — possible mean imputation.,106111,20,3023
+psychtools_sai,column_order,warn,"columns start ['id', 'item', 'occasion']; datastandard.md step 7 writes [id, item, resp] + covariates.",106111,20,3023
+ptam1_immer,resp_na,warn,resp has 6 NAs,18784,2,6877
+ptam1_immer,dup_id_item,error,5036 duplicate id+item rows with no wave/timepoint/date column,18784,2,6877
+ptam1_immer,column_order,warn,"columns start ['id', 'item', 'rater']; datastandard.md step 7 writes [id, item, resp] + covariates.",18784,2,6877
+qol_islam_2025,resp_na,warn,resp has 238 NAs,29584,26,1147
+qol_islam_2025,imputed_values*,warn,Item 'QoL_11' has one resp value accounting for 62% of responses — possible mean imputation.,29584,26,1147
+qol_islam_2025,column_order,warn,"columns start ['id', 'cov_age', 'cov_sex']; datastandard.md step 7 writes [id, item, resp] + covariates.",29584,26,1147
+quantshort,imputed_values*,warn,Item '2' has one resp value accounting for 63% of responses — possible mean imputation.,24000,24,1000
+ravens_deboeck2012,dup_id_item,error,5811 duplicate id+item rows with no wave/timepoint/date column,11622,35,503
+ravens_deboeck2012,imputed_values*,warn,Item 'i05' has one resp value accounting for 70% of responses — possible mean imputation.,11622,35,503
+ravens_deboeck2012,column_order,warn,"columns start ['resp', 'item', 'id']; datastandard.md step 7 writes [id, item, resp] + covariates.",11622,35,503
+realpic_souza2021,dup_id_item,error,28 duplicate id+item rows with no wave/timepoint/date column,4172,7,592
+realpic_souza2021,resp_ordinal*,warn,"968 distinct resp values — confirm continuous, not mis-parsed",4172,7,592
+realpic_souza2021,resp_scale_mixed,warn,"items span more than one response scale: 2 on 2.0-7.0 and 3 on ['1.58620689655172-6.7', '1.5625-6.7', '1.68965517241379-6.32258064516129']. IRW requires one table per construct; split before submitting.",4172,7,592
+riasec,resp_na,warn,resp has 30619 NAs,10760653,74,145828
+riasec,imputed_values*,warn,Item '3' has one resp value accounting for 61% of responses — possible mean imputation.,10760653,74,145828
+riasec,resp_scale_mixed,warn,"items span more than one response scale: 48 on 1.0-5.0 and 26 on ['1.0-7.0', '0.0-1.0']. IRW requires one table per construct; split before submitting.",10760653,74,145828
+rightwing_authoritariansim,resp_na,warn,resp has 832 NAs,473456,48,9881
+rightwing_authoritariansim,imputed_values*,warn,Item '2' has one resp value accounting for 66% of responses — possible mean imputation.,473456,48,9881
+rightwing_authoritariansim,resp_scale_mixed,warn,items span more than one response scale: 22 on 1.0-9.0 and 16 on ['0.0-1.0']. IRW requires one table per construct; split before submitting.,473456,48,9881
+roar_lexical,imputed_values*,warn,Item 'able' has one resp value accounting for 81% of responses — possible mean imputation.,61500,500,123
+rosenberg_selfesteem,resp_na,warn,resp has 2059 NAs,477681,10,47929
+rr98_accuracy,dup_id_item,error,11229 duplicate id+item rows with no wave/timepoint/date column,12205,33,30
+rr98_accuracy,imputed_values*,warn,Item 'i 0' has one resp value accounting for 95% of responses — possible mean imputation.,12205,33,30
+rr98_accuracy,sample_floor,warn,"30 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",12205,33,30
+rr98_accuracy,column_order,warn,"columns start ['id', 'resp', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",12205,33,30
+rrca_mcneish_2025_bdi,imputed_values*,warn,Item 'BDI1' has one resp value accounting for 76% of responses — possible mean imputation.,21840,21,1040
+rrca_mcneish_2025_exp,resp_na,warn,resp has 273 NAs,2815,8,386
+rrca_mcneish_2025_exp,imputed_values*,warn,Item 'Example3' has one resp value accounting for 68% of responses — possible mean imputation.,2815,8,386
+rrca_mcneish_2025_sen,resp_na,warn,resp has 350 NAs,2738,8,385
+rrca_mcneish_2025_sen,imputed_values*,warn,Item 'Sent7' has one resp value accounting for 66% of responses — possible mean imputation.,2738,8,385
+rrca_mcneish_2025_use,resp_na,warn,resp has 203 NAs,2885,8,386
+rrca_mcneish_2025_use,imputed_values*,warn,Item 'Uses2' has one resp value accounting for 74% of responses — possible mean imputation.,2885,8,386
+rvobgvmaas_lsf_lehing_2024,dup_id_item,warn,2024 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),6992,27,184
+rvobgvmaas_lsf_lehing_2024,imputed_values*,warn,Item 'maas_11_t2' has one resp value accounting for 61% of responses — possible mean imputation.,6992,27,184
+rvobgvmaas_lsf_lehing_2024,column_order,warn,"columns start ['id', 'cov_age', 'cov_child_number']; datastandard.md step 7 writes [id, item, resp] + covariates.",6992,27,184
+sabers_vesper2023,imputed_values*,warn,Item 'sozn1' has one resp value accounting for 65% of responses — possible mean imputation.,20415,15,1361
+sabers_vesper2023,multi_scale*,warn,"Item names suggest 5 subscales (['negaf', 'leg', 'info', 'sozn']) — IRW requires separate tables per construct.",20415,15,1361
+sabers_vesper2023,column_order,warn,"columns start ['id', 'language', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",20415,15,1361
+sapa_personality,size_skipped,info,11 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+sat12_wilson_2003,resp_na,warn,resp has 69 NAs,19131,32,600
+sat12_wilson_2003,imputed_values*,warn,Item 'Item.11' has one resp value accounting for 98% of responses — possible mean imputation.,19131,32,600
+science_ltm,imputed_values*,warn,Item 'Comfort' has one resp value accounting for 68% of responses — possible mean imputation.,2744,7,392
+scoliosis_dueber,imputed_values*,warn,Item 'SQLI_10' has one resp value accounting for 91% of responses — possible mean imputation.,46440,20,2322
+sds,imputed_values*,warn,Item '4' has one resp value accounting for 72% of responses — possible mean imputation.,6149,13,473
+selfcompassionscale_shortform_fuochi_2025,resp_na,warn,resp has 186 NAs,24630,12,1816
+selfcompassionscale_shortform_fuochi_2025,dup_id_item,error,3024 duplicate id+item rows with no wave/timepoint/date column,24630,12,1816
+selfcompassionscale_shortform_fuochi_2025,name_length,error,"table name is 41 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",24630,12,1816
+sem_cnes,,ok,,6116,4,1529
+sexual_compulsivity,resp_na,warn,resp has 195 NAs,33565,10,3373
+sexual_selfconcept,resp_na,warn,resp has 37688 NAs,1730812,100,17657
+sexual_selfconcept,imputed_values*,warn,Item '44.0' has one resp value accounting for 69% of responses — possible mean imputation.,1730812,100,17657
+short_dark_triad,resp_na,warn,resp has 748 NAs,490436,27,18186
+si09_sirt,multi_scale*,warn,"Item names suggest 2 subscales (['help', 'voice']) — IRW requires separate tables per construct.",62412,12,5201
+singh_2025_identity_cse,,ok,,23520,16,1470
+singh_2025_identity_gi,,ok,,5880,4,1470
+singh_2025_identity_grit,,ok,,11760,8,1470
+singh_2025_identity_irs,resp_na,warn,resp has 1704 NAs,12996,10,1470
+singh_2025_identity_pba,imputed_values*,warn,Item 'pba10' has one resp value accounting for 62% of responses — possible mean imputation.,16170,11,1470
+singh_2025_identity_pds,,ok,,13230,9,1470
+singh_2025_identity_pia,,ok,,5880,4,1470
+singh_2025_identity_pit,,ok,,5880,4,1470
+singh_2025_identity_pss,,ok,,14700,10,1470
+smacof_pvq40,id_na,warn,id has 6 NAs,6023,40,151
+smacof_pvq40,item_na,warn,item has 6 NAs,6023,40,151
+smacof_pvq40,resp_na,warn,resp has 6 NAs,6023,40,151
+smacof_pvq40,dup_id_item,error,5 duplicate id+item rows with no wave/timepoint/date column,6023,40,151
+smacof_pvq40,multi_scale*,warn,"Item names suggest 10 subscales (['un', 'se', 'sd', 'ac']) — IRW requires separate tables per construct.",6023,40,151
+sned_bendall_2024,column_order,warn,"columns start ['id', 'rt', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",4806,6,801
+socialstereotype_hughes_2025_judgement,resp_na,warn,resp has 77 NAs,14527,12,312
+socialstereotype_hughes_2025_judgement,dup_id_item,error,10860 duplicate id+item rows with no wave/timepoint/date column,14527,12,312
+socialstereotype_hughes_2025_judgement,imputed_values*,warn,Item 'ce1' has one resp value accounting for 81% of responses — possible mean imputation.,14527,12,312
+socialstereotype_hughes_2025_judgement,multi_scale*,warn,"Item names suggest 2 subscales (['affil', 'ce']) — IRW requires separate tables per construct.",14527,12,312
+socialstereotype_hughes_2025_judgement,item_scale_outlier,warn,1 item(s) fall outside the table's 1-5 scale: ['nps']. An isolated out-of-range column is usually not an item -- check for an administrative or count field.,14527,12,312
+socialstereotype_hughes_2025_judgement,column_order,warn,"columns start ['id', 'rater', 'cov_group']; datastandard.md step 7 writes [id, item, resp] + covariates.",14527,12,312
+socialstereotype_hughes_2025_personality_other,resp_na,warn,resp has 19 NAs,34057,28,312
+socialstereotype_hughes_2025_personality_other,dup_id_item,error,25340 duplicate id+item rows with no wave/timepoint/date column,34057,28,312
+socialstereotype_hughes_2025_personality_other,imputed_values*,warn,Item 'qb6hp3' has one resp value accounting for 62% of responses — possible mean imputation.,34057,28,312
+socialstereotype_hughes_2025_personality_other,multi_scale*,warn,"Item names suggest 3 subscales (['bfixs', 'qb', 'wc']) — IRW requires separate tables per construct.",34057,28,312
+socialstereotype_hughes_2025_personality_other,name_length,error,"table name is 46 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",34057,28,312
+socialstereotype_hughes_2025_personality_other,column_order,warn,"columns start ['id', 'rater', 'cov_group']; datastandard.md step 7 writes [id, item, resp] + covariates.",34057,28,312
+socialstereotype_hughes_2025_personality_self,resp_na,warn,resp has 1 NAs,8315,28,297
+socialstereotype_hughes_2025_personality_self,imputed_values*,warn,Item 'qb6hp3' has one resp value accounting for 77% of responses — possible mean imputation.,8315,28,297
+socialstereotype_hughes_2025_personality_self,multi_scale*,warn,"Item names suggest 3 subscales (['bfixs', 'qb', 'wc']) — IRW requires separate tables per construct.",8315,28,297
+socialstereotype_hughes_2025_personality_self,name_length,error,"table name is 45 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",8315,28,297
+socialstereotype_hughes_2025_personality_self,column_order,warn,"columns start ['id', 'cov_group', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",8315,28,297
+spanishmegastudy,size_skipped,info,13 MB exceeds --max-mb=8; not opened. Re-run with a higher cap when the machine is idle.,,,
+spelling2pronounce_edwards2023,resp_na,warn,resp has 12582 NAs,617233,1,23282
+spelling2pronounce_edwards2023,dup_id_item,error,606533 duplicate id+item rows with no wave/timepoint/date column,617233,1,23282
+spelling_assessment_study1,resp_na,warn,resp has 54 NAs,73303,109,673
+spelling_assessment_study1,imputed_values*,warn,Item 'abstinence' has one resp value accounting for 66% of responses — possible mean imputation.,73303,109,673
+spelling_assessment_study2,resp_na,warn,resp has 145 NAs,56447,72,786
+spelling_assessment_study2,imputed_values*,warn,Item 'abstinence' has one resp value accounting for 75% of responses — possible mean imputation.,56447,72,786
+spelling_assessment_study2,column_order,warn,"columns start ['id', 'group', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",56447,72,786
+spidersBAT_grill2024,imputed_values*,warn,Item 'FA02_07' has one resp value accounting for 73% of responses — possible mean imputation.,1922,31,62
+spidersBAT_grill2024,multi_scale*,warn,"Item names suggest 2 subscales (['fa', 'sp']) — IRW requires separate tables per construct.",1922,31,62
+spidersBAT_grill2024,name_charset,warn,"table name 'spidersBAT_grill2024' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",1922,31,62
+spidersBAT_grill2024,sample_floor,warn,"62 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",1922,31,62
+sris_silvia2022,dup_id_item,error,19420 duplicate id+item rows with no wave/timepoint/date column,23840,20,221
+sris_silvia2022,multi_scale*,warn,"Item names suggest 2 subscales (['sr', 'ins']) — IRW requires separate tables per construct.",23840,20,221
+sris_silvia2022,column_order,warn,"columns start ['id', 'study', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",23840,20,221
+ssd12_habib_2025,column_order,warn,"columns start ['id', 'group', 'cov_age']; datastandard.md step 7 writes [id, item, resp] + covariates.",2400,12,200
+stress_deboeck2012,resp_na,warn,resp has 116 NAs,6781,11,185
+stress_deboeck2012,dup_id_item,error,4862 duplicate id+item rows with no wave/timepoint/date column,6781,11,185
+stress_deboeck2012,imputed_values*,warn,Item 'Response10' has one resp value accounting for 64% of responses — possible mean imputation.,6781,11,185
+stress_deboeck2012,column_order,warn,"columns start ['resp', 'id', 'occasion']; datastandard.md step 7 writes [id, item, resp] + covariates.",6781,11,185
+swmd_mokken,dup_id_item,error,4347 duplicate id+item rows with no wave/timepoint/date column,4557,7,30
+swmd_mokken,sample_floor,warn,"30 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",4557,7,30
+swmd_mokken,column_order,warn,"columns start ['id', 'rater', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",4557,7,30
+tdri,resp_na,warn,resp has 33327 NAs,67641,56,1803
+tdri,imputed_values*,warn,Item 'i1' has one resp value accounting for 98% of responses — possible mean imputation.,67641,56,1803
+tears,dup_id_item,error,23227 duplicate id+item rows with no wave/timepoint/date column,24019,11,72
+tears,resp_ordinal*,warn,"101 distinct resp values — confirm continuous, not mis-parsed",24019,11,72
+tears,imputed_values*,warn,Item 'Anger' has one resp value accounting for 80% of responses — possible mean imputation.,24019,11,72
+tears,sample_floor,warn,"72 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",24019,11,72
+tears,column_order,warn,"columns start ['id', 'rater', 'stimulus']; datastandard.md step 7 writes [id, item, resp] + covariates.",24019,11,72
+tenseness_pcmrs,imputed_values*,warn,Item 'Clammy hands' has one resp value accounting for 67% of responses — possible mean imputation.,16336,8,2042
+teq_novak_2021_bfin,column_order,warn,"columns start ['id', 'cov_Gender', 'cov_Age']; datastandard.md step 7 writes [id, item, resp] + covariates.",1320,8,165
+teq_novak_2021_scbs,column_order,warn,"columns start ['id', 'cov_Gender', 'cov_Age']; datastandard.md step 7 writes [id, item, resp] + covariates.",3220,5,644
+teq_novak_2021_selfesteem,imputed_values*,warn,Item 'Self_esteem_1' has one resp value accounting for 61% of responses — possible mean imputation.,1960,10,196
+teq_novak_2021_selfesteem,column_order,warn,"columns start ['id', 'cov_Gender', 'cov_Age']; datastandard.md step 7 writes [id, item, resp] + covariates.",1960,10,196
+teq_novak_2021_socdes,imputed_values*,warn,Item 'SocDes_1' has one resp value accounting for 62% of responses — possible mean imputation.,990,5,198
+teq_novak_2021_socdes,column_order,warn,"columns start ['id', 'cov_Gender', 'cov_Age']; datastandard.md step 7 writes [id, item, resp] + covariates.",990,5,198
+teq_novak_2021_spirit,column_order,warn,"columns start ['id', 'cov_Gender', 'cov_Age']; datastandard.md step 7 writes [id, item, resp] + covariates.",11729,15,782
+teq_novak_2021_teq,imputed_values*,warn,Item 'TEQ_8' has one resp value accounting for 60% of responses — possible mean imputation.,17884,16,1141
+teq_novak_2021_teq,column_order,warn,"columns start ['id', 'cov_Gender', 'cov_Age']; datastandard.md step 7 writes [id, item, resp] + covariates.",17884,16,1141
+test_taking_patterns_over_time,resp_na,warn,resp has 106516 NAs,405252,284,1802
+test_taking_patterns_over_time,imputed_values*,warn,Item 'A1.1' has one resp value accounting for 95% of responses — possible mean imputation.,405252,284,1802
+test_taking_patterns_over_time,multi_scale*,warn,"Item names suggest 2 subscales (['b', 'a']) — IRW requires separate tables per construct.",405252,284,1802
+test_taking_patterns_over_time,item_scale_outlier,warn,"24 item(s) fall outside the table's 0-1 scale: ['A3.1', 'A3.10', 'A3.11', 'A3.12']. An isolated out-of-range column is usually not an item -- check for an administrative or count field.",405252,284,1802
+test_taking_patterns_over_time,column_order,warn,"columns start ['form', 'item', 'id']; datastandard.md step 7 writes [id, item, resp] + covariates.",405252,284,1802
+threatperceptions_isler_2024_experiment1_cognitive_crt,imputed_values*,warn,Item 'crt1' has one resp value accounting for 65% of responses — possible mean imputation.,253,1,253
+threatperceptions_isler_2024_experiment1_cognitive_crt,name_length,error,"table name is 54 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",253,1,253
+threatperceptions_isler_2024_experiment1_cognitive_crt,column_order,warn,"columns start ['id', 'treat', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",253,1,253
+threatperceptions_isler_2024_experiment1_cognitive_panas,imputed_values*,warn,Item 'ashamed' has one resp value accounting for 85% of responses — possible mean imputation.,5566,22,253
+threatperceptions_isler_2024_experiment1_cognitive_panas,name_length,error,"table name is 56 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",5566,22,253
+threatperceptions_isler_2024_experiment1_cognitive_panas,column_order,warn,"columns start ['id', 'treat', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",5566,22,253
+threatperceptions_isler_2024_experiment1_incentive_crt,imputed_values*,warn,Item 'crt1' has one resp value accounting for 65% of responses — possible mean imputation.,253,1,253
+threatperceptions_isler_2024_experiment1_incentive_crt,treat_binary*,warn,treat has non-0/1 values [np.int32(2)],253,1,253
+threatperceptions_isler_2024_experiment1_incentive_crt,name_length,error,"table name is 54 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",253,1,253
+threatperceptions_isler_2024_experiment1_incentive_crt,column_order,warn,"columns start ['id', 'treat', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",253,1,253
+threatperceptions_isler_2024_experiment1_incentive_panas,imputed_values*,warn,Item 'ashamed' has one resp value accounting for 85% of responses — possible mean imputation.,5566,22,253
+threatperceptions_isler_2024_experiment1_incentive_panas,treat_binary*,warn,treat has non-0/1 values [np.int32(2)],5566,22,253
+threatperceptions_isler_2024_experiment1_incentive_panas,name_length,error,"table name is 56 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",5566,22,253
+threatperceptions_isler_2024_experiment1_incentive_panas,column_order,warn,"columns start ['id', 'treat', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",5566,22,253
+threatperceptions_isler_2024_experiment2_cognitive_crt,name_length,error,"table name is 54 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",433,1,433
+threatperceptions_isler_2024_experiment2_cognitive_crt,column_order,warn,"columns start ['id', 'treat', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",433,1,433
+threatperceptions_isler_2024_experiment2_cognitive_panas,imputed_values*,warn,Item 'ashamed' has one resp value accounting for 80% of responses — possible mean imputation.,9526,22,433
+threatperceptions_isler_2024_experiment2_cognitive_panas,name_length,error,"table name is 56 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",9526,22,433
+threatperceptions_isler_2024_experiment2_cognitive_panas,column_order,warn,"columns start ['id', 'treat', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",9526,22,433
+threatperceptions_isler_2024_experiment2_picture_crt,name_length,error,"table name is 52 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",433,1,433
+threatperceptions_isler_2024_experiment2_picture_crt,column_order,warn,"columns start ['id', 'treat', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",433,1,433
+threatperceptions_isler_2024_experiment2_picture_panas,imputed_values*,warn,Item 'ashamed' has one resp value accounting for 80% of responses — possible mean imputation.,9526,22,433
+threatperceptions_isler_2024_experiment2_picture_panas,name_length,error,"table name is 54 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",9526,22,433
+threatperceptions_isler_2024_experiment2_picture_panas,column_order,warn,"columns start ['id', 'treat', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",9526,22,433
+threatperceptions_isler_2024_experiment3_cognitive_panas,imputed_values*,warn,Item 'ashamed' has one resp value accounting for 76% of responses — possible mean imputation.,39094,22,1777
+threatperceptions_isler_2024_experiment3_cognitive_panas,treat_binary*,warn,treat has non-0/1 values [np.int32(2)],39094,22,1777
+threatperceptions_isler_2024_experiment3_cognitive_panas,name_length,error,"table name is 56 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",39094,22,1777
+threatperceptions_isler_2024_experiment3_cognitive_panas,column_order,warn,"columns start ['id', 'treat', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",39094,22,1777
+threatperceptions_isler_2024_experiment4_cognitive_crt,imputed_values*,warn,Item 'crt1' has one resp value accounting for 61% of responses — possible mean imputation.,8067,3,2689
+threatperceptions_isler_2024_experiment4_cognitive_crt,treat_binary*,warn,"treat has non-0/1 values [np.int32(2), np.int32(3), np.int32(4), np.int32(5)]",8067,3,2689
+threatperceptions_isler_2024_experiment4_cognitive_crt,name_length,error,"table name is 54 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",8067,3,2689
+threatperceptions_isler_2024_experiment4_cognitive_crt,column_order,warn,"columns start ['id', 'treat', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",8067,3,2689
+threatperceptions_isler_2024_experiment4_cognitive_panas,imputed_values*,warn,Item 'ashamed' has one resp value accounting for 76% of responses — possible mean imputation.,59158,22,2689
+threatperceptions_isler_2024_experiment4_cognitive_panas,treat_binary*,warn,"treat has non-0/1 values [np.int32(2), np.int32(3), np.int32(4), np.int32(5)]",59158,22,2689
+threatperceptions_isler_2024_experiment4_cognitive_panas,name_length,error,"table name is 56 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",59158,22,2689
+threatperceptions_isler_2024_experiment4_cognitive_panas,column_order,warn,"columns start ['id', 'treat', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",59158,22,2689
+timss_tam,resp_na,warn,resp has 44 NAs,19459,11,1769
+timss_tam,imputed_values*,warn,Item 'M032166' has one resp value accounting for 70% of responses — possible mean imputation.,19459,11,1769
+timss_tam,resp_scale_mixed,warn,items span more than one response scale: 6 on 10-99 and 5 on ['1-9']. IRW requires one table per construct; split before submitting.,19459,11,1769
+timss_tam,column_order,warn,"columns start ['id', 'item', 'country']; datastandard.md step 7 writes [id, item, resp] + covariates.",19459,11,1769
+tma,resp_na,warn,resp has 2612 NAs,267888,50,5401
+tma,imputed_values*,warn,Item 'Q1' has one resp value accounting for 65% of responses — possible mean imputation.,267888,50,5401
+tpi_vangsness_2019,,ok,,3713,16,233
+transreas_mokken,imputed_values*,warn,Item 'T01L' has one resp value accounting for 94% of responses — possible mean imputation.,5100,12,425
+trees_sirt,imputed_values*,warn,Item 'FM10' has one resp value accounting for 78% of responses — possible mean imputation.,5805,15,387
+twod_rotation_mather2023,imputed_values*,warn,Item 'q_16001' has one resp value accounting for 65% of responses — possible mean imputation.,1905487,304,1020195
+twod_rotation_mather2023,density*,warn,"very sparse (density=0.0061); fine for adaptive/booklet designs, else verify",1905487,304,1020195
+ucla_BrummerHoffman_2021,name_charset,warn,"table name 'ucla_BrummerHoffman_2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",5484,3,1828
+ucla_BrummerHoffman_2021,column_order,warn,"columns start ['id', 'group', 'date']; datastandard.md step 7 writes [id, item, resp] + covariates.",5484,3,1828
+ups_vangsness_2019,,ok,,1630,7,233
+verbagg,imputed_values*,warn,Item 'S1DoCurse' has one resp value accounting for 71% of responses — possible mean imputation.,7584,24,316
+vocab_assessment_3_to_8_year_old_children,imputed_values*,warn,Item '1' has one resp value accounting for 100% of responses — possible mean imputation.,30212,52,581
+vocab_assessment_3_to_8_year_old_children,name_length,error,"table name is 41 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",30212,52,581
+vocabulary_iq,resp_na,warn,resp has 76191 NAs,836784,75,12173
+vocabulary_iq,imputed_values*,warn,Item '1' has one resp value accounting for 98% of responses — possible mean imputation.,836784,75,12173
+wang_onlineriskexp_2025,imputed_values*,warn,Item 'FXJC4' has one resp value accounting for 70% of responses — possible mean imputation.,15776,16,986
+wang_onlineriskexp_2025,multi_scale*,warn,"Item names suggest 4 subscales (['fxjc', 'fxqf', 'fxxy', 'fxxl']) — IRW requires separate tables per construct.",15776,16,986
+wang_onlineriskexp_2025,column_order,warn,"columns start ['id', 'cov_gender', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",15776,16,986
+wang_onlineriskexp_2025_anxiety,imputed_values*,warn,Item 'An2' has one resp value accounting for 63% of responses — possible mean imputation.,6902,7,986
+wang_onlineriskexp_2025_anxiety,column_order,warn,"columns start ['id', 'cov_gender', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",6902,7,986
+wang_onlineriskexp_2025_interpersonalsecurity,imputed_values*,warn,Item 'RJLG1' has one resp value accounting for 69% of responses — possible mean imputation.,17748,18,986
+wang_onlineriskexp_2025_interpersonalsecurity,multi_scale*,warn,"Item names suggest 4 subscales (['rjxf', 'rjrj', 'rjzz', 'rjlg']) — IRW requires separate tables per construct.",17748,18,986
+wang_onlineriskexp_2025_interpersonalsecurity,name_length,error,"table name is 45 characters; datastandard.md caps it at 40. Shorten the construct label, never the author or year.",17748,18,986
+wang_onlineriskexp_2025_interpersonalsecurity,column_order,warn,"columns start ['id', 'cov_gender', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",17748,18,986
+wang_onlineriskexp_2025_negativeatt,column_order,warn,"columns start ['id', 'cov_gender', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",4930,5,986
+wemwbs_BrummerHoffman_2021,name_charset,warn,"table name 'wemwbs_BrummerHoffman_2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",12796,7,1828
+wemwbs_BrummerHoffman_2021,column_order,warn,"columns start ['id', 'group', 'date']; datastandard.md step 7 writes [id, item, resp] + covariates.",12796,7,1828
+western_reserve_project,resp_na,warn,resp has 378887 NAs,1066535,2731,2877
+western_reserve_project,dup_id_item,warn,398 duplicate id+item rows (longitudinal column ['wave'] present — likely ok),1066535,2731,2877
+western_reserve_project,imputed_values*,warn,Item '1' has one resp value accounting for 99% of responses — possible mean imputation.,1066535,2731,2877
+western_reserve_project,resp_scale_mixed,warn,"items span more than one response scale: 2080 on 0.0-1.0 and 506 on ['0.0-2.0', '0.0-3.0', '0.0-4.0']. IRW requires one table per construct; split before submitting.",1066535,2731,2877
+western_reserve_project,column_order,warn,"columns start ['person_id', 'id', 'family_id']; datastandard.md step 7 writes [id, item, resp] + covariates.",1066535,2731,2877
+whodas_BrummerHoffman_2021,imputed_values*,warn,Item 'whodas_dressing' has one resp value accounting for 84% of responses — possible mean imputation.,21936,12,1828
+whodas_BrummerHoffman_2021,name_charset,warn,"table name 'whodas_BrummerHoffman_2021' is not lowercase [a-z0-9_.] -- Redivis keeps the case but every client lowercases when joining, so a capitalised name silently drops out of case-sensitive joins.",21936,12,1828
+whodas_BrummerHoffman_2021,column_order,warn,"columns start ['id', 'group', 'date']; datastandard.md step 7 writes [id, item, resp] + covariates.",21936,12,1828
+wine_luckett2021,dup_id_item,error,1947 duplicate id+item rows with no wave/timepoint/date column,1998,3,17
+wine_luckett2021,resp_ordinal*,warn,"100 distinct resp values — confirm continuous, not mis-parsed",1998,3,17
+wine_luckett2021,resp_scale_mixed,warn,items span more than one response scale: 2 on 1-9 and 1 on ['0-100']. IRW requires one table per construct; split before submitting.,1998,3,17
+wine_luckett2021,sample_floor,warn,"17 unique ids; datastandard.md sets a flat floor of 100 with no judgment call in between. Warn rather than block: the floor governs what to accept, not what is already published.",1998,3,17
+wine_luckett2021,column_order,warn,"columns start ['rater', 'id', 'item']; datastandard.md step 7 writes [id, item, resp] + covariates.",1998,3,17
+wirs,imputed_values*,warn,Item 'item_1' has one resp value accounting for 63% of responses — possible mean imputation.,6030,6,1005
+wooly_hartman2022,resp_na,warn,resp has 1857 NAs,27802,19,1561
+wooly_hartman2022,imputed_values*,warn,Item 'Q33correct' has one resp value accounting for 74% of responses — possible mean imputation.,27802,19,1561
+wooly_hartman2022,column_order,warn,"columns start ['id', 'age', 'group']; datastandard.md step 7 writes [id, item, resp] + covariates.",27802,19,1561

--- a/irw_validate/sweep_legacy.py
+++ b/irw_validate/sweep_legacy.py
@@ -1,0 +1,134 @@
+"""Run the validator over the 922 legacy .Rdata tables (#1703, sub-item 1.5).
+
+    python3 -m irw_validate.sweep_legacy ../data/pub -o legacy_sweep.csv
+
+These tables predate every checker in the project. `data/pub/` is not merely
+outside this repository -- it is not under version control at all, a local
+working directory -- so this is a one-off sweep someone runs, never CI.
+
+Uses the `legacy` profile: `upload` minus rules that postdate the tables. The
+`cov_` prefix convention is one of those; failing a 2019 table for not
+anticipating it would produce noise rather than findings.
+
+**Deliberately gentle.** This machine runs other people's work -- vignette
+renders, package checks, other agents. A sweep of 3 GB is easy to write in a way
+that makes the laptop unusable for twenty minutes, so:
+
+* one file at a time, frame released before the next is opened;
+* single-threaded -- numpy and its BLAS will otherwise spawn a thread per core
+  for operations that gain nothing from it here;
+* `--max-mb` skips files above a size and records the skip rather than passing
+  them silently (default 64 MB, which covers all but ~20 of the 922);
+* `--resume` re-reads the output CSV and skips tables already done, so it can be
+  stopped with Ctrl-C and picked up later;
+* and it is worth running under `nice -n 19`, which the module suggests on
+  startup if it is not already niced.
+
+Slower, finishes, and leaves the machine usable while it does.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import gc
+import os
+import pathlib
+import sys
+import time
+
+# Before numpy is imported anywhere: one thread. A per-core BLAS pool buys
+# nothing for row counts and value_counts, and is most of what makes a sweep
+# like this feel like a hang to whoever else is on the machine.
+for _v in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS",
+           "NUMEXPR_NUM_THREADS", "VECLIB_MAXIMUM_THREADS"):
+    os.environ.setdefault(_v, "1")
+
+
+def main(argv: list | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="irw_validate.sweep_legacy")
+    ap.add_argument("directory", help="directory of .Rdata tables")
+    ap.add_argument("-o", "--out", default="legacy_sweep.csv",
+                    help="where to write the per-finding CSV")
+    ap.add_argument("--profile", default="legacy")
+    ap.add_argument("--limit", type=int, default=0, help="stop after N files (for a trial run)")
+    ap.add_argument("--max-mb", type=float, default=64.0,
+                    help="skip files larger than this, recording the skip (default 64)")
+    ap.add_argument("--resume", action="store_true",
+                    help="skip tables already present in the output CSV")
+    args = ap.parse_args(argv)
+
+    try:
+        if os.nice(0) < 10:
+            print("tip: run this under `nice -n 19` -- it shares the machine with "
+                  "vignette renders and other agents", file=sys.stderr)
+    except (AttributeError, OSError):
+        pass
+
+    from .core import validate_file
+
+    files = sorted(pathlib.Path(args.directory).glob("*.Rdata"))
+    if args.limit:
+        files = files[: args.limit]
+    if not files:
+        print(f"no .Rdata files under {args.directory}", file=sys.stderr)
+        return 2
+
+    done: set = set()
+    rows: list = []
+    if args.resume and pathlib.Path(args.out).exists():
+        with open(args.out) as fh:
+            rows = list(csv.DictReader(fh))
+        done = {r["table"] for r in rows}
+        print(f"resuming: {len(done)} tables already recorded")
+
+    unreadable = clean = skipped = 0
+    started = time.time()
+    for i, path in enumerate(files, 1):
+        if path.stem in done:
+            continue
+        size_mb = path.stat().st_size / 1024 ** 2
+        if size_mb > args.max_mb:
+            skipped += 1
+            rows.append({"table": path.stem, "check": "size_skipped", "severity": "info",
+                         "message": f"{size_mb:.0f} MB exceeds --max-mb={args.max_mb:.0f}; "
+                                    f"not opened. Re-run with a higher cap when the "
+                                    f"machine is idle.",
+                         "n_rows": "", "n_items": "", "n_participants": ""})
+            continue
+        try:
+            report = validate_file(path, profile=args.profile)
+        except Exception as exc:                      # a bad file must not stop the sweep
+            unreadable += 1
+            rows.append({"table": path.stem, "check": "unreadable", "severity": "error",
+                         "message": f"{type(exc).__name__}: {exc}"[:300],
+                         "n_rows": "", "n_items": "", "n_participants": ""})
+            print(f"[{i}/{len(files)}] {path.stem}: UNREADABLE {type(exc).__name__}", flush=True)
+            continue
+        st = report.stats or {}
+        if not report.findings:
+            clean += 1
+        for f in report.findings:
+            rows.append({"table": path.stem, "check": f.check, "severity": f.severity,
+                         "message": f.message[:300],
+                         "n_rows": st.get("n_responses", ""),
+                         "n_items": st.get("n_items", ""),
+                         "n_participants": st.get("n_participants", "")})
+        if i % 25 == 0 or i == len(files):
+            print(f"[{i}/{len(files)}] {clean} clean, {len(rows)} findings, "
+                  f"{unreadable} unreadable, {time.time()-started:.0f}s", flush=True)
+        gc.collect()
+
+    with open(args.out, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=["table", "check", "severity", "message",
+                                           "n_rows", "n_items", "n_participants"])
+        w.writeheader()
+        w.writerows(rows)
+    print(f"\n{len(files)} tables: {clean} with nothing to report, "
+          f"{len(files) - clean - skipped} with at least one finding, "
+          f"{unreadable} unreadable, {skipped} skipped for size")
+    print(f"wrote {len(rows)} findings to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/irw_validate/sweep_legacy.py
+++ b/irw_validate/sweep_legacy.py
@@ -19,8 +19,11 @@ that makes the laptop unusable for twenty minutes, so:
   for operations that gain nothing from it here;
 * `--max-mb` skips files above a size and records the skip rather than passing
   them silently (default 64 MB, which covers all but ~20 of the 922);
-* `--resume` re-reads the output CSV and skips tables already done, so it can be
-  stopped with Ctrl-C and picked up later;
+* results are appended **as each table finishes**, not held until the end -- the
+  first version buffered everything and wrote once, so a run that timed out at
+  420 seconds produced no file at all and `--resume` had nothing to resume from;
+* `--resume` re-reads that CSV and skips tables already done, so it can be
+  stopped and picked up later;
 * and it is worth running under `nice -n 19`, which the module suggests on
   startup if it is not already niced.
 
@@ -73,13 +76,26 @@ def main(argv: list | None = None) -> int:
         print(f"no .Rdata files under {args.directory}", file=sys.stderr)
         return 2
 
+    FIELDS = ["table", "check", "severity", "message",
+              "n_rows", "n_items", "n_participants"]
+    out_path = pathlib.Path(args.out)
     done: set = set()
-    rows: list = []
-    if args.resume and pathlib.Path(args.out).exists():
-        with open(args.out) as fh:
-            rows = list(csv.DictReader(fh))
-        done = {r["table"] for r in rows}
+    if args.resume and out_path.exists():
+        with out_path.open() as fh:
+            done = {r["table"] for r in csv.DictReader(fh)}
         print(f"resuming: {len(done)} tables already recorded")
+    fresh = not out_path.exists() or not args.resume
+    sink = out_path.open("w" if fresh else "a", newline="")
+    writer = csv.DictWriter(sink, fieldnames=FIELDS)
+    if fresh:
+        writer.writeheader()
+
+    def record(**kw):
+        """One row, flushed. A sweep that loses its work on Ctrl-C is not resumable."""
+        writer.writerow({k: kw.get(k, "") for k in FIELDS})
+        sink.flush()
+
+    n_findings = 0
 
     unreadable = clean = skipped = 0
     started = time.time()
@@ -89,44 +105,42 @@ def main(argv: list | None = None) -> int:
         size_mb = path.stat().st_size / 1024 ** 2
         if size_mb > args.max_mb:
             skipped += 1
-            rows.append({"table": path.stem, "check": "size_skipped", "severity": "info",
-                         "message": f"{size_mb:.0f} MB exceeds --max-mb={args.max_mb:.0f}; "
-                                    f"not opened. Re-run with a higher cap when the "
-                                    f"machine is idle.",
-                         "n_rows": "", "n_items": "", "n_participants": ""})
+            record(table=path.stem, check="size_skipped", severity="info",
+                   message=f"{size_mb:.0f} MB exceeds --max-mb={args.max_mb:.0f}; not "
+                           f"opened. Re-run with a higher cap when the machine is idle.")
+            n_findings += 1
             continue
         try:
             report = validate_file(path, profile=args.profile)
         except Exception as exc:                      # a bad file must not stop the sweep
             unreadable += 1
-            rows.append({"table": path.stem, "check": "unreadable", "severity": "error",
-                         "message": f"{type(exc).__name__}: {exc}"[:300],
-                         "n_rows": "", "n_items": "", "n_participants": ""})
+            record(table=path.stem, check="unreadable", severity="error",
+                   message=f"{type(exc).__name__}: {exc}"[:300])
+            n_findings += 1
             print(f"[{i}/{len(files)}] {path.stem}: UNREADABLE {type(exc).__name__}", flush=True)
             continue
         st = report.stats or {}
         if not report.findings:
             clean += 1
+            # a row per table either way, so --resume knows it was done
+            record(table=path.stem, check="", severity="ok",
+                   n_rows=st.get("n_responses", ""), n_items=st.get("n_items", ""),
+                   n_participants=st.get("n_participants", ""))
         for f in report.findings:
-            rows.append({"table": path.stem, "check": f.check, "severity": f.severity,
-                         "message": f.message[:300],
-                         "n_rows": st.get("n_responses", ""),
-                         "n_items": st.get("n_items", ""),
-                         "n_participants": st.get("n_participants", "")})
+            record(table=path.stem, check=f.check, severity=f.severity,
+                   message=f.message[:300], n_rows=st.get("n_responses", ""),
+                   n_items=st.get("n_items", ""), n_participants=st.get("n_participants", ""))
+            n_findings += 1
         if i % 25 == 0 or i == len(files):
-            print(f"[{i}/{len(files)}] {clean} clean, {len(rows)} findings, "
+            print(f"[{i}/{len(files)}] {clean} clean, {n_findings} findings, "
                   f"{unreadable} unreadable, {time.time()-started:.0f}s", flush=True)
         gc.collect()
 
-    with open(args.out, "w", newline="") as fh:
-        w = csv.DictWriter(fh, fieldnames=["table", "check", "severity", "message",
-                                           "n_rows", "n_items", "n_participants"])
-        w.writeheader()
-        w.writerows(rows)
+    sink.close()
     print(f"\n{len(files)} tables: {clean} with nothing to report, "
           f"{len(files) - clean - skipped} with at least one finding, "
           f"{unreadable} unreadable, {skipped} skipped for size")
-    print(f"wrote {len(rows)} findings to {args.out}")
+    print(f"wrote {n_findings} findings to {args.out}")
     return 0
 
 

--- a/irw_validate/tests/test_validate.py
+++ b/irw_validate/tests/test_validate.py
@@ -247,6 +247,23 @@ class ScoredTables(unittest.TestCase):
         report = validate_frame(df, label="likert_2024__items.csv")
         self.assertIn("resp_ambiguous", [f.check for f in report.errors])
 
+class TableNames(unittest.TestCase):
+    def test_every_table_suffix_is_stripped(self):
+        from irw_validate.core import _table_name
+        for label, want in (("a_2024_x.csv", "a_2024_x"),
+                            ("a_2024_x.Rdata", "a_2024_x"),
+                            ("a_2024_x.rds", "a_2024_x"),
+                            ("dir/a_2024_x.tsv", "a_2024_x"),
+                            ("a_2024_x", "a_2024_x")):
+            self.assertEqual(_table_name(label), want)
+
+    def test_the_extension_does_not_fail_the_lowercase_rule(self):
+        # stripping only .csv made all 922 legacy tables fail name_charset on
+        # the capital R of ".Rdata"
+        df = pd.DataFrame({"id": [1, 2], "item": ["a", "b"], "resp": [1, 2]})
+        report = validate_frame(df, label="fine_2019_table.Rdata", profile="legacy")
+        self.assertNotIn("name_charset", [f.check for f in report.findings])
+
 
 class RPythonParity(unittest.TestCase):
     """The fork cannot silently reopen: one list, two languages, checked here."""


### PR DESCRIPTION
First run of `irw-validate` over the `.Rdata` files in `../data/pub/`. 852 opened, 70 deferred by an 8 MB cap, 28 clean, **131 with an error**.

## The finding that matters is about the directory, not the tables

1.5 says *"run it over the 922 legacy `.Rdata` tables in `data/pub/`"*, which assumes that directory holds the legacy corpus. **For a quarter of it, it does not.** Row counts against `metadata/metadata.csv`:

| | tables |
|---|---|
| archive matches published exactly | 603 |
| differs by under 1% | 125 |
| archive holds 50–99% of published | 65 |
| archive holds under 50% | 3 |
| **archive empty, published is not** | **16** |
| archive holds *more* than published | 2 |

The under-1% group is probably the comparison rather than drift — this counts rows with a non-null `resp` and `metadata.csv` may not. The other 86 are real.

**The 16 empty ones are every PISA cycle from 2000 to 2012.** `pisa2000_math` through `pisa2012_science`: 4 KB files holding the right columns and **zero rows**, while the published tables hold between 1.5M and 22.6M responses. The 2015/2018/2022 cycles are the real 130–196 MB files. The local archive lost the older PISA data at some point and nothing noticed, because nothing reads these files.

So **56 of the 131 error tables have an archive copy that differs from what is published**. This run is a candidate list, not a verdict on the corpus — the README says so, and acting on any single finding means confirming it against live data first.

## What it found in the 852 it opened

| check | tables | |
|---|---|---|
| `dup_id_item` | 101 | same person, same item, twice, with no `wave`/`timepoint`/`date` to tell them apart |
| `name_length` | 19 | over the 40-character cap; `threatperceptions_isler_2024_*` is 11 of them |
| `id_na`/`item_na`/`resp_na` | 16 | the empty PISA files |
| `resp_variation*` | 16 | the same 16 |

Warnings: `imputed_values*` 557, `column_order` 444, `name_charset` 254 (the known non-lowercase names), `cov_range` 24 (the #1779 class), `sample_floor` 52.

## A correction the sweep forced

`resp_numeric`, inherited from `run_qc`, counts how many values parse as numbers over **all** rows — so `NaN` reads as "does not parse", and a float column with missing values fails a check about non-numeric *text* while `resp_na` already reports the missingness.

That produced **86 false errors**, including `BAFACALO_Golino_2013_CIS`: 39% null, and **100% numeric over the values that are present**. The gate profiles now re-judge it over non-null values; `triage` keeps the inherited behaviour, because fifty scripts depend on it.

Without this the sweep would have reported 214 tables with errors instead of 131, and a third of them would have been wrong.

## Written to share the machine

Single-threaded, with BLAS pools pinned before numpy imports; one file at a time; `--max-mb` skips and *records* the largest; results appended as each table finishes so an interrupt loses nothing; suggests `nice -n 19`. An earlier version buffered everything and wrote once — a run that timed out at 420s produced no file and `--resume` had nothing to resume from.

## What should happen next

The useful version of 1.5 points at **live data**, not this directory. Same tooling, different loader. Worth deciding separately whether `data/pub/` should be repaired, re-synced, or retired — it is not under version control and nothing reads it.

Completes #1703 sub-item 1.5, and with #1829 completes item 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5VsAkTyiVWtFij13gVYGa