### PR TITLE
tags: correct the sample-setting fill — a comma ate 19 rows (#1704)

### DIFF
--- a/tags/scoring/results_calibration_2026-09-03.txt
+++ b/tags/scoring/results_calibration_2026-09-03.txt
@@ -1,7 +1,7 @@
 # w3/w4 calibration, 2026-09-03 (#1704). seed=1704, 150 tables, six blind agents, Sonnet.
-# First run under the rules added 2026-09-03: the Workplace setting atom, the
-# dictionary/source contradiction rule, P4's low_prose_density warning, and
-# P5's per-agent caches. Measurement mode: SKILL.md Step 1 skipped.
+# CORRECTED: the first scoring split `Internet-based (Mturkers, etc)` on its
+# internal comma and dropped it, understating sample-setting fill in BOTH arms.
+# Setting fill is 84.0% (w3/w4) and 51.7% (w5 baseline), not 71.3% and 46.7%.
 
 
 === baseline predictions_pilot_w5: 60 tables ===
@@ -18,7 +18,7 @@ per-column fill, of ALL sampled tables (not of those reached)
 column                      ?      ALL
 primary_languages       73.3%    73.3%
 item_format             83.3%    83.3%
-sample_setting          46.7%    46.7%
+sample_setting          51.7%    51.7%
 measurement_tool       100.0%   100.0%
   ------------------------------------   (held, not published)
 construct_type          81.7%    81.7%
@@ -46,7 +46,7 @@ per-column fill, of ALL sampled tables (not of those reached)
 column                     w3       w4      ALL
 primary_languages       93.8%    91.8%    92.7%
 item_format             93.8%    94.1%    94.0%
-sample_setting          84.6%    61.2%    71.3%
+sample_setting          95.4%    75.3%    84.0%
 measurement_tool       100.0%    97.6%    98.7%
   ---------------------------------------------   (held, not published)
 construct_type          95.4%    94.1%    94.7%
@@ -62,7 +62,3 @@ by batch -- an outlier here is one agent, not one shard
   preds_calib_C4  25 tables   reached 100.0%
   preds_calib_C5  25 tables   reached 100.0%
   preds_calib_C6  25 tables   reached 100.0%
-
-WARNING -- `sample` values outside vocab.md's eight atoms, counted in neither facet:
-  'Internet-based (Mturkers'
-  'etc)'

--- a/tags/scoring/score_calibration.py
+++ b/tags/scoring/score_calibration.py
@@ -44,12 +44,29 @@ UNKNOWN_ATOMS = set()
 
 
 def facets(sample_value):
-    """Split a `sample` cell into (setting atoms, frame atoms)."""
+    """Split a `sample` cell into (setting atoms, frame atoms).
+
+    `Internet-based (Mturkers, etc)` contains a literal comma, so a naive split
+    on commas yields `Internet-based (Mturkers` and `etc)` -- neither of which
+    matches any atom, so BOTH are dropped and the row is counted as having no
+    setting at all. That understated setting fill by 19 rows in 150 here, and
+    it is the same comma that vocab.md records as having spawned three separate
+    workarounds elsewhere in the codebase. Rejoin before matching.
+    """
     atoms = [a.strip() for a in (sample_value or "").split(",") if a.strip()]
-    UNKNOWN_ATOMS.update(a for a in atoms
+    fixed, i = [], 0
+    while i < len(atoms):
+        if atoms[i] == "Internet-based (Mturkers" and i + 1 < len(atoms) \
+                and atoms[i + 1] == "etc)":
+            fixed.append("Internet-based (Mturkers, etc)")
+            i += 2
+        else:
+            fixed.append(atoms[i])
+            i += 1
+    UNKNOWN_ATOMS.update(a for a in fixed
                          if a not in FRAME_ATOMS and a not in SETTING_ATOMS)
-    return ([a for a in atoms if a in SETTING_ATOMS],
-            [a for a in atoms if a in FRAME_ATOMS])
+    return ([a for a in fixed if a in SETTING_ATOMS],
+            [a for a in fixed if a in FRAME_ATOMS])
 
 
 def load(paths):

--- a/tags/scoring/stage_batch.py
+++ b/tags/scoring/stage_batch.py
@@ -1,0 +1,133 @@
+"""Stage a blind run's predictions into tags_auto.csv, publishing four columns.
+
+**Publishing is an act of selection made here, at assembly — not by the agents.**
+The agents fill every field they can support. This script decides what leaves
+`tags/scoring/`, and it blanks the rest before a single row is staged.
+
+Published, having cleared the >=90% per-atom precision bar against the human
+gold set (#1704):
+
+    primary language(s) · item format · measurement tool · sample SETTING facet
+
+Withheld, written by the agents and kept in the predictions for later
+measurement: `construct type` (50.0% per-atom precision on the 2026-09-03
+comparison) and `sample`'s FRAME facet (57.1%). Also withheld: `age range` and
+`child age`, which the `cov_age` derivation owns and outranks the Sheet on
+(#1760, decision 7), and `construct name`, which is not one of the four.
+
+Splitting `sample` is the fiddly part and the reason this is a script rather
+than a spreadsheet gesture: one column carries two facets, and only one of them
+publishes. `Workplace, Targeted/specific` stages as `Workplace`.
+
+Abstentions are staged too, as sentinel rows carrying `table`, `Rater`, `Notes`,
+`Status` and `Reason` and nothing else. `03_tags.R` drops them at the union so
+they never reach the published table — but they stay here, and that file plus
+the Sheet is what stops the tagger re-attempting a dead source forever.
+
+    python3 stage_batch.py preds_calib_C*.json            # dry run, prints only
+    python3 stage_batch.py --commit preds_calib_C*.json   # actually stages
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+STAGE = HERE.parent / ".claude/skills/irw-auto-tag/scripts/stage_tag_row.py"
+AUTO = HERE.parent / "tags_auto.csv"
+
+PUBLISH = ["primary_languages", "item_format", "measurement_tool"]  # plus sample setting
+WITHHOLD = ["construct_type", "age_range", "child_age", "construct_name"]
+
+FRAME_ATOMS = {"Representative", "Targeted/specific", "General/non-specific"}
+SETTING_ATOMS = {"Educational", "Clinical", "Program-based", "Non-human",
+                 "Workplace", "Internet-based", "Internet-based (Mturkers, etc)"}
+
+
+def setting_only(sample):
+    """Keep the SETTING atoms, drop the FRAME ones. Unknown atoms are dropped
+    loudly rather than passed through -- TAG_VOCAB would halt the pipeline on
+    them, and finding that out at staging time is cheaper than at export."""
+    atoms = [a.strip() for a in (sample or "").split(",") if a.strip()]
+    fixed, i = [], 0
+    while i < len(atoms):                      # rejoin the value with a comma in it
+        if atoms[i] == "Internet-based (Mturkers" and i + 1 < len(atoms):
+            fixed.append("Internet-based (Mturkers, etc)"); i += 2
+        else:
+            fixed.append(atoms[i]); i += 1
+    keep, unknown = [], []
+    for a in fixed:
+        if a in SETTING_ATOMS:
+            keep.append(a)
+        elif a not in FRAME_ATOMS:
+            unknown.append(a)
+    return ", ".join(keep), unknown
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("preds", nargs="+")
+    ap.add_argument("--commit", action="store_true")
+    args = ap.parse_args()
+
+    rows = []
+    for p in args.preds:
+        rows += json.loads(Path(p).read_text())
+
+    payloads, unknown_all, tally = [], [], Counter()
+    for r in rows:
+        setting, unknown = setting_only(r.get("sample"))
+        unknown_all += [(r["table"], u) for u in unknown]
+        if r.get("status") != "tagged":
+            payloads.append({"table": r["table"], "notes": r.get("notes") or "",
+                             "status": "abstained",
+                             "reason": r.get("reason") or r.get("notes") or ""})
+            tally["sentinel"] += 1
+            continue
+        pay = {"table": r["table"], "sample": setting, "status": "tagged",
+               "notes": r.get("notes") or ""}
+        for f in PUBLISH:
+            pay[f] = (r.get(f) or "").strip()
+        for f in PUBLISH + ["sample"]:
+            if pay.get(f):
+                tally[f] += 1
+        if not any(pay.get(f) for f in PUBLISH + ["sample"]):
+            tally["nothing_publishable"] += 1
+        payloads.append(pay)
+
+    print(f"{len(rows)} predictions -> {len(payloads)} rows to stage\n")
+    print("what publishes, per column:")
+    for f in PUBLISH + ["sample"]:
+        print(f"  {f:<20}{tally[f]:>4} of {len(rows)}  ({100*tally[f]/len(rows):.1f}%)")
+    print(f"\n  sentinel (abstention) rows      {tally['sentinel']:>4}")
+    print(f"  tagged but nothing publishable  {tally['nothing_publishable']:>4}"
+          "   (staged blank; the withheld columns carried their content)")
+    print("\nwithheld from every row: " + ", ".join(WITHHOLD) + ", sample FRAME facet")
+
+    if unknown_all:
+        print(f"\nREFUSING: {len(unknown_all)} `sample` atom(s) outside vocab.md.")
+        for t, u in unknown_all[:10]:
+            print(f"   {t}: {u!r}")
+        sys.exit(1)
+
+    if not args.commit:
+        print("\ndry run. pass --commit to stage.")
+        return
+
+    staged = failed = 0
+    for pay in payloads:
+        r = subprocess.run([sys.executable, str(STAGE)], input=json.dumps(pay),
+                           capture_output=True, text=True)
+        if r.returncode:
+            failed += 1
+            print(f"  FAILED {pay['table']}: {r.stdout.strip()} {r.stderr.strip()}")
+        else:
+            staged += 1
+    print(f"\nstaged {staged}, failed {failed} -> {AUTO}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-up to #1872, which merged with a wrong figure in its results file.

## The bug

`sample`'s SETTING fill was too low in **both** arms. The cause is the comma inside `Internet-based (Mturkers, etc)`: splitting the cell on commas yields `Internet-based (Mturkers` and `etc)`, neither of which matches any atom, so both are dropped and the row is counted as having no setting at all.

| | #1872 said | correct |
|---|---|---|
| setting fill, w3/w4 | 71.3% | **84.0%** (126 of 150; 32 rows carry the value) |
| setting fill, w5 baseline | 46.7% | **51.7%** (31 of 60) |

`vocab.md` records that this literal comma spawned three separate workarounds — a 34-line parser in `Rpkg`, a tilde-swap in `irw_site`, and nothing at all in `Python-pkg`, where filtering on the value silently matched no tables. This is the fourth. The rejoin now sits in the scorer with the reason written beside it.

## The validation was circular, and worth saying plainly

I validated `score_calibration.py` against #1802 by reproducing its published 28/60 exactly, and treated the match as evidence of correctness. It was agreement on a **shared bug** — #1802's figure was the naive count too.

## It cost real coverage

`chen_2026_il`, `chen_2026_ai` and `chen_2026_bi` produced `Internet-based` in the w5 pilot, were dropped at staging by the same split, and are **published today with `sample=NA`**.

**Not repaired here.** Correcting published tags is out of scope under the 2026-09-03 ruling, and this is Ben's call rather than a tidy-up. It is the one case where the stated exception might apply, since it fell directly out of making the tagger better rather than out of going looking. Three tables, one column.

## Also in this PR

`stage_batch.py`, which performs the selection #1704 describes: `primary language(s)`, `item format`, `measurement tool` and `sample`'s SETTING facet are staged; `construct type`, the FRAME facet, `age range`, `child age` and `construct name` are blanked before a single row is written.

It **refuses to stage** rather than pass through an atom outside `vocab.md`, and it carries the same rejoin — the split is exactly where this bug would reappear, and staging is where it would do damage rather than merely misreport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAN8FrQsfVqz2yhSbDJ1R9