### PR TITLE
automated_finding: a failed search must not be logged as an empty one

### DIFF
--- a/automated_finding/README.md
+++ b/automated_finding/README.md
@@ -392,6 +392,22 @@ of short names so callers can react. Two consumers today:
 See BATCH_LOG.md's 2026-08-17 entry for the Harvard Dataverse incident that
 prompted both.
 
+**Unavailable sources.** `SourceUnavailable` is the per-query sibling of
+`SourceBlocked`: a connector raises it when *this* query did not complete —
+a proxy or connection failure, a timeout, a 5xx, a malformed response.
+`discover()` records the source against that query (`unsearched_sources(q)`)
+and keeps calling it, since the next term may well succeed.
+
+Every connector raises rather than returns on any exception, which is the
+whole point: a generator that returns early is indistinguishable from one
+that ran out of results, so the old `except Exception: print(...); return`
+made "never searched" look exactly like "searched, found nothing." That is
+what cost the 2026-09-02 monthly sweep 88 of its 125 terms — the outbound
+proxy went down mid-run, all 8 sources swallowed the `ProxyError`, and every
+affected term logged a false `0 candidates; sources=<all 8>`, advancing its
+`--since` watermark past a window nobody had queried. The rerun found 1,330
+candidates in it. An incomplete search is never evidence of an empty one.
+
 ### `irw_discover_monthly.py`
 Incremental wrapper around `irw_discover_updated.py` for a fixed
 `TERM_LIST`, meant to run on a schedule (see the `schedule` skill) rather
@@ -401,16 +417,26 @@ an `output_file` starting with `monthly_candidates_` — this avoids
 misreading an unrelated row, e.g. a PLOS batch that happens to reuse the
 same term text, as a repository-API run) and passes that as `--since`; a
 term run for the first time falls back to `--default-lookback-days` (90).
-After a run it appends one `search_terms_log.csv` row per term with today's
-date, so the next scheduled run advances automatically.
+It appends one `search_terms_log.csv` row per term *the moment that term
+finishes*, with today's date, so the next scheduled run advances
+automatically. Per-term rather than batched at the end: a ~100-term sweep
+runs for hours, and a container restart partway through used to discard the
+record of every term already done. Now an interruption costs only the
+in-flight term — rerun the rest with `--terms`.
 
-Only sources that were actually *reachable* go into that row's `sources=`
-note; any that hard-blocked (see `blocked_sources()` below) are listed under
-`blocked=` instead. This matters because the `sources=` note is what the
-next run's `--since` lookup trusts — logging a WAF-challenged source as
+Only sources that actually *completed a search of that term* go into its
+`sources=` note; anything that hard-blocked (`blocked_sources()`) or failed
+that particular query (`unsearched_sources()`) is named under
+`not_searched=` instead. This matters because the `sources=` note is what
+the next run's `--since` lookup trusts — logging an unreached source as
 searched would advance its watermark past a window nobody ever queried and
 skip it forever. Leaving it out means the lookup finds no covering row and
 falls back to the default lookback, which only ever searches wider.
+
+`--terms <term> ...` restricts a run to a subset of the mode's list (terms
+off the list are accepted too, they just get the default lookback), and
+`--note <text>` is appended to every log row's notes — together they are how
+you re-cover a window an earlier run lost, legibly.
 
 Changing `--sources` has the same effect on purpose: the lookup requires a
 prior row whose sources are a *superset* of the current set, so adding a

--- a/automated_finding/TODO.md
+++ b/automated_finding/TODO.md
@@ -3,6 +3,33 @@
 Currently open action items only. For the full batch-by-batch history and
 context behind these (and everything already resolved), see `BATCH_LOG.md`.
 
