### PR TITLE
tags: a Workplace setting atom, and a rule for when the dictionary is wrong (#1704)

### DIFF
--- a/metadata/tag_normalize.R
+++ b/metadata/tag_normalize.R
@@ -30,9 +30,14 @@
 ##but they are combinations, not values). Anything outside these lists is a
 ##typo or a new value that needs a deliberate decision, so it stops the run.
 TAG_VOCAB <- list(
+    ##`Workplace` added 2026-09-03 (#1704). A SETTING atom: it names the
+    ##channel people were reached through, so it does not displace the frame
+    ##residual and is not listed in FRAME_SPECIFIC below. Adding a value is
+    ##additive -- every row already carrying a `sample` keeps it.
     "sample" = c(
         "Clinical", "Educational", "General/non-specific", "Internet-based",
-        "NA", "Non-human", "Program-based", "Representative", "Targeted/specific"
+        "NA", "Non-human", "Program-based", "Representative",
+        "Targeted/specific", "Workplace"
     ),
     "construct type" = c(
         "Affective/mental health", "Behavioral", "Cognitive/educational",

--- a/tags/.claude/skills/irw-auto-tag/SKILL.md
+++ b/tags/.claude/skills/irw-auto-tag/SKILL.md
@@ -131,6 +131,14 @@ and stage a row with every field blank except `table`, `Rater`, and
 package docs, OSF pages without a DOI, etc.) — don't require a DOI to
 proceed.
 
+**The dictionary can be wrong, and it is wrong in a specific way.** A row can
+point at a real, on-topic source whose sample size matches exactly, while naming
+an instrument that source never mentions (#1864). When Step 3's text and this
+description disagree about *which instrument the table is*, do not pick a
+winner — see "When the dictionary and the source disagree" in `vocab.md`. The
+short version: leave `construct_name` and `construct type` blank, tag the
+population and format fields from the source, and say so in `Notes`.
+
 ## Step 3 — Fetch the source text
 
 ```bash

--- a/tags/.claude/skills/irw-auto-tag/references/vocab.md
+++ b/tags/.claude/skills/irw-auto-tag/references/vocab.md
@@ -119,6 +119,7 @@ old form until there is a service account to change it (#1708).
 - `Targeted/specific`
 - `Representative`
 - `Non-human`
+- `Workplace` — added 2026-09-03 (#1704)
 
 **These eight values are two facets, not one (decided 2026-09-01, #1760).**
 
@@ -126,8 +127,32 @@ old form until there is a service account to change it (#1708).
 university or course), `Clinical` (through a health-care setting, or by
 diagnosis or treatment status), `Program-based` (through the specific
 intervention or cohort the study is about), `Internet-based` (an online panel or
-crowdwork platform), `Non-human` (mutually exclusive with everything). **These
+crowdwork platform), `Workplace` (through an employer, an occupation, or a
+professional body), `Non-human` (mutually exclusive with everything). **These
 combine freely** — `Clinical, Educational, Internet-based` is coherent.
+
+**`Workplace` (decided 2026-09-03, #1704).** Respondents were reached through
+their employer, their occupation, or a professional body: an organisation's
+staff, a licensed profession, a union or professional register, a company panel.
+
+It names the *channel*, not a restriction. Recruiting a hospital's nurses is
+`Workplace`; recruiting *nurses who have worked night shifts for five years* is
+`Workplace` plus a FRAME of `Targeted/specific`, and the #1796 amendment governs
+that half unchanged.
+
+**Staff, not clients.** Where the respondents are the institution's clients
+rather than the people who work there, the existing atom applies and `Workplace`
+does not: a study of teachers is `Workplace`, a study of their pupils is
+`Educational`, a study that samples both takes both. Same for a hospital's
+nurses (`Workplace`) against its patients (`Clinical`).
+
+Why it exists: the facet previously had no atom for a workplace, so raters
+either left a published column blank or reached for `Targeted/specific`, which
+answers the other facet. Of 169 already-tagged tables that look occupational, 97
+were blank and 48 said `Targeted/specific` — the shape of raters working around
+a missing category in two directions. **Those existing rows are not being
+corrected**; the atom is for new tagging. See
+`tags/decisions/1704_workplace_setting_atom.md`.
 
 *Frame — how broad was the sampling?*
 
@@ -195,6 +220,40 @@ respondents:
 
 Record what the respondents read. If an instrument went out in more than one
 language, list them all (`eng, vie`).
+
+## When the dictionary and the source disagree (decided 2026-09-03, #1704)
+
+Sometimes the fetched source is plainly a real, on-topic work whose numbers
+match the dictionary — and it describes a **different instrument** from the one
+the table name and the dictionary description claim. `celik_2026_bpns` fetches a
+Mendeley record with the dictionary's exact n of 653, describing an attitude
+scale and the Big Five Inventory, in which the string "BPNS" appears zero times.
+
+**Split the row by what the disagreement actually touches.**
+
+| field | what to do | why |
+|---|---|---|
+| `construct_name`, `construct type` | **leave blank** | These name the instrument, which is exactly what is in dispute. There is no evidence for either candidate over the other |
+| `sample`, `age range`, `child age`, `item format`, `measurement tool`, `primary language(s)` | **tag them from the source** | These describe the population and the administration, and those hold whichever instrument the table turns out to be |
+
+Record the contradiction in `Notes`, naming what the source actually describes.
+
+This is a real split, not a compromise: a mislabelled dictionary row is worse
+for tagging than a missing one, because a missing row makes the tagger abstain
+while a wrong one makes it *confidently* tag an instrument the table may not
+contain — and nothing downstream can tell the difference. But the sample was
+still recruited however the source says it was.
+
+**Do not resolve it by preferring one side.** Neither the dictionary nor the
+source is authoritative here: the dictionary is a human-maintained sheet with
+known defects (#1864), and the source can be the right paper carrying a wrong
+description. If you can tell which is right — the source names the instrument
+somewhere, or describes a battery the table is plainly one scale of — then there
+is no contradiction and this rule does not apply.
+
+**Report it.** A contradiction is a dictionary defect and it is fixable; the
+whole `celik_2026_*` family turned out to share one. Two agents found the same
+defect independently in a forty-table run, which is what made it visible at all.
 
 ## Construct type (multi-select, comma-separated)
 

--- a/tags/decisions/1704_dictionary_source_contradiction.md
+++ b/tags/decisions/1704_dictionary_source_contradiction.md
@@ -1,0 +1,101 @@
+# Decision: when the dictionary and the source disagree
+
+**Status: ACCEPTED by Ben, 2026-09-03.** In force in
+`references/vocab.md`, with a pointer from `SKILL.md` Step 2. Written in the
+form #1760 established — the case as it was put, so the answer's basis stays
+legible later.
+
+Raised by the two-path comparison (#1704), P7's general clause. The specific
+dictionary defect that surfaced it is filed separately as #1864.
+
+---
+
+## The situation
+
+The fetched source is a real work, plainly on topic, and its numbers match the
+dictionary exactly — and it describes a **different instrument** from the one
+the table name and the dictionary description claim.
+
+`celik_2026_bpns` is the clean case. The dictionary's Mendeley URL fetches a
+deposit of Turkish undergraduates, n=653, which is the dictionary's own n. The
+deposit carries an Attitude Scale toward Distance Learning and the Big Five
+Inventory. The string "BPNS" appears **zero times**, and neither does "basic
+psychological need". Two agents, one in each arm, grepped for it independently
+before concluding.
+
+`sumner_2022_asi` is the softer case and shows why a blanket rule is needed:
+the dictionary says a 29-item Aberrant Salience Inventory with ~929
+respondents, the supplied DOI resolves to a paper about a Formal Thought
+Disorder scale, and the sample sizes match closely (324+610=934). Two agents
+read that one in opposite directions.
+
+## Why it needed a rule
+
+Four agents hit this shape in a forty-table run and each decided alone:
+
+| what they did | agents |
+|---|---|
+| abstained on the instrument fields, tagged the rest | 2 |
+| tagged from the fetched source | 1 |
+| tagged from the dictionary description | 1 |
+
+That is not a distribution of judgement, it is a missing convention — the same
+diagnosis #1760 made about `sample` and #1837 about `construct type`.
+
+## The decision
+
+**Split the row by what the disagreement actually touches.**
+
+| field | ruling |
+|---|---|
+| `construct_name`, `construct type` | **blank** — these name the instrument, which is what is in dispute |
+| `sample`, `age range`, `child age`, `item format`, `measurement tool`, `primary language(s)` | **tag from the source** |
+
+Record the contradiction in `Notes`, naming what the source actually describes.
+
+Two clauses guard it:
+
+- **Do not resolve it by preferring one side.** Neither is authoritative. The
+  dictionary is a human-maintained sheet with known defects; a source can be the
+  right paper carrying a wrong description. Where you *can* tell which is right
+  — the source names the instrument somewhere, or describes a battery the table
+  is plainly one scale of — there is no contradiction and the rule does not
+  apply.
+- **Report it.** A contradiction is a fixable dictionary defect. The whole
+  `celik_2026_*` family turned out to share one, and it only became visible
+  because two independent agents wrote it down.
+
+## The argument for the split
+
+A mislabelled dictionary row is worse for tagging than a missing one. A missing
+row makes the tagger abstain; a wrong one makes it **confidently** tag an
+instrument the table may not contain, under a table name that says otherwise,
+and nothing downstream can tell the difference — the row looks exactly like a
+correct one.
+
+But that argument only reaches the fields that name the instrument. However the
+dispute resolves, the respondents were recruited the way the source says they
+were, in the language the source says, on the response format the source shows.
+Blanking those too would throw away evidence nobody disputes, and it would cost
+coverage on three of the four columns that actually publish.
+
+## What was rejected, and why
+
+- **Tag from the source, note the conflict.** The majority behaviour would then
+  be to assert an instrument the table may not contain. The `Notes` field is not
+  read by anything downstream, so the assertion would publish unqualified.
+- **Abstain entirely and flag the row.** Safest, and it was rejected on cost:
+  `primary language(s)`, `item format` and `measurement tool` all publish, all
+  are supported by the source regardless of the dispute, and the untagged
+  population is 1,427 tables. Throwing away three publishable columns to avoid
+  one wrong instrument name is a bad trade.
+
+## What this does not settle
+
+- **How often it happens.** Four sightings in forty tables is not a rate; the
+  denominator is tables where an agent thought to check, and nothing prompts
+  them to.
+- **Whether the tagger reliably notices.** Both `celik` sightings involved an
+  agent grepping the fetched text for the instrument name. Nothing in `SKILL.md`
+  tells them to, and this decision does not add it — a detection step is a
+  separate change with its own cost.

--- a/tags/decisions/1704_workplace_setting_atom.md
+++ b/tags/decisions/1704_workplace_setting_atom.md
@@ -1,8 +1,10 @@
-# Proposed: a `Workplace` atom for `sample`'s SETTING facet
+# A `Workplace` atom for `sample`'s SETTING facet
 
-**Status: PROPOSED, not ruled. Nothing in `vocab.md` or `TAG_VOCAB` has been
-changed.** Put to Ben 2026-09-03. Written in the form #1760 established — the
-case as it was put, so the answer's basis stays legible later.
+**Status: ACCEPTED by Ben, 2026-09-03. Question 1 yes, question 2 no.** The atom
+is in `vocab.md` and `TAG_VOCAB`; the 48 `Targeted/specific` rows and the 97
+blanks are **left as they are**, under the 2026-09-03 ruling that correcting
+existing tags is out of scope. The case below is preserved as it was put, in the
+form #1760 established, so the answer's basis stays legible later.
 
 Raised by the two-path comparison (#1704). It is P6's first clause, split out
 because a vocabulary change is a different kind of decision from a
@@ -111,13 +113,15 @@ express instead of a blank or a wrong-facet answer.
   forty-table run. The corpus-level numbers above are inference from how other
   raters behaved, not from raters saying they were stuck.
 
-## The question
+## The question, and the answer
 
-1. Add `Workplace` to the SETTING facet with the boundary above?
-2. If yes — does anything happen to the 48 `Targeted/specific` and 97 blank
-   rows, or do they stay as they are under the "do not correct existing tags"
-   ruling?
+1. **Add `Workplace` to the SETTING facet with the boundary above? — Yes.**
+2. **Does anything happen to the 48 `Targeted/specific` and 97 blank rows? —
+   No.** They stay. The atom is forward-looking: it is for the ~249 untagged
+   tables, not a licence to revisit published ones.
 
-A "no" is a perfectly good answer, and the cost of it is known: roughly 249
-tables keep producing a blank on a published column, and it stays legible in
-`Status`/`Reason` as of #1859.
+The known consequence of (2), recorded so nobody rediscovers it as a bug: for a
+while the column will carry both conventions. New tagging says `Workplace` where
+48 published rows say `Targeted/specific` for the same situation. That is the
+column getting more correct and less uniform at once, and it was accepted
+deliberately.


### PR DESCRIPTION
Both decisions ruled by Ben on 2026-09-03, with records in `tags/decisions/`.

## `Workplace`, a sixth SETTING atom

The facet had no value for people reached through their employer. A rater either left a **published** column blank or reached for `Targeted/specific`, which answers the FRAME facet — a different question.

The evidence is what the corpus already does. Of 169 already-tagged tables that look occupational:

| value | tables |
|---|---|
| blank / `NA` | **97** |
| `Targeted/specific` | **48** |
| `Educational` | 23 |

Not a distribution of opinions — the shape of raters working around a missing category, in two directions at once.

**The boundary is the channel, not a restriction.** A hospital's nurses are `Workplace`; nurses screened for five years of night shifts are `Workplace` *plus* a frame of `Targeted/specific`. **And staff, not clients:** teachers are `Workplace`, their pupils are `Educational`, a study sampling both takes both.

**Forward-only.** The 48 and the 97 stay as they are, under the ruling that correcting existing tags is out of scope. The cost is written into the decision file rather than left to be rediscovered as a bug: for a while the column carries both conventions, getting more correct and less uniform at once. It affects ~249 of the 1,427 untagged tables.

Being a setting atom it does not displace the frame residual, so `Workplace, General/non-specific` survives normalisation intact — which is the right reading: reached through an employer, no restricted frame.

## When the dictionary and the source disagree

A dictionary row can point at a real, on-topic source whose n matches exactly, while naming an instrument that source never mentions. `celik_2026_bpns` fetches a deposit carrying the dictionary's own n of 653, describing an attitude scale and the BFI, in which "BPNS" appears **zero times**.

Four agents hit this shape in forty tables and each decided alone — two abstained on the instrument fields, one tagged from the source, one from the dictionary. A missing convention, diagnosed the way #1760 diagnosed `sample`.

**The row is split by what the disagreement touches:**

| field | ruling |
|---|---|
| `construct_name`, `construct type` | **blank** — they name the instrument, which is what is in dispute |
| `sample`, `age range`, `child age`, `item format`, `measurement tool`, `primary language(s)` | **tag from the source** |

Three of the four columns that publish are in the second group, and they hold whichever instrument the table turns out to be — blanking them would throw away evidence nobody disputes. Neither side is authoritative and neither wins by default; where you *can* tell which is right, there is no contradiction and the rule does not apply.

The decision file records what it does not settle: nobody knows how often this happens, and nothing tells the tagger to check. Both `celik` sightings involved an agent grepping the fetched text on its own initiative.

Related: #1864 (the dictionary defect itself).

## Verification

- `Rscript tests/test_tags_union.R` — all pass.
- `Workplace` normalises correctly alone and in every combination; `Workplace, General/non-specific` is preserved, `Workplace, Targeted/specific` is preserved.
- A value outside the vocabulary still halts the pipeline.
- No published tag changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAN8FrQsfVqz2yhSbDJ1R9