### PR TITLE
itemtext: give the round runner a standing PR to main

### DIFF
--- a/itemtext/extraction_batches/HANDOFF.md
+++ b/itemtext/extraction_batches/HANDOFF.md
@@ -13,6 +13,7 @@ narrative is in `round_log.md` under batch_016, batch_017 and batch_018.
 | worktree | `/home/ben/irw-queue-runner` — **use this, not `src`** (the old `/home/ben/irw-queue` is retired: 36 commits behind, stale cap) |
 | branch | `itemtext/queue-rounds` (pushed; the wrapper merges `origin/main` in before each round) |
 | runner | `itemtext/extraction_batches/round_cron.sh`, hourly at `:13` from the user crontab |
+| review | a **standing PR** from `itemtext/queue-rounds` → `main`, opened by the runner and left open; rounds accumulate into it |
 | staged for upload | `itemtext/itemtables/clean/` |
 | protocol the cron reads | `itemtext/extraction_batches/round_prompt_v1.md` |
 
@@ -68,6 +69,18 @@ Runs in **`/home/ben/irw-queue-runner`** on `itemtext/queue-rounds`, which the w
 `origin/main` into before each round so protocol changes are picked up. **The old
 `/home/ben/irw-queue` worktree is retired** — it is 36 commits behind main on a branch whose remote
 is gone, and still carries the `batch_018` cap, so a round there would self-cancel on its first fire.
+
+**The worktree keeps itself current.** `git fetch` + `git merge origin/main` run *before* the
+Step 0 guards, so the worktree picks up protocol changes on every hourly fire — including fires
+where no round runs, e.g. once the cap is reached. The only conditions that skip the update are the
+two that should: wrong branch, or a dirty tree.
+
+**The other direction is the standing PR.** Rounds commit to `itemtext/queue-rounds` and the runner
+opens one PR to `main` and leaves it open, accumulating rounds rather than opening one per round.
+Without it the branch only grows: the work goes unreviewed, and the further it drifts from main the
+likelier the pre-round merge is to conflict — which stops the queue outright, since a failed merge
+skips the round. Merging that PR commits extractions to the **repo, not the warehouse**; staging and
+upload stay manual.
 
 **One step is left, and it is yours** — installing the crontab line was blocked by the permission
 classifier:

--- a/itemtext/extraction_batches/round_cron.sh
+++ b/itemtext/extraction_batches/round_cron.sh
@@ -160,6 +160,41 @@ alert() {
   else
     echo "Nothing new to push."
   fi
+
+  # A STANDING pull request, opened once and left open. Rounds accumulate into
+  # it; it is not one PR per round.
+  #
+  # Without this the branch just grows: rounds pile up unreviewed, and the
+  # further it drifts from main the likelier the wrapper's pre-round merge is to
+  # hit a conflict -- which stops the queue entirely, since a failed merge skips
+  # the round. It is also the review surface the work actually needs: roughly 8
+  # of the 12 tables in a round want a human go/no-go before anything is staged
+  # for upload, and a PR is where that happens.
+  #
+  # Failure here is deliberately NOT fatal. The round's work is already
+  # committed and pushed by this point, and losing a PR link is not worth
+  # alerting over or re-running a round for.
+  open_pr="$(gh pr list --repo "$GH_REPO" --head "$BRANCH" --state open \
+    --json number --jq '.[0].number' 2>/dev/null)"
+  if [[ -n "$open_pr" ]]; then
+    echo "Standing PR #$open_pr already open; this round's commits are on it."
+  else
+    gh pr create --repo "$GH_REPO" --base main --head "$BRANCH" \
+      --title "itemtext: extraction rounds from the queue runner" \
+      --body "Standing PR for \`$BRANCH\`, opened automatically by \
+\`itemtext/extraction_batches/round_cron.sh\`. Rounds accumulate here rather than \
+opening a PR each; it stays open between merges.
+
+**Nothing here is published.** A round writes \`__items.csv\` into a batch directory and \
+stops -- triage, staging into \`itemtables/clean/\` and upload are all separate manual \
+steps. Merging this PR commits the extractions to the repo, not to the warehouse.
+
+Review per \`itemtext/BATCH_PROCESS.md\` § 'Triage and staging'. Round-by-round detail is \
+in \`extraction_batches/round_log.md\` and the per-round logs under \
+\`extraction_batches/cron_logs/\` (untracked, local to the runner worktree)." \
+      2>&1 | tail -2
+    echo "Opened the standing PR."
+  fi
   exit 0
 ) > "$LOG_FILE" 2>&1
 


### PR DESCRIPTION
Answers the second half of "should we set up a system so the worktree updates frequently?"

**It already updates itself.** `git fetch` + `git merge origin/main` run *before* the Step 0 guards in `round_cron.sh`, so the runner worktree picks up protocol changes on every hourly fire — including fires where no round runs, e.g. once the cap is reached. The only conditions that skip the update are the two that should: wrong branch, or a dirty tree. No second mechanism needed.

**Nothing went the other way, and that was the real gap.** Rounds commit to `itemtext/queue-rounds` and nothing merged them back. Left alone the branch only grows: the work goes unreviewed, and the further it drifts from main the likelier the pre-round merge is to hit a conflict — which stops the queue outright, since a failed merge skips the round.

So the runner now opens **one standing PR** to main and leaves it open, accumulating rounds rather than opening one per round. That is also the review surface the work needs anyway: roughly 8 of the 12 tables in a round want a human go/no-go before anything is staged.

Merging that PR commits extractions to the **repo, not the warehouse** — a round cannot publish, and staging into `itemtables/clean/` plus upload stay manual.

### Details

- Failure to open the PR is deliberately **non-fatal**. By that point the round's commits are already pushed; losing a PR link is not worth alerting over or re-running a round for.
- Detection uses `gh pr list --head`, verified against a branch with an open PR and one without. Unlike `gh pr edit`, it doesn't trip the Projects-classic GraphQL error that silently swallowed an edit earlier in this session.
- HANDOFF.md records both directions, so the next reader doesn't re-derive which one was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFFQZJ1xqLPiicoxDAbz9g