### PR TITLE
red_up: validate against the target, not before one is chosen (#1703)

### DIFF
--- a/red_up/checks.py
+++ b/red_up/checks.py
@@ -122,21 +122,43 @@ def run_validator(path: Path) -> tuple[list[str], list[str]]:
             [f"{f.check}: {f.message}" for f in report.warnings])
 
 
+def validate_for_target(report: FileReport, target: Target,
+                        enabled: bool = True) -> None:
+    """Run the full IRW format validator, where the target expects that format.
+
+    This has to happen HERE, next to check_schema, and not in check_all --
+    which is the bug that made every `irw_meta` upload a no-op between
+    2026-09-02 and 2026-09-03. `irw_validate` enforces `id`/`item`/`resp`, so
+    it is a check about the destination's schema, and check_all runs before a
+    destination has been chosen. Metadata tables have no such columns and are
+    exempt by design; run from check_all, the validator failed all thirteen of
+    them and red_up reported "nothing here belongs in irw_meta".
+
+    One rule, one place: a target with no required columns is a target whose
+    tables have no common schema, so there is nothing for a format validator to
+    say about them. That is the same condition check_schema returns early on.
+    """
+    if not enabled or not required_columns(target):
+        return
+    if report.errors:
+        return                # a file that is not a table yet is not worth validating
+    errors, warnings = run_validator(report.path)
+    report.errors.extend(errors)
+    report.warnings.extend(warnings)
+
+
 def check_all(pairs: list[tuple[Path, str]]) -> list[FileReport]:
     """Scan every file, and flag names that collide within the batch itself.
+
+    Deliberately target-blind: it runs before the destination is chosen, so
+    every check here must hold for any destination. Anything that depends on
+    where the file is going belongs in check_schema or validate_for_target.
 
     Two files with the same stem in different subdirectories would upload one
     after the other into the same table name, and the second would silently
     win. That is a batch-assembly mistake, so it is an error, not a warning.
     """
     reports = [scan(path, table) for path, table in pairs]
-
-    for report in reports:
-        if report.errors:
-            continue          # a file that is not a table yet is not worth validating
-        errors, warnings = run_validator(report.path)
-        report.errors.extend(errors)
-        report.warnings.extend(warnings)
 
     seen: dict[str, list[FileReport]] = {}
     for report in reports:

--- a/red_up/cli.py
+++ b/red_up/cli.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 from . import plan as planning
 from .auth import authenticate
-from .checks import check_all, check_schema
+from .checks import check_all, check_schema, validate_for_target
 from .discover import Discovery, discover, table_name
 from .push import open_draft, push_one
 from .targets import ConfigError, Target, guess_target, load_registry
@@ -152,6 +152,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--allow-unregistered", action="store_true",
                         help="permit --dataset to name a dataset that is not in "
                              "redivis_config.R (scratch/test datasets only)")
+    parser.add_argument("--no-validate", action="store_true",
+                        help="skip the IRW format validator (the one check that "
+                             "needs pandas). checks.py has pointed at this flag "
+                             "since 2026-09-02; it did not exist until 2026-09-03")
     parser.add_argument("--strict", action="store_true",
                         help="treat warnings as errors and upload nothing")
     args = parser.parse_args(argv)
@@ -210,6 +214,7 @@ def main(argv: list[str] | None = None) -> int:
 
     for report in reports:
         check_schema(report, target)
+        validate_for_target(report, target, enabled=not args.no_validate)
 
     authenticate()
 
@@ -239,9 +244,22 @@ def main(argv: list[str] | None = None) -> int:
     if not live:
         die(f"nothing here belongs in {target.name} -- every file was excluded "
             f"or skipped for the reason shown above.")
+    # A file with errors is a SKIP; a file the target does not take is EXCLUDED.
+    # Only the first is a failure -- excluding `provenance.csv` from irw_meta is
+    # the design working. The all-skipped case already exits non-zero via die()
+    # above; this covers the PARTIAL one, where twelve tables upload, the
+    # thirteenth silently does not, and the run still reports success.
+    skipped = [i for i in items if i.status == planning.SKIP]
+    if skipped:
+        print(f"\n{len(skipped)} file(s) skipped for errors and will NOT be "
+              f"uploaded:", file=sys.stderr)
+        for item in skipped:
+            for err in item.report.errors:
+                print(f"  {item.table}: {err}", file=sys.stderr)
+
     if args.dry_run:
         print(f"\n--dry-run: {len(live)} table(s) would be uploaded. Nothing was written.")