+## From the 2026-09-02 monthly repos sweep
+
+- [ ] **`automated/repos-monthly-2026-09-02` is waiting for review, and only
+  150 of its 1,998 candidates were triaged -- none `good`.** The scheduled
+  run hit a container restart, 88 of 125 terms came back with a false "0
+  candidates" when the outbound proxy went down, and `9a11fbb` reran those 88
+  honestly. The candidates (1,998, no `scholars_portal` -- 403 in that
+  environment) and a 150-row triage landed on the branch; `de97257` put 97
+  dedup keys on `main`. The triage's flag mix is worth a look before working
+  it: 67 `no_usable_file`, 53 `download_failed` (transient, deliberately not
+  ledgered, so a rerun retries them), 19 `human_assistance`, 5 `below_min_n`,
+  3 `not_item_response`, 3 `license_restricted`, **0 `good`**. Whether the
+  other ~1,850 candidates were prefiltered out or the triage was simply cut
+  short by the same outage is the first thing to establish.
+
+- [ ] **The watermark reached `main` hours before the candidates reached a
+  branch.** `9a11fbb` pushed the 88 `search_terms_log.csv` rows -- which
+  advance those terms' `--since` to 2026-09-02 -- at 23:49 UTC; the candidate
+  CSV was not committed anywhere until `7201016` at 00:21, and it lives in
+  `runs/`, which is gitignored precisely so scheduled runs stop committing per-
+  run CSVs. Had the container died in that half hour, all 88 terms would have
+  been permanently marked searched with 1,998 candidates recorded nowhere. It
+  did not, so no harm this time -- but this is the identical shape to the open
+  PLOS item below, now on a second routine, and the fix is the same: either
+  the ledger append moves to a post-merge step, or both commits go on the
+  branch together.
+
 ## From the 2026-09-01 PLOS weekly batch
 
 - [ ] **9 item text tables still need uploading** to `irw_text` — `red_up

--- a/automated_finding/irw_discover_monthly.py
+++ b/automated_finding/irw_discover_monthly.py
@@ -26,8 +26,16 @@ How incrementality works:
     lookback. See automated_finding PR #1625 / TODO.md.)
   - A term run for the first time at a given source set has no prior row,
     so it falls back to --default-lookback-days (default 90) before today.
-  - After a run, one row per term is appended to search_terms_log.csv with
-    today's date, so next month's invocation advances automatically.
+  - One row per term is appended to search_terms_log.csv the moment that
+    term finishes (not batched to the end of the run), with today's date,
+    so next month's invocation advances automatically and an interrupted
+    sweep keeps the terms it did complete. Rerun the rest with --terms.
+  - A row's sources= lists only the sources that actually completed a
+    search of that term -- a source that was hard-blocked, or that hit a
+    proxy/timeout/5xx on that particular query, is left out (and named in
+    not_searched=). An incomplete search is never written down as an empty
+    one, because last_run_date() would then advance the watermark past a
+    window nobody queried. See searched_for() in main().
 
 TERM_LIST below is a starting point, not a final answer -- edit it freely.
 Pull candidates from search_terms_log.csv (which terms/notes mention high
@@ -52,7 +60,7 @@ from dataclasses import asdict
 
 from irw_discover_updated import (
     discover, SOURCE_MAP, _load_auto_exclusions, resolve_out_path,
-    blocked_sources,
+    blocked_sources, unsearched_sources,
 )
 
 LOG_PATH = "search_terms_log.csv"
@@ -335,7 +343,17 @@ def main():
                      help="print each term's computed --since date and exit, no queries run")
     ap.add_argument("--out", default=None,
                      help=f"output CSV (default: {OUT_PREFIX}<mode>_<today>.csv)")
+    ap.add_argument("--note", default="",
+                     help="free text appended to every log row's notes -- say why a "
+                          "non-standard run happened (e.g. re-covering a window an "
+                          "earlier run lost), so the row is readable a month later")
+    ap.add_argument("--terms", metavar="TERM", nargs="+", default=None,
+                     help="run only these terms instead of the mode's whole list. "
+                          "For re-covering a window a previous run lost -- a term "
+                          "not in the mode's list is still accepted (it just gets "
+                          "the default lookback, having no prior run to read).")
     args = ap.parse_args()
+    note_suffix = f" -- {args.note.strip()}" if args.note.strip() else ""
 
     unknown = set(args.sources) - set(SOURCE_MAP)
     if unknown:
@@ -343,6 +361,13 @@ def main():
     active_sources = [SOURCE_MAP[s] for s in args.sources]
 
     terms = HIGH_YIELD_TERMS if args.mode == "weekly" else TERM_LIST
+    if args.terms:
+        off_list = [t for t in args.terms if t not in terms]
+        if off_list:
+            print(f"[terms] not in the {args.mode} list, running anyway: "
+                  f"{', '.join(off_list)}", file=sys.stderr)
+        terms = list(args.terms)
+        print(f"[terms] restricted to {len(terms)} of the {args.mode} list")
 
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     fallback_since = (datetime.now(timezone.utc) - timedelta(days=args.default_lookback_days)).strftime("%Y-%m-%d")
@@ -377,45 +402,72 @@ def main():
         writer.writerow(asdict(h))
         outf.flush()
 
+    # One log row appended per term, as soon as that term finishes -- not
+    # batched to the end. A ~100-term sweep runs for hours, and a container
+    # restart or a killed process partway through used to throw away the
+    # record of every term already done, so a rerun either redid them all or
+    # (worse) skipped them believing they were logged. Per-term rows make an
+    # interrupted sweep cost only the in-flight term: rerun the rest with
+    # --terms. Also why searched_for() is computed per term rather than once
+    # at the end.
+    def searched_for(term: str) -> list[str]:
+        """The sources that actually completed a search of `term`.
+
+        Two ways a source contributes nothing:
+          * hard-blocked for the whole run (WAF challenge etc.) -- blocked_sources()
+          * failed to complete this particular query (proxy down, timeout, 5xx,
+            malformed response) -- unsearched_sources(term)
+        Either way, claiming it in this term's sources= note would let
+        last_run_date() advance the --since watermark past a window nobody ever
+        searched: an invisible, permanent hole in coverage. Leaving it out means
+        the next run finds no covering row and falls back to the (always-safe,
+        only-ever-wider) default lookback.
+
+        The per-term half of this exists because of the 2026-09-02 full sweep:
+        the outbound proxy went down mid-run, every connector swallowed the
+        ProxyError as if it were "no more results", and 88 of 125 terms logged a
+        false "0 candidates; sources=<all 8>" -- advancing their watermark past
+        the 2026-06-04-to-now window for good, with 1,330 real candidates found
+        on the rerun. Nothing was blocked run-wide, so a whole-run check saw
+        nothing wrong. See BATCH_LOG.md.
+        """
+        skip = (blocked_sources() | unsearched_sources(term)) & set(args.sources)
+        return [s for s in args.sources if s not in skip]
+
+    starved = []
     for term, since in since_by_term.items():
         print(f"\n[term] {term!r} (since {since})", flush=True)
         discover([term], exclude, relevance_on=True, sources=active_sources,
                   on_hit=lambda h, term=term: on_hit(h, term), since=since)
+        searched = searched_for(term)
+        missing = sorted(set(args.sources) - set(searched))
+        if not searched:
+            starved.append(term)
+        miss_note = f"; not_searched={','.join(missing)}" if missing else ""
+        append_log_rows([{
+            "date": today,
+            "query": term,
+            "output_file": out_path,
+            "notes": f"monthly automated run; {hits_by_term[term]} candidates; "
+                     f"sources={','.join(searched)}; "
+                     f"since={since}{miss_note}{note_suffix}",
+        }])
 
     outf.close()
 
     total = sum(hits_by_term.values())
     print(f"\n{total} candidates found -> {out_path}")
+    print(f"Logged {len(since_by_term)} term rows to {LOG_PATH}")
 
-    # Only log the sources that were actually reachable. A source that hard-
-    # blocked (WAF challenge etc.) contributed nothing, so claiming it in the
-    # sources= note would let last_run_date() advance its --since past a window
-    # nobody ever searched -- an invisible, permanent hole in coverage. Leaving
-    # it out instead means the next run finds no covering row for it and falls
-    # back to the (always-safe, only-ever-wider) default lookback.
     blocked = blocked_sources() & set(args.sources)
-    searched = [s for s in args.sources if s not in blocked]
     if blocked:
         print(f"\n!! BLOCKED this run, NOT logged as searched: "
               f"{','.join(sorted(blocked))} -- their since-window is left "
               f"un-advanced so a later run re-covers it", file=sys.stderr, flush=True)
-    if not searched:
-        print("!! every requested source was blocked -- this run searched "
-              "nothing; the log rows record 0 sources so no watermark moves",
-              file=sys.stderr, flush=True)
-
-    blocked_note = f"; blocked={','.join(sorted(blocked))}" if blocked else ""
-    log_rows = [
-        {
-            "date": today,
-            "query": term,
-            "output_file": out_path,
-            "notes": f"monthly automated run; {n} candidates; sources={','.join(searched)}; since={since_by_term[term]}{blocked_note}",
-        }
-        for term, n in hits_by_term.items()
-    ]
-    append_log_rows(log_rows)
-    print(f"Logged {len(log_rows)} term rows to {LOG_PATH}")
+    if starved:
+        print(f"!! {len(starved)}/{len(terms)} term(s) had NO source complete a "
+              f"search; their rows record 0 sources so no watermark moves: "
+              f"{', '.join(starved)}", file=sys.stderr, flush=True)
 
 
 if __name__ == "__main__":

--- a/automated_finding/irw_discover_updated.py
+++ b/automated_finding/irw_discover_updated.py
@@ -56,7 +56,33 @@ class SourceBlocked(Exception):
     pass
 
 
+# Source connectors raise this when a query did NOT complete -- a proxy or
+# connection failure, a timeout, a 5xx, a malformed response. Distinct from
+# SourceBlocked in scope: a block is permanent for the run (stop asking), an
+# unavailability is per-query (the next term may well succeed), so discover()
+# keeps calling the source but records that THIS query never got an answer
+# from it.
+#
+# The reason this exists at all: every connector used to swallow these with a
+# bare `except Exception: print(...); return`, which ends the generator exactly
+# the way "no more results" does. Callers could not tell "searched, found
+# nothing" from "never actually searched", so irw_discover_monthly.py logged
+# `0 candidates` for a term whose sources were all unreachable and advanced its
+# --since watermark past a window nobody ever queried. That is a permanent,
+# invisible hole in coverage -- it cost the 2026-09-02 monthly sweep 88 of its
+# 125 terms when the outbound proxy went down mid-run (see BATCH_LOG.md), and
+# is the same failure shape as PR #1625. Anything that stops a connector short
+# is now raised, not printed: an incomplete search is never evidence of an
+# empty one.
+class SourceUnavailable(Exception):
+    pass
+
+
 _blocked_sources: set[str] = set()
+
+# {query: {short source name, ...}} -- sources that raised SourceUnavailable
+# (or were already blocked) while running that query, i.e. did not search it.
+_unsearched_by_query: dict[str, set[str]] = {}
 
 
 def blocked_sources() -> set[str]:
@@ -70,6 +96,17 @@ def blocked_sources() -> set[str]:
     window forever. See irw_discover_monthly.py's log rows for the consumer,
     and BATCH_LOG.md's 2026-08-17 entry for the run where this went wrong."""
     return {name.replace("from_", "", 1) for name in _blocked_sources}
+
+
+def unsearched_sources(query: str) -> set[str]:
+    """Short names of every source that failed to complete `query` in this
+    process -- transient transport failures plus any source already hard-
+    blocked when the query ran.
+
+    Same contract as blocked_sources(), but per-query: a caller writing down
+    what it searched for one term MUST subtract this, or an incremental
+    --since watermark will advance past a window that was never queried."""
+    return set(_unsearched_by_query.get(query, ()))
 
 # ---------------------------------------------------------------------------
 # RELEVANCE FILTER (tiered)
@@ -383,7 +420,7 @@ def from_dataverse(query: str, max_pages: int = 5, per: int = 50):
         except SourceBlocked:
             raise
         except Exception as e:
-            print(f"[dataverse] {e}", file=sys.stderr); return
+            raise SourceUnavailable(f"[dataverse] {e}") from e
         if not items:
             return
         for it in items:
@@ -406,7 +443,7 @@ def from_zenodo(query: str, max_pages: int = 5, per: int = 25):
             r.raise_for_status()
             hits = r.json().get("hits", {}).get("hits", [])
         except Exception as e:
-            print(f"[zenodo] {e}", file=sys.stderr); return
+            raise SourceUnavailable(f"[zenodo] {e}") from e
         if not hits:
             return
         for h in hits:
@@ -434,7 +471,7 @@ def from_osf(query: str, max_pages: int = 5, per: int = 50):
             r.raise_for_status()
             body = r.json()
         except Exception as e:
-            print(f"[osf] {e}", file=sys.stderr); return
+            raise SourceUnavailable(f"[osf] {e}") from e
         for node in body.get("data", []):
             a = node.get("attributes", {})
             yield Hit("osf", a.get("title", ""),
@@ -457,7 +494,7 @@ def from_dryad(query: str, max_pages: int = 5, per: int = 50):
             r.raise_for_status()
             sets = r.json().get("_embedded", {}).get("stash:datasets", [])
         except Exception as e:
-            print(f"[dryad] {e}", file=sys.stderr); return
+            raise SourceUnavailable(f"[dryad] {e}") from e
         if not sets:
             return
         for d in sets:
@@ -479,7 +516,7 @@ def from_figshare(query: str, max_pages: int = 5, per: int = 50):
             r.raise_for_status()
             arts = r.json()
         except Exception as e:
-            print(f"[figshare] {e}", file=sys.stderr); return
+            raise SourceUnavailable(f"[figshare] {e}") from e
         if not arts:
             return
         for a in arts:
@@ -500,7 +537,7 @@ def from_gesis(query: str, max_pages: int = 5, per: int = 25):
             data = r.json()
             hits = data.get("hits", {}).get("hits", [])
         except Exception as e:
-            print(f"[gesis] {e}", file=sys.stderr); return
+            raise SourceUnavailable(f"[gesis] {e}") from e
         if not hits:
             return
         for h in hits:
@@ -607,7 +644,7 @@ def from_datacite(query: str, max_pages: int = 5, per: int = 25):
             data = r.json()
             items = data.get("data", [])
         except Exception as e:
-            print(f"[datacite] {e}", file=sys.stderr); return
+            raise SourceUnavailable(f"[datacite] {e}") from e
         if not items:
             return
         for item in items:
@@ -664,14 +701,14 @@ def from_mendeley(query: str, max_pages: int = 5, per: int = 25):
             data = r.json()
             items = data.get("data", [])
         except Exception as e:
-            # Deliberately does NOT raise SourceBlocked, unlike the connectors
-            # that talk to a repository directly. This one's transport IS
-            # DataCite, so a hard block here blocks from_datacite too -- and
-            # _DATACITE_FALLBACK_FOR["mendeley"] would then be pointing the
-            # backfill at the very host that just failed. Print and return, as
-            # from_datacite does.
-            print(f"[mendeley] {e}", file=sys.stderr)
-            return
+            # Deliberately raises SourceUnavailable, not SourceBlocked, unlike
+            # the connectors that talk to a repository directly. This one's
+            # transport IS DataCite, so hard-blocking here would block
+            # from_datacite too -- and _DATACITE_FALLBACK_FOR["mendeley"] would
+            # then be pointing the backfill at the very host that just failed.
+            # Per-query is the right scope: the failure is recorded against
+            # this term without taking DataCite out of the run.
+            raise SourceUnavailable(f"[mendeley] {e}") from e
         if not items:
             return
         for item in items:
@@ -708,7 +745,7 @@ def _dataverse_connector(name: str, base_url: str):
                 data = r.json().get("data", {})
                 items = data.get("items", [])
             except Exception as e:
-                print(f"[{name}] {e}", file=sys.stderr); return
+                raise SourceUnavailable(f"[{name}] {e}") from e
             if not items:
                 return
             for it in items:
@@ -741,7 +778,7 @@ def from_openaire(query: str, max_pages: int = 5, per: int = 25):
             results = data.get("response", {}).get("results", {}).get("result", [])
             total = int(data.get("response", {}).get("header", {}).get("total", {}).get("$", 0))
         except Exception as e:
-            print(f"[openaire] {e}", file=sys.stderr); return
+            raise SourceUnavailable(f"[openaire] {e}") from e
         if not results:
             return
         for res in results:
@@ -1017,8 +1054,13 @@ def discover(queries, exclude: set, relevance_on: bool, sources=None,
         q_new = 0
         q_start = _time.time()
         print(f"[query {i}/{total}] {q}", flush=True)
+        unsearched = _unsearched_by_query.setdefault(q, set())
         for src in active:
+            short = src.__name__.replace("from_", "", 1)
             if src.__name__ in _blocked_sources:
+                # Blocked before this query even started: it did not search
+                # this term either, so it belongs in the per-query record.
+                unsearched.add(short)
                 continue
             src_new = 0
             try:
@@ -1047,14 +1089,27 @@ def discover(queries, exclude: set, relevance_on: bool, sources=None,
                         on_hit(hit)
             except SourceBlocked as e:
                 _blocked_sources.add(src.__name__)
+                unsearched.add(short)
                 print(f"  [{src.__name__:20}] BLOCKED, skipping for rest "
                       f"of run -- {e}", file=sys.stderr, flush=True)
+                continue
+            except SourceUnavailable as e:
+                # Did not complete this query. Keep the source in the run --
+                # the next term may succeed -- but never let this term be
+                # written down as searched by it.
+                unsearched.add(short)
+                print(f"  [{src.__name__:20}] UNAVAILABLE for this query, "
+                      f"NOT counted as searched -- {e}",
+                      file=sys.stderr, flush=True)
                 continue
             if src_new:
                 print(f"  [{src.__name__:20}] +{src_new}", flush=True)
         elapsed = _time.time() - t0
+        searched_n = len(active) - len(unsearched)
+        note = (f" | !! {searched_n}/{len(active)} sources actually searched, "
+                f"unsearched: {','.join(sorted(unsearched))}") if unsearched else ""
         print(f"  → {q_new} new this query | {len(results)} total | "
-              f"{elapsed:.0f}s elapsed", flush=True)
+              f"{elapsed:.0f}s elapsed{note}", flush=True)
     if n_unreachable:
         print(f"[discover] dropped {n_unreachable} hit(s) from repositories no "
               f"connector can fetch files from "


### PR DESCRIPTION
Every source connector in `irw_discover_updated.py` ended a *failed* query the same way it ends a *finished* one:

```python
except Exception as e:
    print(f"[zenodo] {e}", file=sys.stderr); return
