### PR TITLE
fetch_source: the low-density warning was computed and thrown away (#1704)

### DIFF
--- a/tags/.claude/skills/irw-auto-tag/SKILL.md
+++ b/tags/.claude/skills/irw-auto-tag/SKILL.md
@@ -162,6 +162,24 @@ paywall on — not the fetch failing.** Those are different findings:
 | `UNREACHABLE oa_status=not_checked` | **No DOI**, so OpenAlex was never asked, and the URL refused us — typically a government or institutional data portal answering 403 | **Not a paywall**, and you cannot show it is one: with no DOI there is no open-access status to appeal to. Stage `Notes = "no working link"` |
 | `OK ... content=low_prose_density:N_sentences_per_1k:M_chars_visible` | Long, blocker-free, and **probably furniture** — a CMS or JavaScript shell whose visible text is menus and metadata rather than the work | **Read it before trusting it.** Tag only what the text actually states; if it turns out to be chrome, treat it as `no working link` rather than tagging from the surrounding page |
 
+**What the `content=` string is actually saying.** It carries an *identity*
+verdict, and sometimes a *content* warning appended after a `+`. The identity
+half answers "is this the work we asked for":
+
+| `content=` | meaning |
+|---|---|
+| `doi_in_text` | the requested DOI appears in the fetched text — this is the right work |
+| `title_in_text` | the title matches instead. Same conclusion, weaker evidence |
+| `identity_unchecked` | **no DOI and no title to check against**, so nothing was verified. Normal for a `--url`-only fetch at a data portal, and the case to read most sceptically |
+| `N_chars_visible` | no identity check applied; N characters of visible prose |
+| `repository_metadata:N_chars_visible` | a catalogue record, held to a lower floor — see the row above |
+
+Anything after a `+` is a warning about the content itself, currently only
+`low_prose_density`. So `doi_in_text+low_prose_density:1.6_sentences_per_1k:…`
+means *this is provably the right work, and the page is still mostly furniture*
+— which happens on publisher landing pages that name the article and show none
+of it.
+
 **Data repositories are asked through their APIs** (#1786). Their web pages
 serve a challenge or a JavaScript shell — Dataverse returns HTTP 202 with a
 zero-byte body regardless of user agent, and every OSF project page is the same

--- a/tags/.claude/skills/irw-auto-tag/scripts/fetch_source.py
+++ b/tags/.claude/skills/irw-auto-tag/scripts/fetch_source.py
@@ -237,6 +237,26 @@ def sentence_density(prose):
     return 1000.0 * n / len(prose)
 
 
+def merge_reasons(identity, content):
+    """Combine the identity verdict with the content verdict.
+
+    These answer different questions -- `is_the_right_work` says WHICH work this
+    is, `classify` says whether the page is readable prose -- and both can be
+    worth saying at once. The caller used to get only the identity string,
+    because `reason` was reassigned before it was returned, which silently threw
+    away the low-density warning added for #1704: it is computed, it is correct,
+    and it never once reached the output. Found on 2026-09-03 when a tagging
+    agent asked what `content=doi_in_text` meant and there was no answer,
+    because that label had displaced everything else.
+
+    Only the warning is carried through. An ordinary `N_chars_visible` adds
+    nothing to `doi_in_text` and would just make the line noisier.
+    """
+    if content.startswith("low_prose_density"):
+        return f"{identity}+{content}"
+    return identity
+
+
 def classify(text):
     """Is this the source, or something standing in front of it?
 
@@ -561,13 +581,13 @@ def try_url(url, doi=None, title=None):
     if r.status_code != 200:
         return None, f"http_{r.status_code}"
     text = extract(r)
-    ok, reason = classify(text)
+    ok, content = classify(text)
     if not ok:
-        return None, reason
-    ok, reason = is_the_right_work(text, doi, title)
+        return None, content
+    ok, identity = is_the_right_work(text, doi, title)
     if not ok:
-        return None, reason
-    return (text, r.url), reason
+        return None, identity
+    return (text, r.url), merge_reasons(identity, content)
 
 
 def main():
@@ -644,9 +664,11 @@ def main():
         got = europepmc_fulltext(args.doi)
         if got:
             text, source = got
-            ok, reason = classify(text)
+            ok, content = classify(text)
+            reason = content
             if ok:
-                ok, reason = is_the_right_work(text, args.doi, title)
+                ok, identity = is_the_right_work(text, args.doi, title)
+                reason = merge_reasons(identity, content) if ok else identity
             if ok:
                 write_cache(path, text)
                 print(f"OK oa_status={oa_status} source={source} "


### PR DESCRIPTION
P4 added a sentence-density check so a long CMS or JavaScript shell — 16kB of Liferay menu text, no blocker markers, clears `MIN_USEFUL_CHARS` — is flagged rather than mistaken for the source. **The check works. Its output never reached anybody.**

## The bug

`try_url` reassigned `reason` before returning it:

```python
ok, reason = classify(text)          # may be "low_prose_density:..."
if not ok: return None, reason
ok, reason = is_the_right_work(...)  # overwrites it
if not ok: return None, reason
return (text, r.url), reason         # identity verdict only
```

Low density deliberately returns `ok=True`, so that string is **unreachable on the success path**. Every caller has seen `doi_in_text` or `identity_unchecked` instead, for as long as the check has existed. The Europe PMC branch in `main()` had the same shape.

**This is my bug**, and worth saying how it got in: I verified `classify()` in isolation, confirmed it separated all nine cached CIS pages from every real article, and never checked that the string reached the CLI. *A unit that returns the right value and a program that prints it are different claims.*

## How it surfaced

A tagging agent asked what `content=doi_in_text` meant — and couldn't find out. `SKILL.md`'s Step 3 table documents outcomes the code no longer emits on that path, and says nothing about the identity labels that displaced them.

## The fix

Merge the two verdicts instead of letting one overwrite the other. They answer different questions — *which work is this* and *is the page readable prose* — and both can be true at once:

```
doi_in_text+low_prose_density:1.6_sentences_per_1k:16569_chars_visible
```

…is a publisher landing page that provably names the article and shows none of it. Only the warning is carried through; an ordinary char count adds nothing to `doi_in_text` and would only make the line noisier.

## Documentation

Step 3's table now says what `content=` actually reports:

| `content=` | meaning |
|---|---|
| `doi_in_text` | the requested DOI appears in the text — right work |
| `title_in_text` | title matched instead; same conclusion, weaker evidence |
| `identity_unchecked` | **no DOI and no title to check against** — nothing was verified |
| `N_chars_visible` | no identity check applied |
| `repository_metadata:N_chars_visible` | a catalogue record, lower floor |

`identity_unchecked` is called out as the one to read most sceptically: it is the ordinary state of a `--url`-only fetch at a data portal, which is exactly where the shells live.

## Verification

- All four merge combinations checked, including the real CIS text end-to-end.
- `pytest red_up/tests/` — 51 pass. `Rscript tests/test_tags_union.R` — pass.
- No behaviour change to what is fetched or cached; only what the reason string reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAN8FrQsfVqz2yhSbDJ1R9