### PR TITLE
itemtext: drop machivallianism_test_tipi as below the issues-page bar

### DIFF
--- a/itemtext/fixes/issues_page_dropped.csv
+++ b/itemtext/fixes/issues_page_dropped.csv
@@ -2,3 +2,4 @@ table,reason
 abdullah_2024_bsq_sev24,"Below the bar: the BSQ's per-item multiple-choice categories were never published, so this is a gap in the source rather than a text-vs-table mismatch."
 alcoholstroop_jones2024,"Below the bar: no per-word correct_response key can exist because ink colour was randomised per trial; nothing in the shipped text contradicts the table."
 arora2025_blueq_pedagogical,"Below the bar: the only caveat is that the study's data file records numeric codes and never published anchors, so the anchors come from the published BLUE-Q. Recorded at round_log.md line 619."
+machivallianism_test_tipi,"Below the bar: its two caveats are a pipeline-internal gate note (validate_items.R skipped against the Redivis export cap, both set checks run server-side instead) and a deliberate transcription choice (instructions holds only the stem the deposit documents, not the TIPI's longer published preamble). Neither is a text-vs-table mismatch."


### PR DESCRIPTION
Raised by draft_issues_qmd.R's REVIEW THESE TOO section while closing the issues-page backlog for batches 012, 015, 016 and 018. Its two notes.csv caveats are a pipeline-internal gate note and a deliberate transcription choice, neither of which is a text-vs-table mismatch, so it earns no entry on the public page.

Recorded here so it is not re-reported every run. Nothing from the 17 tables that were actually DUE was dropped; all 17 are on the page as of datapages/irw branch itemtext/batch012-018-issues.

Appended in place: the file is LF with minimal quoting, not the CRLF/quote-all convention BATCH_PROCESS.md describes, and a QUOTE_ALL round-trip is not byte-identical.


Claude-Session: https://claude.ai/code/session_01Wsbf1DRXweudJwB6n9Vczh