### PR TITLE
dup_id_item: a rater is not a duplicate (#1830 follow-up)

### DIFF
--- a/irw_validate/core.py
+++ b/irw_validate/core.py
@@ -139,6 +139,31 @@ def validate_frame(df, *, label: str = "", profile: str = "upload",
         report.findings.append(
             Finding(check.name, severity, check.detail, table=table, group=group))
 
+    # `dup_id_item` asks whether a `wave`/`timepoint`/`date` column explains a
+    # repeated id+item. That list came from validate_irw.R and is stale: it
+    # predates `rater`, and it never covered trial-level designs. In the legacy
+    # sweep it flagged 101 tables, and of the 57 whose local copy matches what is
+    # published, 14 are explained outright by a column the check does not look
+    # at -- `rater` on eleven of them, plus `trialnum`, `order` and `period`.
+    #
+    # A rater is not a defect: two people rating the same person on the same item
+    # is the design. Same for a repeated trial. `datastandard.md` documents
+    # `rater` as a legitimate column, so a check that treats it as a duplicate is
+    # reporting the standard's own schema as an error.
+    #
+    # NOT included: `group`, `study`, `treatment`. Those describe the person or
+    # the arm, not the occasion, and a person appearing twice under them is a
+    # real question rather than an explanation.
+    if profile in ("upload", "legacy") and {"id", "item"}.issubset(df.columns):
+        if any(f.check == "dup_id_item" for f in report.findings):
+            for col in ("rater", "wave", "timepoint", "date", "trialnum", "trial",
+                        "order", "session", "occasion", "period", "block", "subtest"):
+                if col in df.columns and not df.duplicated(subset=["id", "item", col]).any():
+                    report.findings = [f for f in report.findings
+                                       if f.check != "dup_id_item"]
+                    report.checks_run.append(f"dup_id_item:resolved_by_{col}")
+                    break
+
     # `resp_numeric` as inherited from run_qc measures how many values parse as
     # numbers over ALL rows, so a float column with missing values fails it --
     # NaN does not parse. That conflates "not a number" with "not present", and

--- a/irw_validate/results/README.md
+++ b/irw_validate/results/README.md
@@ -74,3 +74,46 @@ on it.
 The useful version of 1.5 points at **live data**, not this directory. The
 tooling is the same; only the loader changes. This run's value is the candidate
 list and the fidelity measurement above — not a verdict on the corpus.
+
+---
+
+# `dup_id_item` triage, 2026-09-02
+
+`dup_id_item_triage_2026-09-02.csv` follows up the 101 tables the sweep flagged.
+
+Ben's method: **where the local `.Rdata` row count matches `metadata.csv`, trust the
+local copy.** That covers 57 of the 101 — 39 differ from what is published and 5 are
+not in `metadata.csv`, so those need live data before anything can be said.
+
+Of the 57:
+
+| | tables | what it means |
+|---|---|---|
+| **explained by a column the check ignores** | 14 | `rater` ×11, plus `trialnum`, `order`, `period` |
+| **bare `id`/`item`/`resp`** | 15 | nothing can explain the repeat — real defects |
+| **unexplained** | 28 | other columns present, none resolves it — needs a per-table look |
+
+## The 14 were the check's fault, and it is fixed
+
+`dup_id_item` asked whether `wave`/`timepoint`/`date` explained a repeated `id`+`item`.
+That list came from `validate_irw.R` and is stale: it predates `rater` and never covered
+trial-level designs. Two raters scoring the same person on the same item is **the design**,
+and `datastandard.md` documents `rater` as a legitimate column — so the check was reporting
+the standard's own schema as an error.
+
+The gate profiles now consult `rater`, `trialnum`, `trial`, `order`, `session`, `occasion`,
+`period`, `block` and `subtest` as well. `triage` is unchanged, because fifty scripts
+depend on it.
+
+Deliberately **not** included: `group`, `study`, `treatment`. Those describe the person or
+the arm rather than the occasion, and a person appearing twice under them is a real
+question, not an explanation. Eleven of the 28 unexplained have exactly such a column.
+
+## What is left
+
+- **15 bare tables** — the `florida_twins_behavior_*` family is six of them, each with
+  100% of rows duplicated and no other column. Candidate for a straight dedupe, but the
+  source should say whether the duplication is in the original.
+- **28 unexplained** — per-table judgment.
+- **44 not yet analysed** — 39 whose local copy disagrees with what is published, 5 absent
+  from `metadata.csv`. These need live data; `data/pub` cannot answer for them.

--- a/irw_validate/results/dup_id_item_triage_2026-09-02.csv
+++ b/irw_validate/results/dup_id_item_triage_2026-09-02.csv
@@ -1,0 +1,58 @@
+table,bucket,resolved_by,other_cols
+AOMT_BR_SF_EDPANAB_Geiger_2021_AOT,unexplained,,Group
+AOMT_BR_SF_EDPANAB_Geiger_2021_BRS,unexplained,,Group
+AOMT_BR_SF_EDPANAB_Geiger_2021_RF,unexplained,,Group
+CV_OASIS_ODSIS_PPE_Novak_2020_BFI,unexplained,,group
+CV_OASIS_ODSIS_PPE_Novak_2020_DSES,unexplained,,group
+CV_OASIS_ODSIS_PPE_Novak_2020_RSES,unexplained,,group
+EWAS_Sanford_2024,unexplained,,study
+Ellipse_Corssley_2024,resolved,rater,rater
+FEDSP_Trzcinska_2023_MonKnow,bare id/item/resp,,
+KTEEM_Schoen_2019-2022,unexplained,,group
+OS_TBMWTFS_Schubert_2023_DMW,unexplained,,group
+OS_TBMWTFS_Schubert_2023_IPIP,unexplained,,group
+OS_TBMWTFS_Schubert_2023_MAAS,unexplained,,group
+OS_TBMWTFS_Schubert_2023_SMW,unexplained,,group
+PTCI_Chinese_Zhan_2024,bare id/item/resp,,
+RD_EppSCQRK_Kipkemoi_2024_scq,bare id/item/resp,,
+alcoholstroop_jones2024,resolved,trialnum,trialnum;stimulus;rt
+autonomysupport_mokken,resolved,rater,rater
+concretewords,bare id/item/resp,,
+cure_data,resolved,period,period
+det_naismith_2023,resolved,rater,cov_gender;cov_test_taker_intent;cov_first_langugage;cov_ielts_writing;itemcov_condition;itemcov_length_characters;rater
+duolingo_en_es__listen,unexplained,,session;format;rt;part.speech;morphology;dependency.label;dependency.head;stem
+duolingo_en_es__reverse_tap,unexplained,,session;format;rt;part.speech;morphology;dependency.label;dependency.head;stem
+duolingo_es_en__reverse_tap,unexplained,,session;format;rt;part.speech;morphology;dependency.label;dependency.head;stem
+duolingo_es_en__reverse_translate,unexplained,,session;format;rt;part.speech;morphology;dependency.label;dependency.head;stem
+duolingo_fr_en__listen,unexplained,,session;format;rt;part.speech;morphology;dependency.label;dependency.head;stem
+duolingo_fr_en__reverse_tap,unexplained,,session;format;rt;part.speech;morphology;dependency.label;dependency.head;stem
+duolingo_fr_en__reverse_translate,unexplained,,session;format;rt;part.speech;morphology;dependency.label;dependency.head;stem
+famous_melodies,resolved,rater,rater;rt
+florida_twins_behavior_cads,bare id/item/resp,,
+florida_twins_behavior_cadsyv,bare id/item/resp,,
+florida_twins_behavior_ecs,bare id/item/resp,,
+florida_twins_behavior_friends,bare id/item/resp,,
+florida_twins_behavior_panas,bare id/item/resp,,
+florida_twins_behavior_rcads,bare id/item/resp,,
+florida_twins_behavior_tas,bare id/item/resp,,
+fractals_rating,resolved,rater,rater
+graphmapping_study1,resolved,order,order;rt
+immer12_immer,resolved,rater,rater
+motion,unexplained,,rt
+mpsycho_lakes,resolved,rater,rater;subtest
+non_parametric_mixture_modeling_exp1_Cleaned,unexplained,,rt
+number_pattern_game,bare id/item/resp,,
+pact_project,unexplained,,treatment
+pass20_klosowska_2025_csq_online,unexplained,,cov_age;cov_sex;cov_race;cov_student;cov_employed_full_time;cov_employed_part_time;cov_unemployed;cov_retired;cov_pensioner;cov_net_monthly_income;cov_sick_leave;cov_marital_status;cov_education;cov_residence
+pass20_klosowska_2025_dass_online,unexplained,,cov_age;cov_sex;cov_race;cov_student;cov_employed_full_time;cov_employed_part_time;cov_unemployed;cov_retired;cov_pensioner;cov_net_monthly_income;cov_sick_leave;cov_marital_status;cov_education;cov_residence
+pass20_klosowska_2025_staix_online,unexplained,,cov_age;cov_sex;cov_race;cov_student;cov_employed_full_time;cov_employed_part_time;cov_unemployed;cov_retired;cov_pensioner;cov_net_monthly_income;cov_sick_leave;cov_marital_status;cov_education;cov_residence
+psychtools_sai,unexplained,,occasion
+ptam1_immer,resolved,rater,rater
+ravens_deboeck2012,bare id/item/resp,,
+realpic_souza2021,bare id/item/resp,,
+rr98_accuracy,unexplained,,rt
+smacof_pvq40,bare id/item/resp,,
+sris_silvia2022,unexplained,,study
+swmd_mokken,resolved,rater,rater
+tears,resolved,rater,rater;stimulus;phase
+wine_luckett2021,resolved,rater,rater

--- a/irw_validate/tests/test_validate.py
+++ b/irw_validate/tests/test_validate.py
@@ -247,6 +247,40 @@ class ScoredTables(unittest.TestCase):
         report = validate_frame(df, label="likert_2024__items.csv")
         self.assertIn("resp_ambiguous", [f.check for f in report.errors])
 
+class RepeatedMeasures(unittest.TestCase):
+    """A rater or a trial explains a repeated id+item; a group does not."""
+
+    def _rated(self, col="rater"):
+        return pd.DataFrame({"id": [1, 1, 2, 2], "item": ["a", "a", "a", "a"],
+                             "resp": [1, 2, 3, 4], col: [1, 2, 1, 2]})
+
+    def test_a_rater_column_explains_the_repeat(self):
+        report = validate_frame(self._rated(), profile="upload")
+        self.assertNotIn("dup_id_item", [f.check for f in report.findings])
+
+    def test_so_do_trial_and_period(self):
+        for col in ("trialnum", "order", "period", "session", "occasion"):
+            with self.subTest(col=col):
+                report = validate_frame(self._rated(col), profile="upload")
+                self.assertNotIn("dup_id_item", [f.check for f in report.findings])
+
+    def test_a_group_column_does_not(self):
+        # group describes the person, not the occasion -- a person appearing
+        # twice under it is a real question, not an explanation
+        report = validate_frame(self._rated("group"), profile="upload")
+        self.assertIn("dup_id_item", [f.check for f in report.errors])
+
+    def test_a_bare_table_still_fails(self):
+        df = pd.DataFrame({"id": [1, 1], "item": ["a", "a"], "resp": [1, 2]})
+        self.assertIn("dup_id_item",
+                      [f.check for f in validate_frame(df, profile="upload").errors])
+
+    def test_triage_is_unchanged(self):
+        # the 50 callers see what they always saw
+        report = validate_frame(self._rated(), profile="triage")
+        self.assertIn("dup_id_item", [f.check for f in report.findings])
+
+
 class TableNames(unittest.TestCase):
     def test_every_table_suffix_is_stripped(self):
         from irw_validate.core import _table_name


### PR DESCRIPTION
Follow-up on the 101 tables the legacy sweep flagged for a repeated `id`+`item`. Triaged with @ben-domingue's method — **where the local `.Rdata` row count matches `metadata.csv`, trust the local copy** — which covers 57 of the 101.

## Fourteen of the 57 were the check's fault

| resolved by | tables |
|---|---|
| `rater` | 11 |
| `trialnum` | 1 |
| `order` | 1 |
| `period` | 1 |

`dup_id_item` asked whether `wave`/`timepoint`/`date` explained the repeat. That list came from `validate_irw.R` and is stale — it predates `rater` and never covered trial-level designs.

**Two raters scoring the same person on the same item is the design, not a defect**, and `datastandard.md` documents `rater` as a legitimate column. The check was reporting the standard's own schema as an error, on `Ellipse_Corssley_2024`, `mpsycho_lakes`, `immer12_immer`, `swmd_mokken` and seven more.

Gate profiles now also consult `rater`, `trialnum`, `trial`, `order`, `session`, `occasion`, `period`, `block`, `subtest`. `triage` is unchanged — fifty scripts depend on it and the golden test pins it.

**Deliberately not included: `group`, `study`, `treatment`.** Those describe the person or the arm, not the measurement occasion, and a person appearing twice under one is a real question rather than an explanation. Eleven of the still-unexplained tables have exactly such a column; folding them into "resolved" would have buried the question.

Re-checked all 57: **14 cleared, 43 still flag.**

## What is actually left

| | tables | |
|---|---|---|
| bare `id`/`item`/`resp` | **15** | nothing can explain the repeat — real defects. `florida_twins_behavior_*` is six of them, each with 100% of rows duplicated and no other column |
| unexplained | **28** | other columns present, none resolves it — per-table judgment |
| not analysable from `data/pub` | **44** | 39 disagree with what is published, 5 absent from `metadata.csv` — these need live data |

Triage recorded in `irw_validate/results/dup_id_item_triage_2026-09-02.csv`.

81 tests pass, including one asserting `group` does *not* resolve a repeat and one asserting `triage` behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5VsAkTyiVWtFij13gVYGa