### PR TITLE
run_pipeline.sh: fix --no-09, which never worked

### DIFF
--- a/.claude/skills/irw-site-update/scripts/run_pipeline.sh
+++ b/.claude/skills/irw-site-update/scripts/run_pipeline.sh
@@ -114,11 +114,24 @@ for a in "$@"; do
 done
 if [[ ${#stages[@]} -eq 0 ]]; then stages=("${DEFAULT_ORDER[@]}"); fi
 if [[ "${SKIP_09:-0}" == "1" ]]; then
-  stages=("${stages[@]/09}")
+  # Drop the element, do not blank it. `${stages[@]/09}` substitutes the text
+  # and leaves an EMPTY element behind, and an empty key is a fatal error when
+  # it reaches an associative array: "STAGE_OUTPUTS: bad array subscript",
+  # which under `set -e` kills the run before a single stage has executed. The
+  # run loop below guards for an empty stage; the snapshot loop above it did
+  # not, so --no-09 failed every time it was used. First hit 2026-09-04, the
+  # first time anything passed this flag.
+  kept=()
+  for s in "${stages[@]}"; do
+    [[ "$s" == "09" ]] && continue
+    kept+=("$s")
+  done
+  stages=("${kept[@]}")
 fi
 
 echo "== Snapshotting current CSVs before running anything =="
 for stage in "${stages[@]}"; do
+  [[ -z "$stage" ]] && continue   # parity with the run loop below
   for f in ${STAGE_OUTPUTS[$stage]:-}; do
     [[ -z "$f" ]] && continue
     if [[ -f "$METADATA_DIR/$f" ]]; then


### PR DESCRIPTION
The first run of the new metadata-pipeline workflow failed immediately:

```
run_pipeline.sh: line 122: STAGE_OUTPUTS: bad array subscript
```

## Cause

```bash
stages=("${stages[@]/09}")
```

That is a **substitution**, not a removal: it replaces the text `09` with the empty string and leaves an empty element in the array. An empty key is fatal when it reaches an associative array, and under `set -e` the run dies before a single stage executes.

The run loop already had `[[ -z "$stage" ]] && continue`. The snapshot loop directly above it did not — so the guard existed, just not where the array was first indexed.

**`--no-09` has therefore never worked.** Nothing noticed because nothing ever passed it: the weekly cron ran the full default sequence, on a machine where stage 09's output path (`../../irw_site/data/hero_stats.json`) actually exists. The workflow added in #1912 is the first caller, and it failed on its first run.

Reproduced locally on the same bash 5.2.21:

```
$ declare -A A=([01]=x); s=(01 09); s=("${s[@]/09}"); for k in "${s[@]}"; do echo "[${A[$k]:-}]"; done
bash: A: bad array subscript
```

## Fix

Filter the element out rather than blanking it, and add the missing guard to the snapshot loop for parity with the run loop. Verified the corrected logic yields `stages = 01 02` with no bad subscript.

Found by putting the pipeline in CI — this is exactly the class of latent bug a cron job on one machine never surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FqXS9cQsmVsQiDV7ARS6F