### PR TITLE
metadata pipeline workflow: comments leaked into the pak package list

### DIFF
--- a/.github/workflows/metadata-pipeline.yml
+++ b/.github/workflows/metadata-pipeline.yml
@@ -72,7 +72,12 @@ jobs:
         with:
           # There is no DESCRIPTION covering metadata/*.R, so the list is
           # explicit: it is the union of every library() call in the stages
-          # run_pipeline.sh executes, plus audit_tables.R.
+          # run_pipeline.sh executes, plus audit_tables.R -- which calls
+          # library(irw), the IRW client itself, not on CRAN (Rpkg#147).
+          #
+          # Keep comments OUT of the block scalar below: a `#` inside a YAML
+          # `|` block is literal text, not a comment, so pak receives it as a
+          # package name and the whole resolution fails.
           packages: |
             any::dplyr
             any::glue
@@ -86,8 +91,6 @@ jobs:
             any::readr
             any::tidyr
             github::redivis/redivis-r
-            # audit_tables.R calls library(irw) -- the IRW client itself, which
-            # is not on CRAN (see itemresponsewarehouse/Rpkg#147).
             github::itemresponsewarehouse/Rpkg
 
       - name: Workflow 1 -- generate and diff


### PR DESCRIPTION
My mistake in #1918, caught by the third run.

A `#` inside a YAML block scalar (`packages: |`) is **literal text, not a comment**. The two explanatory lines I put above `github::itemresponsewarehouse/Rpkg` were handed to pak as package specifications:

```
# audit_tables.R calls library(irw) -- the IRW client itself, which
# is not on CRAN (see itemresponsewarehouse/Rpkg#147).
github::itemresponsewarehouse/Rpkg
```

```
Error:
! error in pak subprocess
```

The run died inside `setup-r-dependencies`, before Workflow 1 — which is also why the log artifact was empty (`No files were found with the provided path: pipeline.log`); nothing had run yet to write one.

## Fix

The explanation moves above the `packages:` key where it is a real comment, plus a note about the trap for whoever edits this next. Verified by parsing the YAML rather than by eye: **13 package specs, none starting with `#`**.

## Where this leaves the migration

Everything that was genuinely uncertain has already passed in earlier runs — R and 12 packages install, Redivis authenticates under R, the Sheets fetch without OAuth, and stage 01 produced a real 4,222-row diff against the committed baseline. The three failures so far have all been plumbing:

1. `--no-09` blanking a stage (#1915) — a pre-existing bug in `run_pipeline.sh`
2. missing `pandas` and `library(irw)` (#1918)
3. this one, self-inflicted while fixing 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FqXS9cQsmVsQiDV7ARS6F