### PR TITLE
Put today's two gates into the item text batch workflow (#1831)

### DIFF
--- a/irw_validate/README.md
+++ b/irw_validate/README.md
@@ -9,6 +9,11 @@ irw-validate out/x.csv --json                # for CI
 
 Exit codes: `0` ok · `1` something blocks · `2` bad input. Same contract as `red_up`.
 
+`irw-validate` is a console script declared in `pyproject.toml`. If the command is not
+found, the editable install predates it — re-run `pip install -e .` from `src/` (this
+machine needs `--break-system-packages`, PEP 668). Otherwise `python3 -m irw_validate.cli`
+works, but only from `src/`.
+
 ## Why this exists
 
 The checks were forked, and neither half could gate anything:

--- a/itemtext/.claude/skills/irw-auto-itemtext/SKILL.md
+++ b/itemtext/.claude/skills/irw-auto-itemtext/SKILL.md
@@ -924,6 +924,13 @@ Before a table leaves your hands, all of these are true and recorded:
    distinguished from every other), and a re-runnable `verify_<table>.R` sits beside the CSV.
 10. `normalize_nulls.R` then `audit_batch.R` run clean, or each WARN is explained;
    `verify_batch.R` and `lint_verification.R` are clean or each flag is explained.
+11. `irw-validate` passes over the batch's `*__items.csv` — it checks the table against the
+   data standard rather than against its source, and catches the two classes the other
+   gates cannot see: a doubled upload (`dup_item_resp`) and two scale directions in one
+   table (`resp_ambiguous`).
+12. `check_provenance.R` passes — every `translation_source` is in
+   `itemtext/provenance_vocab.csv`, and every `machine_translation` table has a line on the
+   public issues page. English this project generated is always disclosed.
 
 ### Step 6d — Normalize and audit before the batch is considered done
 
@@ -932,6 +939,12 @@ Rscript .claude/skills/irw-auto-itemtext/scripts/normalize_nulls.R    itemtables
 Rscript .claude/skills/irw-auto-itemtext/scripts/audit_batch.R        itemtables/batch_<NNN>
 Rscript .claude/skills/irw-auto-itemtext/scripts/verify_batch.R       itemtables/batch_<NNN>
 Rscript .claude/skills/irw-auto-itemtext/scripts/lint_verification.R  itemtables/batch_<NNN>
