### PR TITLE
Version manifest workflow: unique refresh branch per run (#1705)

### DIFF
--- a/.github/workflows/version-manifest.yml
+++ b/.github/workflows/version-manifest.yml
@@ -20,6 +20,12 @@
 # push would simply be rejected. The PR is auto-merged -- `main` requires zero
 # approving reviews -- which keeps the job unattended while leaving an audit
 # trail. Most days the manifest does not change and no PR is opened.
+#
+# This requires the repository setting "Allow GitHub Actions to create and
+# approve pull requests" (Settings -> Actions -> General -> Workflow
+# permissions). Without it `gh pr create` fails with "GitHub Actions is not
+# permitted to create or approve pull requests" *after* the branch has been
+# pushed, which is how it failed the first time this step ran.
 name: version manifest
 
 on:
@@ -98,7 +104,11 @@ jobs:
         run: |
           set -euo pipefail
           date="$(date -u +%F)"
-          branch="manifest/refresh-$date"
+          # The run id keeps two runs on the same day from colliding: a
+          # date-only name would already exist on the remote and the push would
+          # be rejected as non-fast-forward. That is not hypothetical -- the
+          # first run that reached this step failed after pushing its branch.
+          branch="manifest/refresh-$date-$GITHUB_RUN_ID"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$branch"


### PR DESCRIPTION
Found by the live test on 2026-09-04: shards 2 and 4 were published, the workflow was dispatched, and the pull-request step failed.

```
pull request create failed: GraphQL: GitHub Actions is not permitted
to create or approve pull requests (createPullRequest)
```

Everything before that worked — `red_up.manifest` read the new releases and produced the expected **22 rows (v339, v340)**, one snapshot per publish.

## Needs a repository setting, not a code change

The blocker is **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"**, currently off (`can_approve_pull_request_reviews: false`). Equivalent by API:

```
gh api -X PUT repos/ben-domingue/irw/actions/permissions/workflow \
  -f default_workflow_permissions=read \
  -F can_approve_pull_request_reviews=true
```

`default_workflow_permissions` stays `read` — the workflow grants its own `contents: write` in the file, which is why the push succeeded.

This is now documented in the workflow header, because the failure happens *after* the branch is pushed and the error message does not say where to look.

## What this PR actually changes

The failure exposed a second bug it would otherwise have masked. The refresh branch was named `manifest/refresh-$date`, so the pushed-but-abandoned branch from a failed run would collide with any later run on the same day and the push would be rejected as non-fast-forward. Adding `$GITHUB_RUN_ID` makes each branch unique.

## Cleanup already done

- Issue #1906 (`[FAILED]`, opened by the run) closed with an explanation — it was a real failure but not a real problem.
- The stale `manifest/refresh-2026-09-04` branch deleted.

## After merging

Flip the setting, then `gh workflow run "version manifest" --repo ben-domingue/irw`. v339 and v340 are still unrecorded, so the rerun has real work to do and will exercise the commit → PR → auto-merge path end to end.

Refs #1705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FqXS9cQsmVsQiDV7ARS6F