### PR TITLE
vocabulary_iq: stop scoring the 30 survey items against the vocabulary key

### DIFF
--- a/data/vocabulary_iq.R
+++ b/data/vocabulary_iq.R
@@ -92,7 +92,14 @@ df <- df |>
                              (item == 'q43' & resp == 12) |
                              (item == 'q44' & resp == 10) |
                              (item == 'q45' & resp == 9) ~ 1),
-         resp2 = if_else(is.na(resp2), 0, resp2),
+         # The answer key above covers only the 45 vocabulary questions (q1-q45).
+         # s1-s30 are the optional post-test personality survey, answered on a
+         # 1-5 agreement scale -- they are not vocabulary questions and must not
+         # be scored against the key, so their raw response passes through
+         # unchanged (issue #1877). A resp scale may differ across items.
+         resp2 = case_when(!str_starts(item, 'q') ~ resp,
+                           is.na(resp2) ~ 0,
+                           .default = resp2),
          # items without responses remain NA
          resp2 = if_else(is.na(resp), NA, resp2)) |>
   # drop original response variable


### PR DESCRIPTION
Fixes #1877.

`data/vocabulary_iq.R` applied the 45-question vocabulary answer key to **every** column, then swept everything unmatched to `0`. Items 46–75 (`s1`–`s30`) are the optional post-test personality survey, answered on a 1–5 agreement scale, so all **361,632** of their non-missing responses collapsed to `resp = 0` — a single degenerate level carrying no information.

## The change

One line. The key covers only `q1`–`q45`:

```r
-         resp2 = if_else(is.na(resp2), 0, resp2),
+         resp2 = case_when(!str_starts(item, 'q') ~ resp,
+                           is.na(resp2) ~ 0,
+                           .default = resp2),
```

Survey items now pass their raw 1–5 through; only `q*` is scored against the key. Mixed scales across items are permitted by `datastandard.md`, which requires consistent direction *within* an item, not across.

## Verification

There is no cached `VIQT_data.csv` in the repo, so this was verified by running the **actual script** — from `origin/main` and from this branch — against a synthetic source file built with the real column structure (`q1`–`q45`, `e1`–`e45`, `s1`–`s30`, plus the demographics the script drops), covering all-correct, all-wrong, don't-know (`-1`) and unanswered (`0`) response patterns.

| | items 46–75 `resp` values |
|---|---|
| before | `{0}` — 1 distinct level per item |
| after | `{1, 2, 3, 4, 5}` |

Guardrails, which matter more than the headline:

- **items 1–45 `resp` bit-identical** before vs after (`all.equal` TRUE) — vocabulary scoring provably untouched
- NA positions identical across the whole table
- row count, `id` and `item` vectors identical; columns `id,item,resp`; `resp` numeric
- **item numbering unchanged**: 45 → `q45`, 46 → `s1`, 75 → `s30`

So this is a `resp` correction on items 46–75 and nothing else — no renumbering.

## Before merging / uploading

- **Not uploaded.** The live table still serves the old values. This is a data change to a published table, so it needs the draft-release path and a version-manifest entry.
- Synthetic data proves the transformation is right, not that the real file's columns are named as the script assumes. The script's own `starts_with('s')` / `starts_with('e')` calls are strong evidence, but a run against the real source before upload would close that gap.
- Out of scope, noted while here: the script builds a `times` frame of per-item response times and never uses it — `rt` is computed and discarded, though `datastandard.md` has a column for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wsbf1DRXweudJwB6n9Vczh