```

A generator that returns early is indistinguishable from one that ran out of results. So `discover()` could not tell "searched, found nothing" from "never actually searched" — and `irw_discover_monthly.py` wrote that difference into a watermark: `0 candidates; sources=<all 8>`, which `last_run_date()` reads on the next run as proof the window is covered.

That is what happened to the 2026-09-02 monthly sweep (#1843). The outbound proxy went down mid-run, all 8 connectors swallowed the `ProxyError`, and 88 of 125 terms logged a false zero — silently retiring the 2026-06-04-to-now window for them. The honest rerun in 9a11fbb found 1,998 candidates in it. Same shape as PR #1625; third occurrence of the class.

## What changes

- **`SourceUnavailable`** — the per-query sibling of `SourceBlocked`. Connectors raise it instead of returning, on anything that stops them short. A block is permanent for the run; an unavailability is per-query, so `discover()` keeps calling the source and only records that *this* query got no answer from it (`unsearched_sources(q)`).
- **`irw_discover_monthly.py` subtracts both** `blocked_sources()` and `unsearched_sources(term)` **per term**, naming what it skipped under `not_searched=`. A term nothing reached logs `sources=` empty, so no watermark moves and a later run re-covers it.
- **Log rows append per term as each finishes**, not batched at the end. A ~100-term sweep runs for hours; a container restart partway through used to discard the record of every term already done. This is the durable version of the throwaway wrapper 9a11fbb had to write.
- **`--terms`** restricts a run to a subset (for re-covering a window an earlier run lost); **`--note`** annotates its log rows.

## Verification

- All 10 connectors raise `SourceUnavailable` on a `ProxyError` — including figshare, which uses `requests.post` rather than `get`.
- A source that fails one term is still queried on the next.
- End-to-end against a fake source set: the healthy term advances the watermark; the term whose source failed, and the term where a source hard-blocked, both log `sources=` without it, so `last_run_date()` returns `None` for the full source set and the next run falls back to the wider lookback.

No overlapping files with #1843.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfEKLuDXLvd6QNB5jULugj