+
+# Added 2026-09-02. The four gates above check a table against its SOURCE -- do the
+# item and resp sets match, does the mapping reproduce. These two check it against
+# the STANDARD and against the corpus, which nothing in this batch flow did.
+irw-validate itemtables/batch_<NNN>/*__items.csv
+Rscript check_provenance.R ../../irw_site/itemtext_issues.qmd
 ```
 
 The last two are the mapping-side gates: `verify_batch.R` re-runs each table's own

--- a/itemtext/BATCH_PROCESS.md
+++ b/itemtext/BATCH_PROCESS.md
@@ -227,8 +227,32 @@ Rscript .claude/skills/irw-auto-itemtext/scripts/audit_batch.R        itemtables
 Rscript .claude/skills/irw-auto-itemtext/scripts/verify_batch.R       itemtables/batch_<NNN>
 Rscript .claude/skills/irw-auto-itemtext/scripts/lint_verification.R  itemtables/batch_<NNN>
 
+# Added 2026-09-02. The four gates above check a table against its SOURCE -- do the
+# item and resp sets match, does the mapping reproduce. These two check it against
+# the STANDARD and against the corpus, which nothing in this batch flow did.
+irw-validate itemtables/batch_<NNN>/*__items.csv
+Rscript check_provenance.R ../../irw_site/itemtext_issues.qmd
+
 A verify FAIL or NO VERDICT, or a lint ERROR, means a table's own claim did not reproduce: mark that
 table failed rather than done, and say so in the round_log entry.
+
+An `irw-validate` ERROR means the table breaks the data standard regardless of how well
+its mapping reproduces. Two of its checks exist because of defects found in already-published
+tables on 2026-09-02:
+
+- `dup_item_resp` — the same `item`+`resp` twice with identical option text. That is a
+  doubled upload; four live tables carried it (#1816), one of them serving every item twice
+  for a day.
+- `resp_ambiguous` — one `resp` value carrying two different option labels, i.e. two
+  opposite scale directions merged into one table. `afps_vangsness_2019` says a response of
+  1 means both "Strongly agree" and "Strongly disagree" (#1827). Note that per-item
+  direction differences are legitimate and are NOT flagged — `aip_vangsness_2019` has four
+  reverse-worded items labelled the other way round and passes, correctly.
+
+`check_provenance.R` fails on a `translation_source` value outside
+`itemtext/provenance_vocab.csv`, and reports any `machine_translation` table with no entry
+on the public issues page. A table shipping English this project generated is disclosed —
+ratified 2026-09-02, after 60 such tables were found with no public note at all (#1777).
 
 ## Step 5 — Update queue state and check the circuit breaker
 

--- a/itemtext/check_provenance.R
+++ b/itemtext/check_provenance.R
@@ -27,6 +27,8 @@ here <- dirname(sub("^--file=", "",
                     grep("^--file=", commandArgs(FALSE), value = TRUE)[1]))
 if (!length(here) || is.na(here)) here <- "itemtext"
 
+page_is_current <- TRUE     # set FALSE when the page we read may be stale
+
 vocab_path <- file.path(here, "provenance_vocab.csv")
 if (!file.exists(vocab_path)) stop("no provenance_vocab.csv beside this script")
 vocab <- read.csv(vocab_path, stringsAsFactors = FALSE)
@@ -88,9 +90,14 @@ if (file.exists(page)) {
     br <- suppressWarnings(system2("git", c("-C", shQuote(site), "rev-parse",
                                             "--abbrev-ref", "HEAD"),
                                    stdout = TRUE, stderr = FALSE))
-    if (length(br) && !is.na(br[1]) && nzchar(br[1]) && br[1] != "main")
-        cat(sprintf("  NOTE: that checkout is on branch '%s', not main -- it may be stale.\n",
+    if (length(br) && !is.na(br[1]) && nzchar(br[1]) && br[1] != "main") {
+        page_is_current <- FALSE
+        cat(sprintf("  NOTE: that checkout is on branch '%s', not main. The disclosure\n",
                     br[1]))
+        cat("  check below is REPORTED BUT NOT ENFORCED -- a page whose state is\n",
+            "  unknown cannot support a verdict either way. Point this at the site's\n",
+            "  main to enforce it:  Rscript check_provenance.R <path-to-main-copy>\n", sep = "")
+    }
 } else {
     cat(sprintf("\nissues page not found at %s -- skipping the disclosure check\n", page))
 }
@@ -112,4 +119,9 @@ if (file.exists(page) && length(needs_note)) {
     undisclosed <- character(0)
 }
 
-quit(status = if (length(bad) || length(undisclosed)) 1L else 0L)
+## The vocabulary always decides the exit status: it is checked against files in
+## this repository. The disclosure check only decides it when we can trust the
+## copy of the page we read -- otherwise a colleague's branch checkout would
+## fail everyone's gate for a defect that is not there. This exact false
+## positive happened on 2026-09-02, minutes after the 60 entries were merged.
+quit(status = if (length(bad) || (length(undisclosed) && page_is_current)) 1L else 0L)


### PR DESCRIPTION
#1831 lists what batch_016 must pass: `validate_items.R`, `normalize_nulls.R`, `audit_batch.R`, `verify_batch.R`, `lint_verification.R`.

**All five check a table against its SOURCE** — do the item and resp sets match, does the mapping reproduce. **None checks it against the data standard.** So a batch run today would not be checked for either defect class found today.

Now in the gate block in `BATCH_PROCESS.md` and `SKILL.md`, and in the Step 6c-bis checklist as items 11–12:

```
irw-validate itemtables/batch_<NNN>/*__items.csv
Rscript check_provenance.R ../../irw_site/itemtext_issues.qmd
```

## What they add

| check | what it catches | found in |
|---|---|---|
| `dup_item_resp` | same `item`+`resp` twice with identical option text — a doubled upload | 4 live tables, #1816 |
| `resp_ambiguous` | one `resp` value carrying two option labels — two opposite scale directions in one table | `afps_vangsness_2019`, #1827 |
| `check_provenance.R` | a `translation_source` outside the vocabulary; a `machine_translation` table with no public disclosure | 60 tables, #1777 |

The docs are explicit that **per-item direction differences are legitimate and not flagged** — `aip_vangsness_2019` has four reverse-worded items labelled the other way round and passes, correctly. That distinction is why the check reads option text rather than counting duplicates.

## Two corrections found by running the instructions I had just written

Both would have failed for whoever ran them first. Which is the argument for running a gate before documenting it.

- **`python3 -m irw_validate.cli` only resolves from `src/`**, and the `irw-validate` console script was declared in `pyproject.toml` but never installed — the editable install predates it. Reinstalled; it works from any directory now, and `irw_validate/README.md` says what to do when it does not.
- **`check_provenance.R` exited 1 against a sibling `irw_site` checkout sitting on another branch**, reporting 64 undisclosed tables that had been disclosed hours earlier. As a gate that is worse than nothing — it fails on a colleague's in-flight vignette work rather than on a defect. The disclosure half is now **reported but not enforced** whenever the page may be stale, with a message saying how to point it at a current copy. The vocabulary half still always decides the exit status, because it reads files in this repository.

## Verified

- `batch_015` passes both gates cleanly — this does not retro-fail good work.
- Against a current page, `check_provenance.R` reports **0** undisclosed and exits 0.
- 76 tests pass.

Ready for batch_016 to run through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5VsAkTyiVWtFij13gVYGa