-        return 0
+        return 1 if skipped else 0
 
     if ask(f"\nUpload {len(live)} table(s)? [y/N] ", "yn", "y" if args.yes else "n",
            args.yes) != "y":
@@ -272,7 +290,7 @@ def main(argv: list[str] | None = None) -> int:
     if failed:
         return 1
     print("\nThese are DRAFT versions. Review the diff on Redivis and publish by hand.")
-    return 0
+    return 1 if skipped else 0
 
 
 if __name__ == "__main__":

--- a/red_up/tests/test_red_up.py
+++ b/red_up/tests/test_red_up.py
@@ -15,7 +15,7 @@ import unittest
 from pathlib import Path
 
 from red_up import plan as planning
-from red_up.checks import check_all, check_schema, scan
+from red_up.checks import check_all, check_schema, scan, validate_for_target
 from red_up.discover import discover, table_name
 from red_up.targets import (
     ConfigError,
@@ -323,7 +323,18 @@ def test_drafts_reports_no_draft(monkeypatch):
 # --- the format-validator gate (#1703 sub-item 1.4) --------------------------
 
 class ValidatorGate(unittest.TestCase):
-    """red_up refuses a table the format validator blocks."""
+    """red_up refuses a table the format validator blocks.
+
+    The validator runs against a TARGET, not against a file in the abstract:
+    it enforces id/item/resp, which is a statement about where the file is
+    going. These tests therefore go through `validate_for_target` with a
+    response target, the way cli.py does, rather than through `check_all`,
+    which runs before a target has been chosen. See MetadataIsExemptFrom
+    Validation below for why that distinction is load-bearing.
+    """
+
+    RESPONSE = Target(name="item_response_warehouse_5", label="response data",
+                      kind="core")
 
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
@@ -334,9 +345,14 @@ class ValidatorGate(unittest.TestCase):
         path.write_text(body)
         return path
 
+    def _check(self, path, table, target=None):
+        report, = check_all([(path, table)])
+        validate_for_target(report, target or self.RESPONSE)
+        return report
+
     def test_a_broken_table_is_blocked(self):
         path = self._csv("broken_2024_scale.csv", "id,item,resp\n1,a,x\n2,b,y\n3,c,z\n")
-        report, = check_all([(path, "broken_2024_scale")])
+        report = self._check(path, "broken_2024_scale")
         self.assertFalse(report.ok)
         self.assertTrue(any("resp_numeric" in e for e in report.errors), report.errors)
 
@@ -344,16 +360,40 @@ class ValidatorGate(unittest.TestCase):
         rows = "\n".join(f"{i},q{j},{(i + j) % 5 + 1}"
                          for i in range(1, 40) for j in range(1, 5))
         path = self._csv("ok_2024_scale.csv", "id,item,resp\n" + rows + "\n")
-        report, = check_all([(path, "ok_2024_scale")])
+        report = self._check(path, "ok_2024_scale")
         self.assertTrue(report.ok, report.errors)
 
     def test_a_cov_age_sentinel_warns_without_blocking(self):
         rows = "\n".join(f"{i},q{j},{(i + j) % 5 + 1},{999 if i == 1 else 40}"
                          for i in range(1, 40) for j in range(1, 5))
         path = self._csv("sentinel_2024_scale.csv", "id,item,resp,cov_age\n" + rows + "\n")
-        report, = check_all([(path, "sentinel_2024_scale")])
+        report = self._check(path, "sentinel_2024_scale")
         self.assertTrue(report.ok, "an already-live defect must not block (#1779)")
         self.assertTrue(any("cov_range" in w for w in report.warnings), report.warnings)
+
+    def test_metadata_is_exempt_from_the_format_validator(self):
+        """The regression that made every irw_meta upload a no-op (#1703).
+
+        `irw_validate` enforces id/item/resp. Metadata tables have none of
+        them and are exempt by design -- REQUIRED_COLUMNS["meta"] is empty.
+        Between 2026-09-02 and 2026-09-03 the validator ran from `check_all`,
+        before a target existed, so it failed all thirteen of them and red_up
+        reported "nothing here belongs in irw_meta" while uploading zero rows.
+        """
+        meta = Target(name="irw_meta", label="metadata tables", kind="aux",
+                      source="meta")
+        path = self._csv("tags.csv",
+                         "table,age range,sample\nfoo_2024,Adult (18+),Educational\n")
+        report = self._check(path, "tags", target=meta)
+        self.assertTrue(report.ok, report.errors)
+        self.assertEqual([], report.errors)
+
+    def test_a_target_with_required_columns_is_still_validated(self):
+        """The exemption must not become a hole: response data still gets it."""
+        path = self._csv("broken_2024_scale.csv",
+                         "id,item,resp\n1,a,x\n2,b,y\n3,c,z\n")
+        report = self._check(path, "broken_2024_scale")
+        self.assertFalse(report.ok, "response data must still be validated")
 
     def test_a_missing_validator_blocks_rather_than_passes(self):
         import red_up.checks as checks_mod


### PR DESCRIPTION
**Every `irw_meta` upload has been a no-op since 2026-09-02.** `upload_meta.py --dry-run` reports all thirteen tables SKIPped for *"missing required columns: id, item, resp"* and exits `nothing here belongs in irw_meta`. Nobody had hit it — #1802's upload died earlier, on the absent draft version — so it surfaced only when the #1704 tagging batch needed to go up.

## The bug

`red_up` validates in two stages, and the split is right:

| stage | call | knows the target? |
|---|---|---|
| scan | `check_all(...)` — `cli.py:180` | **no** |
| schema | `check_schema(report, target)` — `cli.py:212` | yes |

Metadata is **already exempt** in the second: `REQUIRED_COLUMNS["meta"]` is empty, and `targets.py` says why — *`irw_meta` holds thirteen pipeline outputs that each have their own schema, so membership in that fixed list is the gate there, not a column set.*

`run_validator` was wired into the **first** stage. It enforces `id`/`item`/`resp`, which is a statement about the destination — so it could not honour an exemption that is a property of the destination. Not a missing `if`: **a target-specific check placed where no target exists yet.**

## The fix

It moves to `validate_for_target`, called beside `check_schema`, returning early on the same condition: a target with no required columns is a target whose tables share no schema, so a format validator has nothing to say about them. One rule, one place. **`irw_validate` is untouched.**

The exemption is scoped to targets that declare no required columns, so it can't become a hole — response data is still validated, and there's a test in each direction.

## Also, both as asked

**`--no-validate` now exists.** `checks.py` has been telling users to pass it since 2026-09-02 (*"install pandas, or pass `--no-validate` to upload without a format check"*) — the flag was never added, so the documented escape hatch from a missing-pandas failure was unrunnable.

**A partial skip now exits non-zero.** The all-skipped case already exited 2 via `die()`, and an upload failure returned 1 — but twelve tables uploading while the thirteenth was skipped for errors returned **0**, with the skip as one line in a table. Skipped files and their errors now go to stderr and the exit is 1. `EXCLUDED` is untouched and stays quiet: excluding `provenance.csv` from `irw_meta` is the design working, not a failure.

## Verification

- `irw_meta`: **0 → 13 tables uploadable**, exit 0, non-metadata files still correctly `EXCLUDED` rather than `SKIP`.
- A response shard with one good and one bad file: plans the good one, prints the bad one's error to stderr, **exits 1** (previously 0).
- `pytest red_up/tests/` — **48 pass**, including two new regression tests: metadata is exempt, and a target with required columns still gets validated.
- The two existing `ValidatorGate` tests were asserting the old placement (they went through `check_all` and expected the validator to have run); they now go through the new seam.

Nothing was uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAN8FrQsfVqz2yhSbDJ1R9