### PR TITLE
metadata pipeline workflow: install pandas and the irw R package

### DIFF
--- a/.github/workflows/metadata-pipeline.yml
+++ b/.github/workflows/metadata-pipeline.yml
@@ -54,6 +54,13 @@ jobs:
           python-version: "3.12"
           cache: pip
 
+      - name: Install Python dependencies
+        # diff_csv.py -- the script that turns "the CSVs changed" into the
+        # readable diff this whole job exists to produce -- imports pandas.
+        # Without it stage 01 regenerates metadata.csv fine and then dies
+        # reporting what changed, which is the one part that cannot be skipped.
+        run: python -m pip install --upgrade pip && python -m pip install pandas
+
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: release
@@ -79,6 +86,9 @@ jobs:
             any::readr
             any::tidyr
             github::redivis/redivis-r
+            # audit_tables.R calls library(irw) -- the IRW client itself, which
+            # is not on CRAN (see itemresponsewarehouse/Rpkg#147).
+            github::itemresponsewarehouse/Rpkg
 
       - name: Workflow 1 -- generate and diff
         id: generate


### PR DESCRIPTION
Two missing dependencies, found by the second run of the workflow.

## What the run proved first

Real progress before it broke — everything genuinely uncertain now works:

- R and all 12 packages install, `quanteda` included, as binaries
- **Redivis authenticates under R from the repo secret**
- the four dictionary Google Sheets fetch with no OAuth
- **stage 01 completed**: `metadata.csv` regenerated, 4,222 rows, with real changes against the committed baseline (e.g. `AOMT_BR_SF_EDPANAB_Geiger_2021_*`, `n_participants` 286 → 507)

That last point also confirms the core design decision from #1912: the committed CSVs give the runner a baseline and the diff is meaningful.

## The two fixes

**`pandas`.** `diff_csv.py` imports it and `setup-python` installs nothing. So stage 01 regenerated the CSV correctly and then the run died *reporting* what changed — the one part of this job that cannot be skipped, since the diff is the product.

```
ModuleNotFoundError: No module named 'pandas'
```

**`library(irw)`.** `audit_tables.R` calls it and it was not in the package list, so Workflow 2 would have failed on the very next step for the same class of reason. Not on CRAN (`itemresponsewarehouse/Rpkg#147`), so it installs from GitHub alongside `redivis-r`.

## Still unexercised after this

`02_biblio.R`'s Claude fallback for missing BibTeX. It only fires when a table has no citation, so it may not trigger every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FqXS9cQsmVsQiDV7ARS6F