### PR TITLE
itemtext: run extraction rounds by hand, not on a schedule (#1709 decision (c))

### DIFF
--- a/itemtext/BATCH_PROCESS.md
+++ b/itemtext/BATCH_PROCESS.md
@@ -1,8 +1,10 @@
 # Item-text batch extraction — round protocol
 
-How the `itemtables/batch_NNN/` extraction runs work, and the exact prompt to
-restart them. Companion to `.claude/skills/irw-auto-itemtext/SKILL.md` (which
-covers per-table extraction) — this file covers the batching/scheduling layer.
+How the `itemtables/batch_NNN/` extraction runs work, and how to start one.
+Companion to `.claude/skills/irw-auto-itemtext/SKILL.md` (which covers per-table
+extraction) — this file covers the batching layer. The round's own prompt is
+`extraction_batches/round_prompt_v1.md`; the entry point is
+`extraction_batches/run_round.sh`, which a human runs.
 
 ## State on disk
 
@@ -31,35 +33,61 @@ the corpus by volume — 2.12 billion of what were 2.44 billion pending response
 pending response volume** — so any statistic about queue coverage should say whether it includes
 them. Post-exclusion the queue is 1,176 pending.
 
-## Scheduling
+## Running a round
 
-Rounds are driven by a **session-scoped `CronCreate` job** (`recurring: true`),
-the same pattern the availability audit used. Two consequences worth knowing:
+**Nothing schedules a round. You start one, when you are ready to triage what it
+produces.** Decision (c) of `extraction_batches/HANDOFF.md`, settled 2026-09-04:
 
-- The job lives only in the Claude session that created it and **dies when that
-  session closes**. Restarting means recreating it with the prompt below.
-- A cron job cannot cancel itself implicitly — the protocol has the agent call
-  `CronList` → `CronDelete` on its own marker string when a stop condition hits.
+```bash
+/home/ben/irw-queue-runner/itemtext/extraction_batches/run_round.sh
+```
 
-Cadence: `13 * * * *` (hourly, on an off-minute). **Corrected 2026-09-03 — the old
-`7,22,37,52` was wrong and actively harmful.** That 15-minute cadence was calibrated
-for the retired groups-of-3 dispatch, on the reasoning that "a 12-table round takes
-well under 10 minutes wall-clock with 4-way parallelism". One agent per table is
-slower per round, not faster: in batch_016 the twelve agents ran **3.6 to 16.4
-minutes** each and the round took roughly **40 minutes** end to end, because the
-round is only as fast as its slowest table and hard tables are exactly the ones that
-take longest. A second round fired while batch_016 was still `in_progress`.
+That script is the only entry point. It checks the guards (branch, clean tree,
+circuit breaker, `in_progress` rows, pending count, batch cap), merges
+`origin/main`, launches the round agent with `round_prompt_v1.md`, then pushes and
+opens or reuses the standing PR. It writes a dated log under
+`extraction_batches/cron_logs/` and also prints to your terminal; a failure exits
+nonzero and says what to check.
 
-Cron cannot express a clean 45-minute interval, so this is hourly — comfortably
-above the observed 40-minute round, and off the `:00`/`:30` marks. **Re-derive it if
-the dispatch shape changes again**: the cadence must exceed the round's *worst-case*
-wall clock, not its average. The stop condition below is the real safety net; the
-cadence only keeps it from firing routinely.
+**Why there is no scheduler, and why "add one later" is the wrong turn:**
 
-Because each firing is a **stateless context** with no memory of prior rounds,
-the prompt must be a complete, idempotent recipe — not a reference to "continue
-the batches."
+- **The bottleneck is triage, not the trigger.** Roughly 8 of the 12 tables in a
+  round need a human go/no-go, and at ~1,165 pending that is ~98 rounds. Any
+  cadence faster than "when someone is ready to triage" just grows an unreviewed
+  branch — which is also what makes the pre-round merge of `origin/main` start
+  conflicting, and a failed merge stops the queue entirely. One round per triage
+  session is the honest rate.
+- **A round costs real money.** Measured on batch_019 (2026-09-04, and a *short*
+  round — four of its agents were killed by 429s): 670K output tokens, 2.3M cache
+  writes, 49.4M cache reads across the orchestrator and 12 subagents. About **$56**
+  at Opus 5 list rates; a clean round is nearer $60–70, and draining the queue is
+  **$5.5–7k**. Nothing should be able to spend that on a timer.
+- **Crontab is ruled out** as a standing preference across projects (2026-09-04).
+  Its failure mode is not misfiring but failing *silently* on a laptop that has to
+  be on and in the right state, with nothing reporting on it — the version-manifest
+  entry ran zero times and said nothing.
+- **GitHub Actions was considered and rejected for this job**, even though the
+  version-manifest job moved there (#1905, #1907). Three reasons: the work is
+  fetching publisher and repository sources, and a datacenter IP gets bot-walled
+  far more than this laptop does — and a WAF block lands in `queue_state.csv` as
+  `blocked`, which quietly removes a table from the queue for good; a cloud runner
+  is cancelled and evicted more readily, and every death leaves 12 rows
+  `in_progress` that block all later rounds until a human reconciles them; and
+  `--dangerously-skip-permissions` in a PUBLIC repo, with secrets in the
+  environment and public logs, around an agent whose whole job is reading
+  untrusted third-party files, is a different risk from the same flag on a machine
+  Ben is sitting at. If the GitHub ergonomics are ever wanted, the answer is a
+  **self-hosted runner on Ben's laptop** — residential IP, local credentials, local
+  `.cache/` — not `ubuntu-latest`.
 
+**Wall clock, for planning:** one agent per table means the round is only as fast as
+its slowest table, and hard tables are exactly the slow ones. In batch_016 the
+twelve agents ran **3.6 to 16.4 minutes** each and the round took roughly **40
+minutes** end to end; batch_019 took 19. Budget 20–40 minutes, and do not start a
+second round while one is running — the `in_progress` guard will refuse anyway.
+
+Because each round is a **stateless context** with no memory of prior rounds, the
+prompt is a complete, idempotent recipe — not a reference to "continue the batches."
 ## History
 
 Batches 001–005 ran 2026-08-16 (50 tables extracted, 10 blocked). The loop
@@ -86,327 +114,16 @@ and the processing script side by side.
 
 ## The round-trigger prompt
 
-Paste verbatim into `CronCreate` (`recurring: true`, cron `13 * * * *`).
-Adjust the batch cap in Step 0 for the run you want.
+**The prompt lives in `extraction_batches/round_prompt_v1.md`, and that file is the
+only copy.** `run_round.sh` reads it directly; adjust the batch cap in its Step 0
+for the run you want.
 
-**Working directory.** The prompt below names `src/itemtext/`, which is right whenever
-`src` is checked out on `main`. When `src` is on another branch, run the round from a
-worktree instead and substitute that path throughout the prompt — a round must never
-write batch output onto an unrelated branch. The 2026-09-03 restart ran from
-`/home/ben/irw-queue/itemtext/` (branch `itemtext/queue-runner`) because `src`
-was on `tags/construct-type-rules`. `queue_state.csv` was byte-identical between the two
-at fork, so no state was lost; it is the file to reconcile when the branch merges.
-
-```
-# ITEMTEXT_BATCH_ROUND_V1 (self-identification marker for CronList/CronDelete — do not remove this line)
-
-You are firing as a recurring cron round of the IRW item-text batch-extraction pipeline. This is a
-stateless firing — you have no memory of prior rounds. Everything you need is either in this prompt
-or on disk. Follow this protocol exactly, once, then stop (do not loop internally).
-
-Working directory: /home/ben/Dropbox/projects/irw/src/itemtext/ — cd there first. Read
-itemtext/BATCH_PROCESS.md if you need context beyond this prompt.
-
-## Step 0 — Stop conditions (check BEFORE any extraction work)
-
-Run: ls -d itemtables/batch_* 2>/dev/null | sort -V
-
-Stop, self-cancel, and log if ANY of these hold:
-- itemtables/batch_020 already exists (round cap reached)
-- zero rows with status=="pending" in extraction_batches/queue_state.csv (queue exhausted)
-- extraction_batches/circuit_breaker.flag exists (a prior round tripped it; human review pending)
-
-SEPARATELY — the in-flight check, which is NOT a self-cancel (added 2026-09-03):
-
-Run: awk -F, 'NR>1 && $2=="in_progress"' extraction_batches/queue_state.csv
-
-If that prints ANY row, a round is already running (or died mid-round). **Stop
-immediately. Do NOT claim tables, do NOT create a batch directory, and do NOT
-self-cancel the cron job** — a live round will finish on its own and the next firing
-should proceed normally. Append one line to extraction_batches/round_log.md saying
-you stood down, which batch the in_progress rows belong to, and their timestamp.
-Then stop.
-
-The one exception: if those rows' timestamp is more than 2 hours old, the round that
-claimed them is almost certainly dead. Say so in that log line and stop anyway —
-reconciling them back to "pending" is a HUMAN decision, because a dead round may have
-left half-written files in its batch directory. Never flip in_progress back to pending
-on your own.
-
-Why this exists: on 2026-09-03 a second round fired while batch_016 was still in
-flight. None of the three stop conditions above covered it, and nothing in the
-protocol would have prevented two orchestrators from rewriting queue_state.csv and
-globbing each other's sidecars. It stood down only because a human was watching.
-
-To self-cancel: call CronList, find the job whose prompt contains "ITEMTEXT_BATCH_ROUND_V1", call
-CronDelete on its id, append one line to extraction_batches/round_log.md saying which stop
-condition fired and when, then stop. Do nothing else.
-
-## Step 1 — Claim this round's tables
-
-- Next batch number = highest existing itemtables/batch_NNN + 1, zero-padded to 3 digits.
-  mkdir -p itemtables/batch_<NNN>
-- Take the first 12 rows with status=="pending" from queue_state.csv (fewer is fine if the queue
-  is nearly empty — don't stall). ONLY status=="pending" rows are eligible: rows marked
-  "excluded" are off-limits permanently (currently the 52 enem* tables, whose item text Ben is
-  handling separately). Never re-mark an excluded row as pending.
-- Immediately rewrite queue_state.csv marking exactly those tables status="in_progress",
-  batch="batch_<NNN>", timestamp=<now ISO 8601>, BEFORE dispatching, so nothing is double-claimed.
-
-## Step 2 — Dispatch extraction (parallel subagents)
-
-**Dispatch ONE AGENT PER TABLE** (subagent_type "general-purpose"), all in the same message so
-they run in parallel. Twelve agents sits under the concurrency cap, so this costs no wall clock.
-
-This replaces the earlier groups-of-3, which lost three tables to every single failure:
-batch_010's group 3 was killed by a content-filter error before it read anything, and all three
-tables passed on individual retry — the trip was spurious, not about the data. One table per agent
-makes the blast radius of an infrastructure failure exactly one table, and a retry is a re-dispatch
-of that one prompt.
-
-Give each agent a distinct sidecar suffix (`notes_<table>.csv`, `provenance_<table>.csv`,
-`verification_<table>.csv`) so they cannot collide, and glob for those suffixes at merge time.
-
-**Tell each agent to namespace its SCRATCH files too, under `itemtext/.cache/<table>/`.** The
-session scratchpad is shared across parallel agents: in batch_011 two agents independently reported
-that a sibling overwrote their `cand.csv` mid-run, and one spent a retry chasing the spurious
-validation failure that caused. Both caught it — but a collision on a candidate CSV is exactly the
-failure that could ship one table's rows under another table's name, and neither `validate_items.R`
-nor `audit_batch.R` would notice, because each only compares the file in front of it against the
-live data that file claims to describe.
-
-**The ground-truth step is the expensive one — treat it that way.** Every `table_context.R` and
-`irw_fetch` call EXPORTS THE WHOLE TABLE. In batch_011 twelve agents pointed at the corpus's largest
-tables exhausted a 200GB/30-day Redivis export quota account-wide (see round_log 2026-08-18). Prefer
-`irw::irw_table_sets()` — or `scripts/table_sets.R`, now a thin CLI wrapper over it: it answers the
-same item/resp-set question with server-side aggregate queries and is not subject to the export
-limit. `audit_batch.R` uses the same route.
-
-That quota window has since rolled over and exports work again, but the arithmetic that made
-exhaustion inevitable has not changed: the core warehouse is 181.8GB against a 200GB/30-day cap, so
-one full pass spends ~91% of a month's allowance. The durable fix is an export billing project on
-the datapages datasets, which is still outstanding. Until then, treat the query route as the default
-and an export as a decision.
-
-The misreporting half of that incident IS fixed. Rpkg#121 landed (irw >= 1.0.1): an export-quota
-failure used to surface as "table does not exist in IRW", which sent four agents chasing a phantom
-missing table, and `irw_fetch()` now names an account-wide export limit as such. **"does not exist
-in IRW" can again be taken at face value** — it means all four core datasources genuinely returned
-not-found.
-
-When several tables in a round come from ONE source file (common — five `butt_2022_*`, five
-`buzgova_2023_*`, four `baka2023_*` in recent rounds), tell each agent explicitly which sibling
-tables belong to another agent and must not be touched. Two agents independently deriving the same
-convention from the same file is useful corroboration; two agents writing the same files is a race.
-Each subagent prompt must tell it to:
-
-- cd to /home/ben/Dropbox/projects/irw/src/itemtext/ and read
-  .claude/skills/irw-auto-itemtext/SKILL.md in full (plus references/itemtext_standard.md) before
-  doing anything, and follow it precisely.
-- Process its ONE assigned table via SKILL.md Steps 2-6:
-  table_context.R for ground truth (respect a STOP) -> find the source paper (Step 3, including
-  Step 3b's instrument-mismatch check) -> extract/structure (Step 4, literal transcript, match the
-  source's terseness) -> validate_items.R as a HARD GATE (Step 5), run it with **--table-sets** on
-  a published table so the gate uses server-side aggregates instead of exporting the whole table -> Step 5b mapping verification
-  (REQUIRED, see below) -> on pass write itemtables/batch_<NNN>/<table>__items.csv (Step 6). On a
-  block, write NO CSV and log why. One retry max on transient failures. A partial/honest "couldn't
-  automate this one" is a correct outcome per SKILL.md, not a failure.
-- **Check the wording's rights before transcribing it** — see the "Rights" section of
-  references/itemtext_standard.md (ruled on #1891 and the ECR-R, 2026-09-04). Two separate tests,
-  and they have different consequences:
-  - **The SOURCE you copy from.** If its terms state a non-commercial restriction, write NO CSV,
-    record the table `blocked`, and quote the clause. It fires on a stated restriction only, never
-    on an inference that a scale is copyrighted or reproduced without an explicit grant.
-  - **The INSTRUMENT's rights holder.** If they state a non-commercial restriction but your source
-    is openly licensed, the source governs — ship it, set `wording_rights=NC` on every row, and
-    flag it for an issues-page entry. Do NOT block on this.
-
-  Note that a table's dictionary `License` describes the RESPONSE data and can differ from the
-  wording's licence entirely.
-- **On a block, state the retry test explicitly in notes_<table>.csv and in your report**: would an
-  unchanged retry, right now, plausibly produce a different result? Say YES (an unresolved access
-  failure -- 403, timeout, quota, source not located, no verdict reached) or NO (a determinate
-  verdict -- no wording published, licence bars reuse, images only, gated behind registration or
-  author contact, or a data defect that makes item text unattachable), and say what would have to
-  change for the answer to become different. The orchestrator uses this at Step 5 to decide
-  `failed` vs `blocked`, and those are counted differently by the circuit breaker. Do not guess:
-  if you cannot tell, say so and it will be treated as `failed`, which merely costs a retry.
-- Do SKILL.md Step 5b for every table whose mapping_basis is not `data_labels`, and record it in
-  the per-table verification sidecar below. Do NOT write to itemtext/mapping_verification.csv
-  directly — concurrent agents would clobber each other; the orchestrator merges the sidecars.
-  validate_items.R and audit_batch.R only compare SETS -- they cannot catch item_text mapped to the
-  wrong item code, which is the one error that silently ships wrong content. Step 5b lists eight
-  routes (per-item statistics, response-range fingerprint, implied parameter, subscale blocks,
-  keying polarity, marker item, subscale totals, semantic coherence) plus two exemptions
-  (self-describing codes, explicit code labels in the paper) and the two scripts item_stats.R and
-  mapping_structure.R. status=NO_ROUTE is a legitimate, expected outcome -- record it rather than
-  leaving a table looking checked.
-- Prefer sources that carry embedded labels — .sav/.xlsx/Forms exports very often tie each item
-  code to its text directly, which makes the mapping authoritative instead of inferred. Useful
-  access tricks: Europe PMC's supplementaryFiles zip endpoint when PMC/publisher links are
-  bot-walled; python-docx table parsing (LibreOffice silently drops Word table cells);
-  Rd_db() for CRAN packages; soffice --convert-to txt for legacy .doc.
-- NEVER pad an unlabeled scale point with its own number — leave option_text blank.
-- Write itemtables/batch_<NNN>/notes_<table>.csv (header table,note) if its table didn't get a
-  clean pass, including a pass carrying a real caveat.
-- Write itemtables/batch_<NNN>/provenance_<table>.csv (header
-  table,mapping_basis,text_source,source_ref,note,public_note,uploaded) with a row for its table,
-  clean or not. Vocabularies are defined in SKILL.md Step 6c. Record mapping_basis=unknown honestly
-  rather than guessing.
-- Write itemtables/batch_<NNN>/verification_<table>.csv (header
-  table,batch,mapping_basis,uploaded,route,status,evidence) for every table whose mapping_basis is
-  NOT data_labels, per SKILL.md Step 5b. status is VERIFIED/PARTIAL/NO_ROUTE, and `evidence` must
-  contain the actual numbers compared, not a description of intent. This sidecar is why
-  verification now arrives WITH the batch instead of being reconstructed weeks later by a sweep.
-  **VERIFIED means the route distinguishes every item from every other item.** Pinning a polarity
-  class, a subscale or some positions is PARTIAL. State in the evidence what the route does NOT
-  establish, then choose the status to match that sentence.
-- **Also write itemtables/batch_<NNN>/verify_<table>.R — a re-runnable version of that evidence.**
-  Copy .claude/skills/irw-auto-itemtext/references/verify_template.R. It must fetch its own data,
-  print the numbers it compares, and end with exactly "VERDICT: PASS" or "VERDICT: FAIL". Verify the
-  MAPPING, not the plumbing: re-checking item counts is not evidence, because validate_items.R
-  already did it and the result merely looks like evidence. Skip only for data_labels tables, where
-  the source file itself ties code to text.
-- NOT touch itemtables/pilot/pending_index_notes.csv (a separate, older file).
-
-Wait for all agents to finish.
-
-## Step 3 — Merge sidecars
-
-Merge notes_*.csv into notes.csv, provenance_*.csv into provenance.csv, and verification_*.csv
-into verification_merged.csv (header once, data rows concatenated), then delete the per-table files.
-
-**Delete them BY NAME, never with `rm -f verification_*.csv`.** That glob also matches
-`verification_merged.csv` -- the file this step just told you to create, and the exact filename
-`lint_verification.R` requires inside a batch directory. Running the documented cleanup literally
-destroys the merge output: it happened at batch_016's round close and took all nine verification
-rows with it. They were recoverable only because each agent still held its evidence string and
-could be resumed to rewrite its own file; nothing on disk could have rebuilt them, and an evidence
-string reconstructed from memory would be worse than a missing one. Delete the exact filenames you
-merged, or write the merge to a name outside the glob and rename it afterwards.
-Leave the verify_<table>.R scripts in place — they are the batch's re-runnable evidence and triage
-executes them.
-
-Then merge verification_merged.csv into the permanent `itemtext/mapping_verification.csv`, and add a
-NOT_NEEDED row for every written table that has no verification row because its mapping_basis is
-data_labels. Every written table must end up with exactly one tracker row.
-
-## Step 4 — Normalize and audit
-
-Rscript .claude/skills/irw-auto-itemtext/scripts/normalize_nulls.R    itemtables/batch_<NNN>
-Rscript .claude/skills/irw-auto-itemtext/scripts/audit_batch.R        itemtables/batch_<NNN>
-Rscript .claude/skills/irw-auto-itemtext/scripts/verify_batch.R       itemtables/batch_<NNN>
-Rscript .claude/skills/irw-auto-itemtext/scripts/lint_verification.R  itemtables/batch_<NNN>
-
-# Added 2026-09-02. The four gates above check a table against its SOURCE -- do the
-# item and resp sets match, does the mapping reproduce. These two check it against
-# the STANDARD and against the corpus, which nothing in this batch flow did.
-irw-validate itemtables/batch_<NNN>/*__items.csv
-Rscript check_provenance.R ../../irw_site/itemtext_issues.qmd
-
-A verify FAIL or NO VERDICT, or a lint ERROR, means a table's own claim did not reproduce: mark that
-table failed rather than done, and say so in the round_log entry.
-
-An `irw-validate` ERROR means the table breaks the data standard regardless of how well
-its mapping reproduces. Two of its checks exist because of defects found in already-published
-tables on 2026-09-02:
-
-- `dup_item_resp` — the same `item`+`resp` twice with identical option text. That is a
-  doubled upload; four live tables carried it (#1816), one of them serving every item twice
-  for a day.
-- `resp_ambiguous` — one `resp` value carrying two different option labels, i.e. two
-  opposite scale directions merged into one table. `afps_vangsness_2019` says a response of
-  1 means both "Strongly agree" and "Strongly disagree" (#1827). Note that per-item
-  direction differences are legitimate and are NOT flagged — `aip_vangsness_2019` has four
-  reverse-worded items labelled the other way round and passes, correctly.
-
-`check_provenance.R` fails on a `translation_source` value outside
-`itemtext/provenance_vocab.csv`, and reports any `machine_translation` table with no entry
-on the public issues page. A table shipping English this project generated is disclosed —
-ratified 2026-09-02, after 60 such tables were found with no public note at all (#1777).
-
-## Step 5 — Update queue state and check the circuit breaker
-
-- Table wrote a CSV AND audit_batch.R says PASS or WARN -> status="done".
-- Otherwise classify it. **Ruled 2026-09-03: a table that produced no CSV is NOT automatically a
-  failure.** Use the retry test, which is the whole distinction:
-
-  > *Would an unchanged retry, right now, plausibly produce a different result?*
-
-  - **YES -> status="failed".** A fault or an unresolved access failure: a gate FAIL or ERROR, a
-    crash, a verify FAIL or missing VERDICT, a lint ERROR, an HTTP 403/timeout/connection error,
-    an exhausted export quota, "couldn't find the source" with no verdict reached. These COUNT
-    toward the circuit breaker, because a cluster of them is what a systemic breakage looks like.
-  - **NO -> status="blocked".** A determinate verdict: the source publishes no item wording, the
-    licence bars reuse, the wording exists only as images, the pool is gated behind a human action
-    such as registration or author contact, or a data defect makes item text unattachable at all
-    (e.g. a transposed table whose item axis holds respondent IDs). An unchanged retry fails
-    identically; changing the outcome needs a HUMAN action or a data change. These do NOT count
-    toward the circuit breaker.
-
-  Never leave a table in_progress. When in doubt between the two, choose "failed" — it costs a
-  retry, whereas a wrong "blocked" quietly removes a table from the queue forever.
-
-- **Circuit breaker: if >30% of this round's tables ended up `failed` (NOT `blocked`)**: write
-  extraction_batches/circuit_breaker.flag explaining what happened, self-cancel exactly as in
-  Step 0, log it, and stop.
-
-- Always log BOTH numbers in the round entry — written / blocked / failed — plus the round's
-  yield. A high `blocked` rate is a fact about which tables the queue served up, not about
-  pipeline health, but it is worth watching: the queue is worked in table order and the head of
-  the queue holds the corpus's large closed-source datasets. Every `blocked` table also gets a
-  row in itemtables/pending_index_notes.csv saying what would have to change.
-
-  WHY THIS SPLIT EXISTS. The breaker is there to stop a BROKEN pipeline burning rounds
-  unattended. Before 2026-09-03 it counted every no-CSV table, so a table the extractor correctly
-  DECLINED was indistinguishable from one where the extractor broke. It fired twice on correct
-  behaviour -- batch_005 (33%, recorded then as "not a pipeline fault") and batch_016 (33.3%,
-  8 clean extractions plus 4 determinate source blocks). SKILL.md calls an honest "couldn't
-  automate this one" a correct outcome, and the 110-table blind study found declining-rather-than-
-  guessing to be the extractor's validated property; a threshold that halts on it trains future
-  rounds toward guessing. But blocks are not simply ignorable either: a network or quota outage
-  surfaces as a wave of "couldn't reach the source", which is why unresolved access failures stay
-  on the counting side.
-
-## Step 5b — Verify the round's own claims before trusting them
-
-The subagents are careful but not infallible, and their reports are the only thing the orchestrator
-sees. **Independently re-check any claim that (a) overrides a source, (b) reports a defect in the
-response data, or (c) is about to be filed publicly or written into a note.** This is cheap — one
-`irw_fetch` and a few lines of R — and in practice it has changed the answer:
-
-- An agent reported that all nine items of `anh_2026_finbehavior` have a mean of *exactly* 3.000.
-  They run 2.980–3.016. Still notable, but the note as written would have been false.
-- An agent overrode a `.sav`'s value labels on `baka2023_bpnsf`. Re-checking confirmed it — and
-  showed the correlation evidence alone was ambiguous until item content fixed which block was
-  which, so the note had to say that too.
-- I filed issue #1654 concluding a file's column names were right and its labels scrambled. The
-  next round's agent showed the opposite, with item means at floor/ceiling settling it. The issue
-  had to be corrected and closed.
-
-Rule of thumb: an agent's *finding* is a lead; the orchestrator's job is to confirm it before it
-becomes a public artifact. Where the check confirms, say so and record the numbers.
-
-## Step 5c — Explain every audit WARN in notes.csv
-
-`audit_batch.R` WARNs are frequently correct-but-expected (blank `item_text` on a forced-choice
-instrument, applicability-driven missingness on a matrix item, an item nobody used every level of).
-Leaving them unexplained means the next reviewer re-derives the explanation. Append the reason to
-that table's `notes.csv` row, and say plainly whether it is an itemtext defect or a property of the
-response data — several WARNs this session pointed at data defects worth their own GitHub issue.
-
-## Step 6 — Log, then re-check the cap
-
-- Append an entry to extraction_batches/round_log.md: batch id, timestamp, table count,
-  pass/fail counts, and anything notable (systemic access issues, Step 3b instrument mismatches,
-  dictionary/metadata problems found).
-- If this round completed itemtables/batch_020, log "cap reached" in round_log.md and stop.
-  Under round_cron.sh there is no cron job to delete — the wrapper reads the cap out of
-  round_prompt_v1.md itself and declines to launch the next round.
-- Otherwise end normally; the next firing picks up the next batch.
-
-Never run red_up — uploading is a separate, explicit, human-triggered step.
-```
+A full copy used to be pasted here as well, and it drifted — by 2026-09-04 the copy
+in this file still pointed the round at `src/itemtext/` (the wrong checkout, on an
+unrelated branch) and still told the agent to cancel itself via
+`CronList`/`CronDelete`, which the real prompt explicitly forbids. A round reading
+the wrong one gets the wrong protocol and a stale `queue_state.csv`. So: one copy,
+and a pointer here.
 
 ## Triage and staging (after a round, before upload)
 
@@ -414,6 +131,14 @@ Extraction leaves a batch validated but unshipped. Triage is the per-table go/no
 turns `itemtables/batch_NNN/` into an upload. Done for batches 001, 006 and 007; the shape
 is the same each time.
 
+0. **If the round hit a rate limit or spend cap, reconcile the batch directory against
+   `queue_state.csv` first.** The harness reports an agent's *first* assistant message, not its
+   last, so an agent killed on its closing message is indistinguishable from one that died before
+   reading anything. In batch_019 two of three "failed" agents had in fact finished, one with a
+   complete 65-row `__items.csv` and all four sidecars on disk. `run_round.sh` prints a warning
+   when the transcript mentions a limit; when it does, `ls` the batch directory and classify on
+   the gates rather than on the report. Orphaned `__items.csv` files with no provenance are
+   quarantined, not promoted.
 1. **Re-run the gates live** rather than trusting the round's own report —
    `normalize_nulls.R`, `audit_batch.R`, then `verify_batch.R` and `lint_verification.R`
    on the batch. The first two re-check against current live data, so a table that passed at
@@ -439,7 +164,13 @@ is the same each time.
    were missed that way.
 5. **Log it** in `round_log.md` under that batch: what was staged, what was held and why,
    which issues-page drafts were dropped, and what the re-checks found.
-6. **On the user's confirmation that the upload happened**, stamp `uploaded=<date>` in the
+6. **Merge the standing PR without deleting the branch.** Rounds accumulate into one open PR
+   from `itemtext/queue-rounds`; that is the point of it. #1904 was merged with `--delete-branch`,
+   which removed `origin/itemtext/queue-rounds` — that broke the runner's push check (the commits
+   of the next round would have stayed local, unpushed) and would have started a fresh PR per
+   round. Use `gh pr merge --squash` with no `--delete-branch`, and do not press GitHub's
+   "Delete branch" button afterwards.
+7. **On the user's confirmation that the upload happened**, stamp `uploaded=<date>` in the
    batch's `provenance.csv` and in `mapping_verification.csv`, and delete the uploaded
    `__items.csv` files from the batch folder — sidecars stay, so the folder still documents
    every table the batch claimed. `clean/` is cleared by the user, not by you. **Never stamp

--- a/itemtext/BATCH_PROCESS.md
+++ b/itemtext/BATCH_PROCESS.md
@@ -445,7 +445,7 @@ is the same each time.
    every table the batch claimed. `clean/` is cleared by the user, not by you. **Never stamp
    ahead of confirmation**; a stamp that runs ahead of the actual upload is worse than none.
 
-Both CSVs are CRLF with every field quoted. Reserialising them with a default `csv.writer`
+Both CSVs are CRLF, but **the quoting is not uniform and this line used to claim it was**: `batch_019/provenance.csv` and `mapping_verification.csv` are MINIMAL-quoted, while `batch_018/provenance.csv` is QUOTE_ALL. Do not assume either. Round-trip the file with the convention you intend to use and check the result is **byte-identical** before writing; if it is not, append or edit the target lines in place. Reserialising them with a default `csv.writer`
 rewrites the whole file — check that a `QUOTE_ALL` + `\r\n` round-trip is byte-identical
 before writing, or edit the target lines in place.
 

--- a/itemtext/extraction_batches/HANDOFF.md
+++ b/itemtext/extraction_batches/HANDOFF.md
@@ -56,7 +56,7 @@ questionnaire's English. Two agents independently established that the back-tran
 administered form** despite being titled "used in the first pilot study". Its mapping is sound and
 its gates are green. Switching the wording base to the S4 Code Book is a re-extraction of one table.
 
-**c. Scheduling of itemtext rounds — REOPENED 2026-09-04, this is the live question.**
+**c. Scheduling of itemtext rounds — crontab is RULED OUT; the runner is paused pending a replacement.**
 
 Sequence matters here, so read it in order rather than assuming the last state:
 
@@ -76,17 +76,29 @@ Sequence matters here, so read it in order rather than assuming the last state:
 **Current state: paused, not dismantled.**
 - `extraction_batches/circuit_breaker.flag` is set as a DELIBERATE PAUSE, not a tripped breaker.
   The file says so itself. Delete it to resume.
-- The crontab line `13 * * * * .../round_cron.sh` is **still installed**. Removing it is the
-  durable stop; the flag is the immediate one. Note an agent cannot edit the crontab — the
-  permission classifier blocks it, so that step is always Ben's.
+- The crontab line `13 * * * * .../round_cron.sh` is **still installed and should be removed** —
+  it is one of two IRW crontab entries still to migrate (the other is the weekly metadata
+  pipeline, `0 6 * * 1`). The flag is the immediate stop; removing the line is the durable one.
+  An agent cannot do it: the permission classifier blocks crontab edits, so that step is Ben's.
+  `crontab -e`, delete the line.
 - The cap is `batch_020`, so even unpaused it would run one more round and stop.
 
-**A precedent landed the same day and is worth weighing.** #1705 moved the version-manifest
-refresh **off local cron into GitHub Actions** (#1905, #1907; first Actions run `d0a42d7`). That
-is a better shape than a laptop crontab — it survives the machine being off, runs in a clean
-environment, logs per run, and needs no `--dangerously-skip-permissions` locally. The open
-question for adopting it here is whether an extraction round's needs (Redivis credentials, the R
-and Python toolchain, ~19 min runtime, 12 parallel subagents) fit that runner.
+**Crontab is out, as a standing preference across projects.** Ben ruled on 2026-09-04: "i have
+had no luck with crontab across a variety of different projects now." It was earned — the
+version-manifest job was installed as a crontab entry on 2026-09-03 and ran **zero** times,
+refusing silently because the live checkout was never on `main`. The failure mode is not
+misfiring, it is failing *quietly* on a laptop that has to be on and in the right state, with
+nothing reporting on it. **Do not propose a crontab here.**
+
+The direction is **GitHub Actions**, which is what #1705 chose for the version manifest (#1905,
+#1907; first Actions run `d0a42d7`) — a scheduled workflow plus `workflow_dispatch`, opening an
+auto-merged PR because `GITHUB_TOKEN` does not inherit Ben's `enforce_admins: false` bypass on
+`main`. Local systemd timers are weaker: `Linger=no`, so they only fire while he is logged in.
+
+**This job is not a straight lift, which is why it is still open.** The manifest job only reads a
+remote API and commits a file. A round needs Redivis credentials, the R and Python toolchain,
+~19 minutes, and 12 parallel `claude` subagents. Whether that fits an Actions runner — and what
+it costs there — is the thing to work out.
 
 **What the round cannot do, under any scheduler:** publish. It writes `__items.csv` into a batch
 directory and stops. Triage, staging into `clean/` and upload are all manual. That property is

--- a/itemtext/extraction_batches/HANDOFF.md
+++ b/itemtext/extraction_batches/HANDOFF.md
@@ -56,43 +56,50 @@ questionnaire's English. Two agents independently established that the back-tran
 administered form** despite being titled "used in the first pilot study". Its mapping is sound and
 its gates are green. Switching the wording base to the S4 Code Book is a re-extraction of one table.
 
-**c. ~~Restarting the queue needs a durability decision.~~ RULED 2026-09-04: crontab + `claude -p`.**
-Built as `extraction_batches/round_cron.sh`, shaped after the two crons this repo already runs
-(`metadata/version_manifest_cron.sh`, `weekly_pipeline_cron.sh`) — dated log, guards before any
-work, a GitHub issue on failure so GitHub mails you. It is the **first unattended agent in this
-repo**; those two run deterministic scripts. What bounds it is that a round *cannot publish* —
-it writes `__items.csv` into a batch dir and stops, with triage, staging and upload all separate
-manual steps, the same rule `weekly_pipeline_cron.sh` follows by never running `upload_meta.py`.
-Worst case is spend, a mutated `queue_state.csv`, and files in a batch dir.
+**c. Scheduling of itemtext rounds — REOPENED 2026-09-04, this is the live question.**
 
-Runs in **`/home/ben/irw-queue-runner`** on `itemtext/queue-rounds`, which the wrapper merges
-`origin/main` into before each round so protocol changes are picked up. **The old
-`/home/ben/irw-queue` worktree is retired** — it is 36 commits behind main on a branch whose remote
-is gone, and still carries the `batch_018` cap, so a round there would self-cancel on its first fire.
+Sequence matters here, so read it in order rather than assuming the last state:
 
-**The worktree keeps itself current.** `git fetch` + `git merge origin/main` run *before* the
-Step 0 guards, so the worktree picks up protocol changes on every hourly fire — including fires
-where no round runs, e.g. once the cap is reached. The only conditions that skip the update are the
-two that should: wrong branch, or a dirty tree.
+1. Ruled that morning: crontab + `claude -p`. Built as `extraction_batches/round_cron.sh`,
+   shaped after this repo's existing crons — dated log, guards before any work, a GitHub issue
+   on failure. It is the **first unattended agent in this repo**; the others run deterministic
+   scripts.
+2. **It ran, once, and it worked.** batch_019: 19 minutes, exit 0, 7 tables written with
+   `audit_batch` 7 PASS / 0 WARN, 4 determinate blocks, 1 failure. Every guard behaved. All 7
+   survived a live re-run of the gates at triage; 6 shipped.
+3. Ben then **cancelled** it and said a different system is wanted. Two reasons were given: an
+   API monthly spend cap, and the cron being too complicated for the value. **The spend cap is
+   no longer a reason — Ben is working around it** (stated 2026-09-04). So the remaining
+   argument is complexity alone, and it is weaker than when it was made: the round worked, and
+   the one real defect found since (the self-edit bug, below) is fixed.
 
-**The other direction is the standing PR.** Rounds commit to `itemtext/queue-rounds` and the runner
-opens one PR to `main` and leaves it open, accumulating rounds rather than opening one per round.
-Without it the branch only grows: the work goes unreviewed, and the further it drifts from main the
-likelier the pre-round merge is to conflict — which stops the queue outright, since a failed merge
-skips the round. Merging that PR commits extractions to the **repo, not the warehouse**; staging and
-upload stay manual.
+**Current state: paused, not dismantled.**
+- `extraction_batches/circuit_breaker.flag` is set as a DELIBERATE PAUSE, not a tripped breaker.
+  The file says so itself. Delete it to resume.
+- The crontab line `13 * * * * .../round_cron.sh` is **still installed**. Removing it is the
+  durable stop; the flag is the immediate one. Note an agent cannot edit the crontab — the
+  permission classifier blocks it, so that step is always Ben's.
+- The cap is `batch_020`, so even unpaused it would run one more round and stop.
 
-**One step is left, and it is yours** — installing the crontab line was blocked by the permission
-classifier:
+**A precedent landed the same day and is worth weighing.** #1705 moved the version-manifest
+refresh **off local cron into GitHub Actions** (#1905, #1907; first Actions run `d0a42d7`). That
+is a better shape than a laptop crontab — it survives the machine being off, runs in a clean
+environment, logs per run, and needs no `--dangerously-skip-permissions` locally. The open
+question for adopting it here is whether an extraction round's needs (Redivis credentials, the R
+and Python toolchain, ~19 min runtime, 12 parallel subagents) fit that runner.
 
-```
-( crontab -l; echo "13 * * * * /home/ben/irw-queue-runner/itemtext/extraction_batches/round_cron.sh" ) | crontab -
-```
+**What the round cannot do, under any scheduler:** publish. It writes `__items.csv` into a batch
+directory and stops. Triage, staging into `clean/` and upload are all manual. That property is
+what bounded the risk of running it unattended, and it is the thing to preserve in whatever
+replaces it.
 
-To stop it: `crontab -e` and delete that line, or `touch
-/home/ben/irw-queue-runner/itemtext/extraction_batches/circuit_breaker.flag`, which makes every
-round skip without removing anything. With the cap at `batch_020` the first install runs **two
-rounds and then skips indefinitely** — that bound is deliberate for a first unattended run.
+**The self-edit bug, fixed — do not reintroduce it.** `round_cron.sh` merges `origin/main` into
+the worktree it lives in, so a merge carrying a change to the script rewrites the file bash is
+executing. git rewrites in place keeping the inode, and bash reads scripts lazily in 8KB blocks
+by byte offset, so this really does corrupt — reproduced as `unexpected EOF while looking for
+matching quote`. It bit once, harmlessly, on 2026-09-04. The fix is a snapshot re-exec at the top
+of the script. Any replacement that both self-updates and runs from the updated file needs the
+same guard.
 
 **d. Seven permission-blocked tables** (six `dwyer_2025_genomics_*`, `rd_ppsl7as_ghasemy_2024_sl`),
 recorded `blocked` in `pending_index_notes.csv`. A rights question, not an access one.
@@ -145,7 +152,8 @@ Five `data fix` issues were filed from batch_016: #1875–#1879.
 
 ## 5. To restart the queue
 
-1. ~~Decide (c) above.~~ Ruled — see (c).
+1. Settle (c) above — REOPENED. The crontab line is installed but the queue is paused by
+   `circuit_breaker.flag`; delete the flag to resume as-is, or replace the scheduler first.
 2. ~~Raise the cap~~ **done 2026-09-04: the cap is now `batch_020` in Step 0 of both
    `BATCH_PROCESS.md` and `round_prompt_v1.md`, which allows two more rounds (019, 020).** Re-raise
    it before any run beyond that. The off-by-one: the cap self-cancels after *completing* that batch.

--- a/itemtext/extraction_batches/HANDOFF.md
+++ b/itemtext/extraction_batches/HANDOFF.md
@@ -12,8 +12,8 @@ narrative is in `round_log.md` under batch_016, batch_017 and batch_018.
 |---|---|
 | worktree | `/home/ben/irw-queue-runner` — **use this, not `src`** (the old `/home/ben/irw-queue` is retired: 36 commits behind, stale cap) |
 | branch | `itemtext/queue-rounds` (pushed; the wrapper merges `origin/main` in before each round) |
-| runner | `itemtext/extraction_batches/round_cron.sh`, hourly at `:13` from the user crontab |
-| review | a **standing PR** from `itemtext/queue-rounds` → `main`, opened by the runner and left open; rounds accumulate into it |
+| runner | `itemtext/extraction_batches/run_round.sh` — **run it by hand, one round per triage session.** Nothing schedules it |
+| review | a **standing PR** from `itemtext/queue-rounds` → `main`, opened by the runner and left open; rounds accumulate into it. **Merge it without deleting the branch** |
 | staged for upload | `itemtext/itemtables/clean/` |
 | protocol the cron reads | `itemtext/extraction_batches/round_prompt_v1.md` |
 
@@ -56,62 +56,85 @@ questionnaire's English. Two agents independently established that the back-tran
 administered form** despite being titled "used in the first pilot study". Its mapping is sound and
 its gates are green. Switching the wording base to the S4 Code Book is a re-extraction of one table.
 
-**c. Scheduling of itemtext rounds — crontab is RULED OUT; the runner is paused pending a replacement.**
+**c. ~~Scheduling of itemtext rounds.~~ SETTLED 2026-09-04: there is no scheduler. Rounds are run
+by hand, one per triage session.**
 
-Sequence matters here, so read it in order rather than assuming the last state:
+Read the sequence rather than assuming the last state:
 
-1. Ruled that morning: crontab + `claude -p`. Built as `extraction_batches/round_cron.sh`,
-   shaped after this repo's existing crons — dated log, guards before any work, a GitHub issue
-   on failure. It is the **first unattended agent in this repo**; the others run deterministic
-   scripts.
+1. Ruled the morning of 2026-09-04: crontab + `claude -p`, built as `round_cron.sh`. It is the
+   **first unattended agent in this repo**; the others run deterministic scripts.
 2. **It ran, once, and it worked.** batch_019: 19 minutes, exit 0, 7 tables written with
    `audit_batch` 7 PASS / 0 WARN, 4 determinate blocks, 1 failure. Every guard behaved. All 7
    survived a live re-run of the gates at triage; 6 shipped.
-3. Ben then **cancelled** it and said a different system is wanted. Two reasons were given: an
-   API monthly spend cap, and the cron being too complicated for the value. **The spend cap is
-   no longer a reason — Ben is working around it** (stated 2026-09-04). So the remaining
-   argument is complexity alone, and it is weaker than when it was made: the round worked, and
-   the one real defect found since (the self-edit bug, below) is fixed.
+3. Ben cancelled it the same day and asked for a different system. **Crontab is out as a standing
+   preference across projects** — "i have had no luck with crontab across a variety of different
+   projects now." Earned: the version-manifest crontab entry ran **zero** times and said nothing,
+   refusing silently because the live checkout was never on `main`. The failure mode is not
+   misfiring, it is failing *quietly*. **Do not propose a crontab here.**
+4. GitHub Actions — the answer for the version manifest (#1705, #1905, #1907) — was worked out
+   properly for this job and **rejected**. It is not a straight lift, and the reasons are not
+   about plumbing:
 
-**Current state: paused, not dismantled.**
-- `extraction_batches/circuit_breaker.flag` is set as a DELIBERATE PAUSE, not a tripped breaker.
-  The file says so itself. Delete it to resume.
-- The crontab line `13 * * * * .../round_cron.sh` is **still installed and should be removed** —
-  it is one of two IRW crontab entries still to migrate (the other is the weekly metadata
-  pipeline, `0 6 * * 1`). The flag is the immediate stop; removing the line is the durable one.
-  An agent cannot do it: the permission classifier blocks crontab edits, so that step is Ben's.
-  `crontab -e`, delete the line.
-- The cap is `batch_020`, so even unpaused it would run one more round and stop.
+   - **The bottleneck is triage, not the trigger.** ~8 of 12 tables per round need a human
+     go/no-go; at ~1,165 pending that is ~98 rounds. Any cadence faster than "when someone is
+     ready to triage" grows an unreviewed branch, and the further it drifts from `main` the more
+     likely the pre-round merge conflicts — which stops the queue outright.
+   - **Cost, measured.** batch_019 (a *short* round; four agents were 429'd): 670K output, 2.3M
+     cache write, 49.4M cache read across orchestrator + 12 subagents ≈ **$56** at Opus 5 list
+     rates. A clean round is $60–70; the queue is **$5.5–7k**. Hourly would be ~$1,340/day.
+     Nothing should spend that on a timer. Note this is currently subscription usage, not metered
+     API spend — an `ANTHROPIC_API_KEY` in CI would convert it into real per-fire dollars, and a
+     `CLAUDE_CODE_OAUTH_TOKEN` would keep the exact rate limits that killed 8/12 agents in
+     batch_018 and 4/12 in batch_019, unattended.
+   - **A datacenter IP is the wrong place for this work.** The round's expensive step is fetching
+     publisher, OSF, Dataverse, Europe PMC and CRAN sources. A Harvard Dataverse AWS WAF challenge
+     already blocked three tables from *this* laptop. From Azure runner space it gets worse — and
+     the damage is silent: it lands as `blocked`, and a wrong `blocked` quietly removes a table
+     from the queue forever.
+   - **Stuck rounds get more common, not less.** A cloud runner is cancelled, timed out and
+     evicted more readily than the laptop; every death leaves 12 rows `in_progress`, which blocks
+     every later round until a human reconciles. A concurrency group and `if: always()` cleanup
+     bound it but cannot prevent it.
+   - **`--dangerously-skip-permissions` does not transfer.** That posture was decided for a
+     machine Ben controls and watches. In Actions it would run in a **public** repo, with
+     `REDIVIS_API_TOKEN` and `GITHUB_TOKEN` in the environment and **public logs**, around an
+     agent whose whole job is reading untrusted third-party files. `GITHUB_TOKEN` with
+     `pull-requests: write` on a repo where `main` requires zero approving reviews is the same
+     auto-merge capability the manifest job uses — so "the round cannot publish" would no longer
+     bound the blast radius the way it does locally.
 
-**Crontab is out, as a standing preference across projects.** Ben ruled on 2026-09-04: "i have
-had no luck with crontab across a variety of different projects now." It was earned — the
-version-manifest job was installed as a crontab entry on 2026-09-03 and ran **zero** times,
-refusing silently because the live checkout was never on `main`. The failure mode is not
-misfiring, it is failing *quietly* on a laptop that has to be on and in the right state, with
-nothing reporting on it. **Do not propose a crontab here.**
+   Actions *would* have deleted real problems, and that is worth recording: a fresh checkout makes
+   the self-snapshot `exec`, the dirty-worktree guard and the wrong-branch guard all unnecessary.
+   It also throws away `.cache/<table>/` (gitignored; the cached sources that make triage minutes
+   rather than hours). **If the GitHub ergonomics are ever wanted, the answer is a self-hosted
+   runner on Ben's laptop** — residential IP, local credentials, local cache — not `ubuntu-latest`.
 
-The direction is **GitHub Actions**, which is what #1705 chose for the version manifest (#1905,
-#1907; first Actions run `d0a42d7`) — a scheduled workflow plus `workflow_dispatch`, opening an
-auto-merged PR because `GITHUB_TOKEN` does not inherit Ben's `enforce_admins: false` bypass on
-`main`. Local systemd timers are weaker: `Linger=no`, so they only fire while he is logged in.
+**Current state.**
+- `extraction_batches/run_round.sh` (renamed from `round_cron.sh`) is the entry point. Run it
+  when you sit down to triage. It still keeps every guard, still cannot publish, still reads the
+  cap out of Step 0 of `round_prompt_v1.md`, and no longer opens a GitHub issue on failure —
+  it exits nonzero and tells you, because you are the one who started it.
+- **The crontab line `13 * * * * .../round_cron.sh` is still installed and must be removed.**
+  An agent cannot do it — the permission classifier blocks crontab edits — so this step is Ben's:
+  `crontab -e`, delete the line. It now points at a path that no longer exists, so it would fail
+  hourly and silently until it is gone.
+- `circuit_breaker.flag` is still set as a DELIBERATE PAUSE, not a trip. Once the crontab line is
+  gone the flag has no job to do; delete it then.
+- The cap is `batch_020`, so the next run does one round and stops. Raise it in Step 0 of
+  `round_prompt_v1.md` for more.
+- The runner worktree was found parked on `itemtext/handoff-scheduling-state` on 2026-09-04, not
+  on `itemtext/queue-rounds`. The branch guard would refuse to run a round until that is put back.
 
-**This job is not a straight lift, which is why it is still open.** The manifest job only reads a
-remote API and commits a file. A round needs Redivis credentials, the R and Python toolchain,
-~19 minutes, and 12 parallel `claude` subagents. Whether that fits an Actions runner — and what
-it costs there — is the thing to work out.
-
-**What the round cannot do, under any scheduler:** publish. It writes `__items.csv` into a batch
+**What the round cannot do, under any trigger:** publish. It writes `__items.csv` into a batch
 directory and stops. Triage, staging into `clean/` and upload are all manual. That property is
-what bounded the risk of running it unattended, and it is the thing to preserve in whatever
-replaces it.
+what bounds the risk of `--dangerously-skip-permissions`, and it is not negotiable.
 
-**The self-edit bug, fixed — do not reintroduce it.** `round_cron.sh` merges `origin/main` into
-the worktree it lives in, so a merge carrying a change to the script rewrites the file bash is
-executing. git rewrites in place keeping the inode, and bash reads scripts lazily in 8KB blocks
-by byte offset, so this really does corrupt — reproduced as `unexpected EOF while looking for
-matching quote`. It bit once, harmlessly, on 2026-09-04. The fix is a snapshot re-exec at the top
-of the script. Any replacement that both self-updates and runs from the updated file needs the
-same guard.
+**The self-edit bug, fixed — do not reintroduce it.** `run_round.sh` merges `origin/main` into the
+worktree it lives in, so a merge carrying a change to the script rewrites the file bash is
+executing. git rewrites in place keeping the inode, and bash reads scripts lazily in 8KB blocks by
+byte offset, so this really does corrupt — reproduced as `unexpected EOF while looking for matching
+quote`. It bit once, harmlessly, on 2026-09-04. The fix is the snapshot re-exec at the top of the
+script. Any replacement that both self-updates and runs from the updated file needs the same guard.
 
 **d. Seven permission-blocked tables** (six `dwyer_2025_genomics_*`, `rd_ppsl7as_ghasemy_2024_sl`),
 recorded `blocked` in `pending_index_notes.csv`. A rights question, not an access one.
@@ -164,12 +187,12 @@ Five `data fix` issues were filed from batch_016: #1875–#1879.
 
 ## 5. To restart the queue
 
-1. Settle (c) above — REOPENED. The crontab line is installed but the queue is paused by
-   `circuit_breaker.flag`; delete the flag to resume as-is, or replace the scheduler first.
+1. ~~Settle (c)~~ **SETTLED: run `extraction_batches/run_round.sh` by hand.** Two things must
+   happen first: Ben removes the crontab line (`crontab -e`), and the runner worktree goes back
+   onto `itemtext/queue-rounds`. Then delete `circuit_breaker.flag`.
 2. ~~Raise the cap~~ **done 2026-09-04: the cap is now `batch_020` in Step 0 of both
    `BATCH_PROCESS.md` and `round_prompt_v1.md`, which allows two more rounds (019, 020).** Re-raise
    it before any run beyond that. The off-by-one: the cap self-cancels after *completing* that batch.
 3. ~~Confirm~~ **checked 2026-09-04: no `circuit_breaker.flag`, 0 `in_progress` rows, no `clean/`.**
-4. Install the crontab line in (c) above — `round_cron.sh` reads `round_prompt_v1.md` itself.
-   Hourly at `:13`; the old 15-minute cadence was calibrated for a retired groups-of-3 dispatch
-   and caused an overlap.
+4. Run `extraction_batches/run_round.sh`. It reads `round_prompt_v1.md` itself. One round, then
+   triage what it produced before running another.

--- a/itemtext/extraction_batches/round_prompt_v1.md
+++ b/itemtext/extraction_batches/round_prompt_v1.md
@@ -1,7 +1,9 @@
-# ITEMTEXT_BATCH_ROUND_V1 (self-identification marker for CronList/CronDelete — do not remove this line)
+# ITEMTEXT_BATCH_ROUND_V1
 
-You are firing as a recurring cron round of the IRW item-text batch-extraction pipeline. This is a
-stateless firing — you have no memory of prior rounds. Everything you need is either in this prompt
+You are one round of the IRW item-text batch-extraction pipeline, started deliberately by a human
+who is about to triage what you produce (decision (c) of HANDOFF.md, settled 2026-09-04 — there is
+no scheduler; `extraction_batches/run_round.sh` is run by hand, one round per triage session). This
+is a stateless firing — you have no memory of prior rounds. Everything you need is either in this prompt
 or on disk. Follow this protocol exactly, once, then stop (do not loop internally).
 
 Working directory: /home/ben/irw-queue-runner/itemtext/ — cd there first. Read
@@ -41,11 +43,11 @@ globbing each other's sidecars. It stood down only because a human was watching.
 To self-cancel: append one line to extraction_batches/round_log.md saying which stop condition
 fired and when, then stop. Do nothing else.
 
-You are launched by extraction_batches/round_cron.sh, which checks these same conditions in bash
+You are launched by extraction_batches/run_round.sh, which checks these same conditions in bash
 before it ever launches you -- so reaching this point at all means something changed between its
-check and yours. There is no cron job for you to delete: do NOT call CronList or CronDelete (they
-do not exist in a headless run), and do NOT edit the crontab. Stopping is sufficient; the wrapper
-will decline to start the next round for the same reason.
+check and yours. There is nothing scheduled to cancel: do NOT call CronList or CronDelete (they do
+not exist in a headless run), and do NOT edit the crontab. Stopping is sufficient; a human starts
+the next round, and the wrapper will decline to start one for the same reason.
 
 ## Step 1 — Claim this round's tables
 
@@ -240,6 +242,21 @@ ratified 2026-09-02, after 60 such tables were found with no public note at all 
   Never leave a table in_progress. When in doubt between the two, choose "failed" — it costs a
   retry, whereas a wrong "blocked" quietly removes a table from the queue forever.
 
+- **Before you classify ANY agent the harness reported as failed, `ls` its batch directory.**
+  The report you see is an agent's FIRST assistant message, not its last, so an agent killed on
+  its closing message looks identical to one that died before reading anything. In batch_019
+  three agents were reported failed with a 429; two had finished, and `chatton2024_honos13` had a
+  complete 65-row `__items.csv` and all four sidecars already on disk. Taking the report at face
+  value would have thrown away a clean table and a fully-argued block.
+
+  So: for every agent whose report reads as a failure, check for
+  `itemtables/batch_<NNN>/<table>__items.csv` and its sidecars before deciding anything. If the
+  files are there, run the Step 4 gates on the table and classify it on the gates, not on the
+  report. If a rate limit or spend cap killed agents mid-round, say so explicitly in the round log
+  -- a round that hit a limit is not a round whose blocked/failed counts mean anything, and it
+  should NOT set the circuit breaker on that basis (nothing was determined about those tables).
+  Orphaned `__items.csv` files with no provenance are quarantined, not promoted.
+
 - **Circuit breaker: if >30% of this round's tables ended up `failed` (NOT `blocked`)**: write
   extraction_batches/circuit_breaker.flag explaining what happened, self-cancel exactly as in
   Step 0, log it, and stop.
@@ -302,5 +319,6 @@ NOTE ON PATHS (2026-09-03 restart): this round runs from a WORKTREE, not src.
 `irw_site` is NOT a sibling of the worktree -- use the absolute path above for
 check_provenance.R. Do not `cd` into /home/ben/Dropbox/projects/irw/src and do not
 switch branches there; it is checked out on an unrelated branch. Commit round output
-on branch itemtext/queue-runner, naming paths explicitly per BATCH_PROCESS.md's
+on branch itemtext/queue-rounds -- NOT itemtext/queue-runner, which is retired and which
+this line named wrongly until 2026-09-04 -- naming paths explicitly per BATCH_PROCESS.md's
 repo-hygiene section, and push after each round.

--- a/itemtext/extraction_batches/run_round.sh
+++ b/itemtext/extraction_batches/run_round.sh
@@ -1,30 +1,59 @@
 #!/usr/bin/env bash
-# Cron entry point for one round of the IRW item-text batch extraction (#1709).
+# One round of the IRW item-text batch extraction (#1709). YOU run this; nothing
+# schedules it.
 #
-# Shaped after metadata/version_manifest_cron.sh and weekly_pipeline_cron.sh --
-# dated log, guards before any work, a GitHub issue on failure so GitHub mails
-# Ben. It differs from both in one respect that is worth stating plainly: those
-# two run deterministic scripts, and this one launches an AGENT. It is the first
-# unattended agent in this repo (decision (c) of extraction_batches/HANDOFF.md,
-# ruled 2026-09-04).
+# Decision (c) of extraction_batches/HANDOFF.md, settled 2026-09-04: rounds are
+# fired deliberately, one per triage session, and there is no scheduler at all.
+# The reasoning is worth keeping, because "add a scheduler later" is the obvious
+# wrong turn:
 #
-# What bounds it:
+#   - The bottleneck is triage, not the trigger. Roughly 8 of the 12 tables in a
+#     round need a human go/no-go (BATCH_PROCESS, "Triage and staging"), and at
+#     ~1,165 pending that is ~98 rounds. Any cadence faster than "when someone is
+#     ready to triage a batch" just grows an unreviewed branch -- which is also
+#     what makes this script's pre-round merge of origin/main start conflicting,
+#     and a failed merge stops the queue entirely.
+#   - A round costs real money. Measured on batch_019 (2026-09-04, and a SHORT
+#     round -- four of its agents were killed by 429s): 670K output tokens, 2.3M
+#     cache writes and 49.4M cache reads across the orchestrator and 12
+#     subagents, about $56 at Opus 5 list rates. A clean round is nearer $60-70,
+#     and draining the queue is $5.5-7k. Nothing should be able to spend that on
+#     a timer.
+#   - GitHub Actions was considered and rejected (the version-manifest job moved
+#     there; this one should not). Three reasons: the work is fetching publisher
+#     and repository sources, and a datacenter IP gets bot-walled far more than
+#     this laptop does -- and a WAF block lands in queue_state.csv as `blocked`,
+#     which quietly removes a table from the queue for good; a cloud runner is
+#     cancelled and evicted more readily, and every death leaves 12 rows
+#     in_progress that block all later rounds; and --dangerously-skip-permissions
+#     in a PUBLIC repo, with secrets in the environment and public logs, around
+#     an agent whose whole job is reading untrusted third-party files, is a
+#     different risk from the same flag on a machine Ben is sitting at.
+#
+# --dangerously-skip-permissions is what lets the round run without a babysitter
+# for its 20-40 minutes. It is bounded by two things, and if either stops being
+# true this line is the one to revisit:
 #   - The round CANNOT PUBLISH. It writes __items.csv into a batch directory and
 #     stops. Triage, staging into itemtables/clean/ and upload are separate
-#     manual steps. The worst case here is spend, a mutated queue_state.csv and
-#     files in a batch dir -- nothing a warehouse user can see. This is the same
-#     rule weekly_pipeline_cron.sh follows by never running upload_meta.py.
-#   - The batch cap in Step 0 of round_prompt_v1.md. Raise it deliberately;
-#     when it is reached this script stops firing rounds and says so.
-#   - extraction_batches/circuit_breaker.flag, which a bad round sets.
+#     manual steps. The worst case is spend, a mutated queue_state.csv and files
+#     in a batch dir -- nothing a warehouse user can see.
+#   - The batch cap in Step 0 of round_prompt_v1.md, read out of the prompt
+#     below rather than duplicated here.
 #
-# The guards below duplicate the prompt's own Step 0 on purpose: checking them
-# in bash costs nothing, and it means a capped or breakered queue never pays for
-# an agent launch at all.
+# The guards below duplicate the prompt's own Step 0 on purpose: checking them in
+# bash costs nothing, and it means a capped or breakered queue never pays for an
+# agent launch at all. extraction_batches/circuit_breaker.flag still stops a
+# round; a bad round still sets it.
 #
-# It runs in its OWN worktree, never Ben's src checkout, which moved branch
-# three times during the 2026-09-03 session -- twice mid-round. A round that
-# reads a reparked tree gets the wrong protocol and a stale queue_state.csv.
+# It runs in its OWN worktree, never Ben's src checkout, which moved branch three
+# times during the 2026-09-03 session -- twice mid-round. A round that reads a
+# reparked tree gets the wrong protocol and a stale queue_state.csv. The branch
+# guard below is not paranoia: on 2026-09-04 the runner worktree itself was found
+# parked on an unrelated branch.
+#
+# Output goes to a dated log under cron_logs/ and to your terminal. A failure
+# exits nonzero and says so -- there is no GitHub issue any more, because you are
+# the one who started it and are watching.
 set -uo pipefail
 
 # Run from a snapshot, because this script edits itself.
@@ -56,10 +85,10 @@ set -uo pipefail
 # So: copy ourselves somewhere git will never touch and exec that. The snapshot
 # is what runs; the merge below can rewrite the original freely, and the next
 # fire picks the new version up.
-if [[ "${ROUND_CRON_SNAPSHOT:-}" != "1" ]]; then
-  _snap="$(mktemp -t round_cron.XXXXXX)" || exit 1
+if [[ "${ROUND_SNAPSHOT:-}" != "1" ]]; then
+  _snap="$(mktemp -t run_round.XXXXXX)" || exit 1
   cat "$0" > "$_snap" && chmod +x "$_snap" || { rm -f "$_snap"; exit 1; }
-  ROUND_CRON_SNAPSHOT=1 "$_snap" "$@"
+  ROUND_SNAPSHOT=1 "$_snap" "$@"
   _rc=$?
   rm -f "$_snap"
   exit "$_rc"
@@ -77,32 +106,11 @@ DATE="$(date +%F)"
 STAMP="$(date +%F_%H%M)"
 LOG_FILE="$LOG_DIR/round_${STAMP}.log"
 GH_REPO="ben-domingue/irw"
-GH_MENTION="@ben-domingue"
 
 mkdir -p "$LOG_DIR"
 
-alert() {
-  # $1 = title suffix, $2 = body preamble. The log is on disk either way; the
-  # issue exists so GitHub sends mail.
-  local body
-  body="$(mktemp)"
-  {
-    echo "$GH_MENTION $2"
-    echo
-    echo "Log: \`$LOG_FILE\`"
-    echo
-    echo '```'
-    tail -c 50000 "$LOG_FILE"
-    echo '```'
-  } > "$body"
-  gh issue create --repo "$GH_REPO" \
-    --title "IRW itemtext round -- $STAMP [$1]" \
-    --body-file "$body" --assignee ben-domingue >> "$LOG_FILE" 2>&1
-  rm -f "$body"
-}
-
 # A subshell, not a brace group: the steps use `exit` to stop early, and in a
-# brace group that would exit the whole script and skip the alerting.
+# brace group that would exit the whole script and skip the reporting below.
 (
   echo "# IRW itemtext extraction round -- $STAMP"
   echo
@@ -176,20 +184,55 @@ alert() {
   echo "Launching round agent at $(date -Is)."
   echo
 
-  # --skip-permissions is what makes this unattended. It is bounded by the fact
-  # that the round cannot publish, and by the cap above. If that stops being
-  # true, this line is the one to revisit.
+  # --dangerously-skip-permissions is what lets the round run for its 20-40
+  # minutes without a babysitter. It is bounded by the fact that the round cannot
+  # publish, and by the cap above. If that stops being true, this line is the one
+  # to revisit. See the header for why this posture is defensible here and would
+  # not be on a cloud runner.
+  #
+  # Keep a copy of the transcript so the rate-limit check below can read it; the
+  # copy is deleted at the end of the round.
+  _agent_out="$(mktemp -t round_agent.XXXXXX)"
   claude -p "$(cat "$PROMPT")" \
-    --dangerously-skip-permissions 2>&1
-  rc=$?
+    --dangerously-skip-permissions 2>&1 | tee "$_agent_out"
+  rc="${PIPESTATUS[0]}"
   echo
   echo "Round agent exited $rc at $(date -Is)."
+
+  # A 429 does NOT fail the round. When subagents are killed by a rate limit or a
+  # spend cap the orchestrator finishes and exits 0, so nothing above notices and
+  # the round self-reports as a normal completion with a poor yield. That has
+  # already cost real work: in batch_018 eight of twelve agents were killed this
+  # way, and in batch_019 three were -- two of which had actually FINISHED, with
+  # a complete 65-row items CSV on disk, and were reported as plain failures
+  # because the harness shows an agent's first message, not its last.
+  #
+  # So say it out loud. A round that hit a limit is not a round whose blocked and
+  # failed counts mean anything, and its batch directory must be read before
+  # queue_state.csv is believed.
+  if grep -qiE '(rate.?limit|429|spend (cap|limit)|usage limit)' "$_agent_out"; then
+    echo
+    echo "WARNING: the transcript mentions a rate limit / spend cap. Some agents"
+    echo "were probably killed. Before trusting this round's classifications, ls"
+    echo "the batch directory -- a killed agent may have written a complete table"
+    echo "and still been reported as failed. Do not mark those tables 'blocked'."
+  fi
+  rm -f "$_agent_out"
+
   [[ "$rc" -ne 0 ]] && exit "$rc"
 
   # The round commits its own work (BATCH_PROCESS "Repo hygiene"). Push it, so
   # a round's output is never stranded on a local branch -- an unpushed branch
   # has cost this project published tables before.
-  if [[ -n "$(git log --oneline "origin/$BRANCH..HEAD" 2>/dev/null)" ]]; then
+  #
+  # The remote branch may not exist: merging the standing PR with --delete-branch
+  # removes it, which is what happened to #1904. When it is gone the range
+  # `origin/$BRANCH..HEAD` is not a revision at all -- git exits 128 and prints
+  # nothing, so the old `-n "$(...)"` test read as "nothing to push" and the
+  # round's commits stayed local. That is precisely the stranded-branch failure
+  # the paragraph above is about, so check the ref exists before using the range.
+  if ! git rev-parse --verify --quiet "origin/$BRANCH" >/dev/null \
+     || [[ -n "$(git log --oneline "origin/$BRANCH..HEAD")" ]]; then
     git push -u origin "$BRANCH" 2>&1 || {
       echo "ERROR: push failed. The round's commits are local only."
       exit 1
@@ -209,9 +252,15 @@ alert() {
   # of the 12 tables in a round want a human go/no-go before anything is staged
   # for upload, and a PR is where that happens.
   #
+  # MERGE THIS PR WITHOUT DELETING THE BRANCH. "Standing" depends on it: #1904
+  # was merged with --delete-branch, which removed origin/itemtext/queue-rounds,
+  # broke the push check above and meant the next round would open a fresh PR
+  # rather than accumulate into one. GitHub's "delete branch" button after a
+  # merge does the same thing.
+  #
   # Failure here is deliberately NOT fatal. The round's work is already
   # committed and pushed by this point, and losing a PR link is not worth
-  # alerting over or re-running a round for.
+  # failing or re-running a round for.
   open_pr="$(gh pr list --repo "$GH_REPO" --head "$BRANCH" --state open \
     --json number --jq '.[0].number' 2>/dev/null)"
   if [[ -n "$open_pr" ]]; then
@@ -220,7 +269,7 @@ alert() {
     gh pr create --repo "$GH_REPO" --base main --head "$BRANCH" \
       --title "itemtext: extraction rounds from the queue runner" \
       --body "Standing PR for \`$BRANCH\`, opened automatically by \
-\`itemtext/extraction_batches/round_cron.sh\`. Rounds accumulate here rather than \
+\`itemtext/extraction_batches/run_round.sh\`. Rounds accumulate here rather than \
 opening a PR each; it stays open between merges.
 
 **Nothing here is published.** A round writes \`__items.csv\` into a batch directory and \
@@ -229,18 +278,25 @@ steps. Merging this PR commits the extractions to the repo, not to the warehouse
 
 Review per \`itemtext/BATCH_PROCESS.md\` § 'Triage and staging'. Round-by-round detail is \
 in \`extraction_batches/round_log.md\` and the per-round logs under \
-\`extraction_batches/cron_logs/\` (untracked, local to the runner worktree)." \
+\`extraction_batches/cron_logs/\` (untracked, local to the runner worktree).
+
+**Do not delete the branch when merging.** Rounds accumulate into this one PR; deleting \
+\`$BRANCH\` on merge breaks the runner's push check and starts a new PR per round." \
       2>&1 | tail -2
     echo "Opened the standing PR."
   fi
   exit 0
-) > "$LOG_FILE" 2>&1
+) 2>&1 | tee "$LOG_FILE"
 
-rc=$?
+# tee is the last command in the pipe, so take the subshell's status, not tee's.
+rc="${PIPESTATUS[0]}"
 if [[ "$rc" -ne 0 ]]; then
-  alert "FAILED" "an unattended item-text extraction round failed. Nothing was \
-published -- rounds cannot publish -- but the queue may have rows left \
-in_progress, which blocks every later round until a human reconciles them."
+  echo
+  echo "ROUND FAILED (exit $rc). Log: $LOG_FILE"
+  echo "Nothing was published -- rounds cannot publish -- but the queue may have"
+  echo "rows left in_progress, which blocks every later round until you reconcile"
+  echo "them. Check the batch directory before touching queue_state.csv: a killed"
+  echo "agent often finished its table first."
 fi
 
-exit 0
+exit "$rc"


### PR DESCRIPTION
Settles decision (c) of `itemtext/extraction_batches/HANDOFF.md`: **there is no scheduler.** `round_cron.sh` becomes `run_round.sh`, and a human runs it — one round per triage session.

Also carries the two unmerged handoff commits from `itemtext/handoff-scheduling-state` (that branch had no PR), so this is the whole story in one place.

## Why not GitHub Actions

The version-manifest job moved to Actions and should have. This one shouldn't, and it isn't close:

- **The bottleneck is triage, not the trigger.** ~8 of 12 tables per round need a human go/no-go; ~1,165 pending is ~98 rounds. A faster trigger just grows an unreviewed branch — and the further it drifts from `main`, the likelier the pre-round merge conflicts, which stops the queue outright.
- **Cost, measured.** batch_019 (a *short* round — four agents were 429'd): 670K output, 2.3M cache write, 49.4M cache read across the orchestrator and 12 subagents ≈ **$56** at Opus 5 list rates. Clean round $60–70; draining the queue **$5.5–7k**; hourly ≈ $1,340/day. Nothing should spend that on a timer. It is subscription usage today — an `ANTHROPIC_API_KEY` in CI makes it metered dollars, and a `CLAUDE_CODE_OAUTH_TOKEN` keeps the rate limits that killed 8/12 agents in batch_018, unattended.
- **A datacenter IP is the wrong place for this work.** The round fetches publisher/OSF/Dataverse/Europe PMC sources; a Harvard Dataverse WAF challenge already blocked three tables from *this* laptop. From Azure space it gets worse, and it lands silently as `blocked` — which removes a table from the queue for good.
- **Stuck rounds get more common.** Cloud runners are cancelled and evicted more readily; each death leaves 12 rows `in_progress` blocking every later round.
- **`--dangerously-skip-permissions` doesn't transfer.** Public repo, secrets in the environment, public logs, an agent whose job is reading untrusted third-party files, and a `GITHUB_TOKEN` that (as the manifest job shows) can merge to `main` with zero approving reviews. "The round cannot publish" would stop bounding the blast radius.

Recorded honestly in HANDOFF: Actions *would* have deleted the self-snapshot `exec` and both worktree guards. It would also have thrown away `.cache/<table>/`, which is what makes triage minutes rather than hours. If the GitHub ergonomics are ever wanted, the answer is a **self-hosted runner on Ben's laptop**, not `ubuntu-latest`.

## Broken today, independent of the trigger

1. **The push check could never fire.** #1904 was merged with `--delete-branch`, so `origin/itemtext/queue-rounds` is gone and `git log origin/$BRANCH..HEAD 2>/dev/null` exits 128 with empty output — the script printed "Nothing new to push" and would have left a round's commits local. That is exactly the stranded-branch failure its own comment warns about. Fixed by verifying the ref first; the standing-PR invariant ("merge without deleting the branch") is now in the script, the PR body it writes, and triage.
2. **Wrong branch in the prompt** — it told the round to commit on `itemtext/queue-runner` (retired) while the runner pushes `itemtext/queue-rounds`.
3. **The killed-agent rule never reached the protocol.** A 429 kill exits 0, and the harness shows an agent's *first* message, not its last, so a finished table reads as a failure — it nearly cost a complete 65-row `chatton2024_honos13`. Now in Step 5 of the prompt and in triage, and `run_round.sh` greps the transcript for a rate limit and warns.
4. **BATCH_PROCESS carried a drifted second copy of the prompt** — pointing at `src/itemtext` (wrong checkout, unrelated branch) and still telling the agent to self-cancel via `CronList`/`CronDelete`, which the real prompt forbids. Replaced with a pointer; `round_prompt_v1.md` is the only copy.

## Yours to do after merging

- `crontab -e` and delete `13 * * * * .../round_cron.sh`. An agent can't (the classifier blocks crontab edits), and it now points at a path that no longer exists.
- Put the runner worktree back on `itemtext/queue-rounds` — it was found parked on `itemtext/handoff-scheduling-state`, so the branch guard would refuse to run a round.
- Then delete `circuit_breaker.flag`; with the crontab line gone it has no job left.
- **Merge this one however you like, but merge the *standing* PR without deleting its branch.**

Nothing here is published, and rounds still can't publish. Refs #1709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFFQZJ1xqLPiicoxDAbz9g