### PR TITLE
auto-tag: the publication gate, a cache that survives concurrency, and three rules (#1704)

### DIFF
--- a/tags/.claude/skills/irw-auto-tag/SKILL.md
+++ b/tags/.claude/skills/irw-auto-tag/SKILL.md
@@ -151,6 +151,8 @@ paywall on — not the fetch failing.** Those are different findings:
 | `OK ... content=repository_metadata:N_chars_visible` | **A catalogue record, not a paper** — the deposit's own title, description, keywords and file list, reached through the repository's API because its web page answers a bot challenge | Read it, but tag only what it actually says. It will usually support `construct_name` and sometimes `construct type`; it almost never states a sample or an age range, and vocab.md's rule against inferring those still binds |
 | `UNREACHABLE oa_status=closed` | No open copy exists | Stage `Notes = "cannot fully access due to paywall"` |
 | `UNREACHABLE oa_status=gold\|green\|hybrid\|bronze\|diamond` | An open copy **exists** and something else blocked us — a WAF, a captcha, a JS-only page, a dead link | **Not a paywall.** Stage `Notes = "no working link"`, and it is worth reporting: these are fixable |
+| `UNREACHABLE oa_status=not_checked` | **No DOI**, so OpenAlex was never asked, and the URL refused us — typically a government or institutional data portal answering 403 | **Not a paywall**, and you cannot show it is one: with no DOI there is no open-access status to appeal to. Stage `Notes = "no working link"` |
+| `OK ... content=low_prose_density:N_sentences_per_1k:M_chars_visible` | Long, blocker-free, and **probably furniture** — a CMS or JavaScript shell whose visible text is menus and metadata rather than the work | **Read it before trusting it.** Tag only what the text actually states; if it turns out to be chrome, treat it as `no working link` rather than tagging from the surrounding page |
 
 **Data repositories are asked through their APIs** (#1786). Their web pages
 serve a challenge or a JavaScript shell — Dataverse returns HTTP 202 with a
@@ -222,6 +224,30 @@ live-sheet half.
 
 Open a pull request with the new rows in `tags/tags_auto.csv`. **Merging is the
 accept** — no pasting, and nothing to confirm afterwards.
+
+### Columns publish per column, against a measured bar
+
+**Staging a value is not deciding to publish it.** Every column this skill fills
+is held to a per-atom precision bar — currently 90% — measured against the human
+gold set by `tags/scoring/`, and a column that has not cleared it is written by
+the tagger, kept in the predictions for later measurement, and **blanked before
+the rows are staged**. Selection is an act performed at assembly, deliberately
+and once, not something each tagging run decides for itself.
+
+As of 2026-09-03 that means `primary language(s)`, `item format`, `measurement
+tool` and the SETTING facet of `sample` publish; `construct type` and
+`sample`'s FRAME facet do not. Those two are not broken — they are measured, and
+they are under the bar: on the 2026-09-03 comparison `construct type` scored
+50.0% per-atom precision and the frame facet 57.1%.
+
+Do not read the current list off this paragraph and assume it is live. **Quote
+`tags/scoring/` and the most recent results file**, the way `status.json` rather
+than prose is what you quote for coverage.
+
+The gate has earned itself once already: #1802 withheld 44 of 60 `primary
+language(s)` rows after four agents disclosed, unprompted, that they had
+inferred the language from the study's *country* — the move the `age range`
+rule forbids and which `vocab.md` had never addressed for language.
 
 Since #1723 the file is unioned into `tags.csv` by `03_tags.R`, with three rules
 worth knowing:

--- a/tags/.claude/skills/irw-auto-tag/references/vocab.md
+++ b/tags/.claude/skills/irw-auto-tag/references/vocab.md
@@ -260,6 +260,22 @@ differently-ordered existing row as a discrepancy.
 - `Mixed`
 - `Slider/continuous`
 
+**`Likert Scale/selected response` is not only for five-point agreement
+scales.** The value names two things, and the second half is the general case:
+*any* item where the respondent picks from options the instrument supplies. So
+it covers a binary yes/no or done/not-done checklist, a 0–2 or 0–3 severity
+scale, a multiple-choice test item, and a true/false item, none of which is a
+Likert scale in the strict sense.
+
+Recorded 2026-09-03 because three raters in the two-path comparison hit exactly
+these cases — a 15-item binary OSCE checklist, a 0–3 HADS, a 0–2 attitude scale
+— reached the same answer, and each flagged it as an unsanctioned guess. It was
+the right answer; the vocabulary just never said so.
+
+`Constructed Response` is the contrast: the respondent supplies the answer
+rather than choosing it. `Mixed` is for an instrument that genuinely does both,
+not for one whose scale has an unusual number of points.
+
 ## Item text available? (single-select)
 
 - `Yes`

--- a/tags/.claude/skills/irw-auto-tag/scripts/fetch_source.py
+++ b/tags/.claude/skills/irw-auto-tag/scripts/fetch_source.py
@@ -38,6 +38,7 @@ Cache lives in ../.cache/ next to this scripts/ dir, one file per table --
 gitignored, not committed (see tags/.gitignore).
 """
 import argparse
+import os
 import io
 import json
 import re
@@ -50,7 +51,18 @@ import requests
 # OpenAlex asks for a contact address in the UA and gives faster, more
 # reliable service to requests that carry one ("the polite pool").
 UA = {"User-Agent": "irw-auto-tag/2.0 (research; ben.domingue@gmail.com)"}
-CACHE_DIR = Path(__file__).resolve().parent.parent / ".cache"
+# One cache per run when asked for one. Concurrent taggers share this directory
+# by default, and it has no locking: during the 2026-09-03 two-path comparison
+# two agents reported files appearing that they had not fetched, and one watched
+# its own entry vanish between fetching it and reading it, because another agent
+# had --force'd the same table. Both worked around it by hand.
+#
+# `--cache-dir`, or IRW_TAG_CACHE, gives a run its own namespace so that cannot
+# happen. The default is unchanged, so a single-agent run keeps sharing the
+# cache across sessions -- which is the point of it: a paywalled or rate-limited
+# source is not re-hit on every retry.
+CACHE_DIR = Path(os.environ.get("IRW_TAG_CACHE") or
+                 (Path(__file__).resolve().parent.parent / ".cache"))
 OPENALEX = "https://api.openalex.org/works/doi:{}"
 EPMC_SEARCH = ("https://www.ebi.ac.uk/europepmc/webservices/rest/search"
                "?query=DOI:%22{}%22&format=json&resultType=core")
@@ -94,6 +106,25 @@ BLOCKER_MARKERS = (
 def cache_path(table):
     safe = "".join(c if c.isalnum() or c in "-_." else "_" for c in table.lower())
     return CACHE_DIR / f"{safe}.txt"
+
+
+def write_cache(path, text):
+    """Write the cache entry so a concurrent reader never sees half of it.
+
+    `Path.write_text` truncates the file and then fills it, so a reader that
+    opens it in between gets an empty or partial file and reads it as the
+    source. Writing to a unique temporary in the same directory and then
+    os.replace()-ing it over the target makes the swap atomic: a reader holds
+    either the whole old entry or the whole new one, never a torn one.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(f".{os.getpid()}.tmp")
+    try:
+        tmp.write_text(text, encoding="utf-8", errors="replace")
+        os.replace(tmp, path)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
 
 
 def openalex_locations(doi):
@@ -176,6 +207,36 @@ def is_the_right_work(text, doi, title):
     return False, "wrong_work:doi_and_title_absent"
 
 
+# A page can be long, blocker-free, and still be furniture. Spain's CIS
+# barometer pages return ~16kB of visible Liferay/React menu text with the
+# survey itself loaded client-side; they clear MIN_USEFUL_CHARS and trip no
+# BLOCKER_MARKERS, and three independent raters in the 2026-09-03 two-path
+# comparison mistook them for reachable sources before reading them.
+#
+# What separates chrome from prose is not length but SENTENCE DENSITY. Menu
+# labels and JSON-LD fragments are not sentences. Measured over the 101 cached
+# pages with >=8000 chars of prose, every CIS page falls between 1.48 and 1.77
+# sentences per 1000 characters, the next page up is 3.36, and real articles run
+# 3.7-7.8. The threshold sits in that gap.
+#
+# This WARNS, it does not reject. The failure it catches is rare in the corpus
+# that still needs tagging -- of the 1,427 untagged tables, 543 are PLOS and
+# ~400 are the four repositories #1789 routed through APIs, and none is a
+# government CMS -- so rejecting on a heuristic would risk turning usable
+# fetches into failures to prevent a problem the reader can already see once
+# told to look. The reason string is what tells them to look.
+LOW_DENSITY_MIN_CHARS = 8000
+LOW_DENSITY_PER_1K = 2.5
+
+
+def sentence_density(prose):
+    """Sentences per 1000 characters. A sentence is >=8 words before a stop."""
+    if not prose:
+        return 0.0
+    n = sum(1 for seg in re.split(r"[.!?]+", prose) if len(seg.split()) >= 8)
+    return 1000.0 * n / len(prose)
+
+
 def classify(text):
     """Is this the source, or something standing in front of it?
 
@@ -188,6 +249,10 @@ def classify(text):
             return False, f"blocker:{marker.replace(' ', '_')}"
     if len(prose) < MIN_USEFUL_CHARS:
         return False, f"too_short:{len(prose)}_chars_visible"
+    density = sentence_density(prose)
+    if len(prose) >= LOW_DENSITY_MIN_CHARS and density < LOW_DENSITY_PER_1K:
+        return True, (f"low_prose_density:{density:.2f}_sentences_per_1k:"
+                      f"{len(prose)}_chars_visible")
     return True, f"{len(prose)}_chars_visible"
 
 
@@ -511,6 +576,10 @@ def main():
     ap.add_argument("--doi")
     ap.add_argument("--url")
     ap.add_argument("--force", action="store_true")
+    ap.add_argument("--cache-dir",
+                    help="write the cache here instead of ../.cache. Give each "
+                         "agent in a concurrent run its own, or they will "
+                         "--force over one another's entries.")
     ap.add_argument("--no-oa", action="store_true",
                     help="skip the OpenAlex lookup and resolve the DOI directly")
     args = ap.parse_args()
@@ -532,6 +601,9 @@ def main():
                 break
         args.doi = d
 
+    global CACHE_DIR
+    if args.cache_dir:
+        CACHE_DIR = Path(args.cache_dir)
     path = cache_path(args.table)
     if path.exists() and not args.force:
         print(f"CACHED {path} ({path.stat().st_size} bytes)")
@@ -576,8 +648,7 @@ def main():
             if ok:
                 ok, reason = is_the_right_work(text, args.doi, title)
             if ok:
-                CACHE_DIR.mkdir(exist_ok=True)
-                path.write_text(text, encoding="utf-8", errors="replace")
+                write_cache(path, text)
                 print(f"OK oa_status={oa_status} source={source} "
                       f"final_url={source} content={reason} attempts=1 -> {path}")
                 return
@@ -594,8 +665,7 @@ def main():
         if got is None:
             continue
         text, final_url = got
-        CACHE_DIR.mkdir(exist_ok=True)
-        path.write_text(text, encoding="utf-8", errors="replace")
+        write_cache(path, text)
         print(f"OK oa_status={oa_status} source={url} final_url={final_url} "
               f"content={reason} attempts={len(attempted)} -> {path}")
         return
@@ -609,8 +679,7 @@ def main():
     if repo_text:
         prose = visible_text(repo_text)
         if len(prose) >= MIN_METADATA_CHARS:
-            CACHE_DIR.mkdir(exist_ok=True)
-            path.write_text(repo_text, encoding="utf-8", errors="replace")
+            write_cache(path, repo_text)
             print(f"OK oa_status={oa_status} source={repo_source} "
                   f"final_url={repo_source} "
                   f"content=repository_metadata:{len(prose)}_chars_visible "

--- a/tags/decisions/1704_workplace_setting_atom.md
+++ b/tags/decisions/1704_workplace_setting_atom.md
@@ -1,0 +1,123 @@
+# Proposed: a `Workplace` atom for `sample`'s SETTING facet
+
+**Status: PROPOSED, not ruled. Nothing in `vocab.md` or `TAG_VOCAB` has been
+changed.** Put to Ben 2026-09-03. Written in the form #1760 established — the
+case as it was put, so the answer's basis stays legible later.
+
+Raised by the two-path comparison (#1704). It is P6's first clause, split out
+because a vocabulary change is a different kind of decision from a
+documentation fix, and every previous one — #1760, #1837 — was ruled
+separately.
+
+---
+
+## The gap
+
+#1760 split `sample` into two facets. SETTING answers *how were these people
+reached*; FRAME answers *how broad was the sampling*. Under #1704 only SETTING
+publishes.
+
+SETTING has five atoms: `Educational`, `Clinical`, `Program-based`,
+`Internet-based`, `Non-human`. **There is no atom for a workplace.** A study
+that recruits hotel frontline staff through their employer, or nurses through a
+hospital's nursing service, or teachers through a school district, has a real
+and nameable recruitment channel, and the vocabulary cannot express it.
+
+The rater then has three options and all of them are bad:
+
+1. **Leave SETTING blank.** A false abstention on a *published* column — the
+   tagger knew the answer and had nowhere to put it. This is what happened on
+   `song_2025_sb` in the comparison run.
+2. **Reach for `Targeted/specific`.** This is the common failure and it is
+   worse, because that is a FRAME value answering a different question. A study
+   can recruit through a workplace *and* impose no restriction beyond it, which
+   under the #1796 amendment makes it `General/non-specific`.
+3. **Reach for `Educational` or `Clinical`** because the workplace happens to be
+   a school or a hospital. That silently reclassifies the study as being about
+   students or patients when its respondents are staff.
+
+## What the corpus already does about it
+
+Measured 2026-09-03 against the Data Dictionary, matching descriptions and
+references on occupational keywords (`employee`, `worker`, `nurse`, `teacher`,
+`staff`, `burnout`, `job satisfaction`, `occupational`, …). **This is a keyword
+proxy and an upper bound** — "teachers" recruited *as learners* in a training
+study is legitimately `Educational`, and the regex cannot tell.
+
+| | tables |
+|---|---|
+| occupational-looking, in the 1,427 untagged | **249** (17%) |
+| occupational-looking, already tagged | 169 |
+
+And what the 169 already-tagged ones say for `sample` today:
+
+| value | tables |
+|---|---|
+| blank / `NA` | **97** |
+| `Targeted/specific` | **48** |
+| `Educational` | 23 |
+| `Educational, Internet-based` | 10 |
+| everything else | ≤4 each |
+
+**That distribution is the argument.** Ninety-seven blanks and forty-eight
+frame-values-standing-in-for-a-setting is not a distribution of opinions; it is
+the shape of raters working around a missing category, and they worked around it
+in two different directions. The 23 `Educational` rows are the ambiguous middle
+the keyword proxy cannot resolve and a rule would have to.
+
+## The proposal
+
+Add `Workplace` to the SETTING facet, with this boundary:
+
+> `Workplace` — respondents were reached **through their employer, their
+> occupation, or a professional body**: an organisation's staff, a licensed
+> profession, a union or professional register, a company panel.
+>
+> It describes the *channel*, not a restriction. Recruiting a hospital's nurses
+> is `Workplace`; recruiting *nurses who have worked night shifts for five
+> years* is `Workplace` plus a FRAME of `Targeted/specific`. The #1796
+> amendment governs the frame half unchanged.
+>
+> Where the respondents are the institution's **clients** rather than its
+> staff — students at a school, patients at a clinic — the existing atom
+> applies and `Workplace` does not. A study of teachers is `Workplace`; a study
+> of their pupils is `Educational`. A study that samples both takes both.
+
+## Why this is lower-risk than it looks
+
+**Adding an enum value is additive.** It invalidates nothing: all 2,257 rows
+carrying a `sample` value keep exactly the value they have, and `tag_normalize.R`
+enforces membership, not completeness. Only new tagging can use it.
+
+The corollary is that adding it **does not by itself fix the 97 blanks and 48
+frame-substitutions above** — those are existing tags, and correcting existing
+tags is out of scope under the 2026-09-03 ruling. The value of the atom is
+forward: 249 untagged tables, 17% of the remaining work, get a setting they can
+express instead of a blank or a wrong-facet answer.
+
+## The case against, put fairly
+
+- **Six atoms is a bigger vocabulary to hold a boundary against.** `Workplace`
+  and `Program-based` touch where the employer *is* the intervention, and
+  `Workplace` and `Educational` touch on school staff. The rule above draws
+  both lines, but it is one more line to get wrong.
+- **It creates a visible inconsistency.** New tagging says `Workplace` where 48
+  published rows say `Targeted/specific` for the same situation, and nothing is
+  authorised to reconcile them. The column gets more correct and less uniform at
+  the same time.
+- **The 249 is a keyword proxy.** The true count is lower, and nobody has read
+  a sample of them to find out how much lower.
+- **It was measured on one confirmed sighting.** `song_2025_sb`, in a
+  forty-table run. The corpus-level numbers above are inference from how other
+  raters behaved, not from raters saying they were stuck.
+
+## The question
+
+1. Add `Workplace` to the SETTING facet with the boundary above?
+2. If yes — does anything happen to the 48 `Targeted/specific` and 97 blank
+   rows, or do they stay as they are under the "do not correct existing tags"
+   ruling?
+
+A "no" is a perfectly good answer, and the cost of it is known: roughly 249
+tables keep producing a blank on a published column, and it stays legible in
+`Status`/`Reason` as of #1859.

--- a/tags/scoring/README.md
+++ b/tags/scoring/README.md
@@ -1,6 +1,27 @@
 # Auto-tagger scoring (issue #1721, sub-action 2.2)
 
 Scores the `irw-auto-tag` skill against the gold set, per column.
+
+**What that claim rests on, since it is easy to over-read** (established
+2026-09-03, #1704). The agents that produced every `preds_*.json` here
+demonstrably ran the skill's scripts and obeyed its vocabulary: 60 of 60 tables
+in the w5 pilot carry a `fetch_source.py` cache entry, and across all 402
+prediction rows every value in all six controlled columns sits inside
+`vocab.md`'s enums, with none outside. The skill's own files also cite these
+runs as measurements *of themselves* and were amended in response — the
+repository-API fix, the frame-facet amendment, `SKILL.md` twice.
+
+What is **not** established is that any agent was handed `SKILL.md` verbatim.
+No dispatch prompt for any historical run exists anywhere in git. So "scores the
+skill" is well-evidenced at the level of scripts and vocabulary, and unverified
+at the level of instructions. See `tags/decisions/1704_two_tagging_paths.md`.
+
+One thing follows for anyone running a new scoring batch: **a scored run skips
+the skill's Step 1 entirely.** Everything Step 1 consults holds the answers the
+run is being marked against. `SKILL.md` now says so; before 2026-09-03 it did
+not, and every scoring run had suppressed that step without any document
+recording it.
+
 Predictions were produced 2026-08-30. Reproduce with:
 
 ```bash


### PR DESCRIPTION
**P1, P4, P5, P6 (documentation half) and P8** from `tags/decisions/1704_two_tagging_paths.md`, all ruled by Ben on 2026-09-03. P2 and P3 went in as #1859.

P6's **workplace atom is deliberately not here** — it is a vocabulary change, and those get their own decision record and their own ruling, as #1760 and #1837 did. The case is written up in `tags/decisions/1704_workplace_setting_atom.md` and awaits an answer.

## P1 — publication is per column, against a measured bar

`SKILL.md` Step 6 previously ended at "open a pull request" with no mention that a column can be written and then withheld. It now says that every column is held to a per-atom precision bar, that a column under the bar is written by the tagger and **blanked before staging**, and that selection is an act performed once at assembly rather than decided per run. It names the current split but tells the reader to quote `tags/scoring/` rather than the paragraph — the same discipline as quoting `status.json` rather than prose for coverage.

## P5 — the cache stops eating itself under concurrency

`fetch_source.py` takes `--cache-dir`, or `IRW_TAG_CACHE`. During the 2026-09-03 comparison two agents reported files appearing that they had not fetched, and one watched its own entry vanish between fetching it and reading it, because another agent had `--force`d the same table. Both worked around it by hand.

Cache writes also go through a temp-and-`os.replace` now: `write_text` truncates before it fills, so a reader arriving in the gap got a partial file and read it as the source.

The default path is unchanged, so a single-agent run still shares the cache across sessions — which is the point of it: a paywalled or rate-limited source is not re-hit on every retry.

## P4 — a page can be long, blocker-free, and still be furniture

Spain's CIS barometer pages return ~16kB of *visible* Liferay menu text with the survey loaded client-side. They clear `MIN_USEFUL_CHARS`, trip no `BLOCKER_MARKERS`, and three independent raters took them for reachable sources before reading them.

What separates chrome from prose is not length but **sentence density**. Measured across the 101 cached pages with ≥8000 chars of visible prose:

| | sentences per 1k chars |
|---|---|
| every CIS page (9 of them) | **1.48 – 1.77** |
| next page up | 3.36 |
| real articles | 3.7 – 7.8 |

The threshold sits in that gap at 2.5, and short pages are exempt — a repository record is legitimately short.

**It warns rather than rejects, deliberately.** Of the 1,427 tables still needing tags, 543 are PLOS and ~400 are the four repositories #1789 routed through APIs; **not one is a government CMS**. Rejecting on a heuristic would risk turning usable fetches into failures, to prevent a failure nearly absent from the work that remains. The reason string tells the reader to look, which is all they needed.

## P6 — two rules that were being followed without being written

- **A no-DOI URL answering 403** now has a row in Step 3's outcome table. With no DOI there is no open-access status to appeal to, so it cannot be shown to be a paywall however much it looks like one. Three agents defaulted it to `no working link` and none could cite a rule.
- **`Likert Scale/selected response` covers any item where the respondent picks from supplied options** — a binary yes/no checklist, a 0–3 severity scale, a multiple-choice item. Three raters reached that answer independently on a 15-item OSCE checklist, a HADS and a 0–2 attitude scale, and all three flagged it as an unsanctioned guess. It was the right answer; the vocabulary never said so.

## P8 — the README says what is established

The opening claim is replaced by the evidence for it: the agents demonstrably ran the skill's scripts (60/60 w5 pilot tables carry a `fetch_source.py` cache entry) and obeyed its vocabulary (402 prediction rows, zero values outside the enums) — while **no dispatch prompt for any historical run exists in git**, so the claim is unverified at the level of instructions.

## Also filed

#1864 — the `celik_2026_*` dictionary defect (P7), plus the general question it raises: should the tagger abstain when the dictionary contradicts the source?

## Verification

- `Rscript tests/test_tags_union.R` — all pass.
- Cache routing verified both ways (env var hits a warm cache, `--cache-dir` on an empty dir is a real miss); atomic write leaves no temp files.
- Density classifier checked against 213 real cached pages; flags 9 CIS pages plus one other, no article.
- No published tag changed. Nothing staged, nothing uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAN8FrQsfVqz2yhSbDJ1R9