### PR TITLE
metadata: retry Google Sheet fetches

### DIFF
--- a/metadata/02_biblio.R
+++ b/metadata/02_biblio.R
@@ -2,6 +2,8 @@
 ##################################################################################
 ##Construct biblio.csv
 library(gsheet)
+source("gsheet_retry.R")  ## retrying gsheet2tbl; see that file
+
 library(redivis)
 source("redivis_config.R")
 library(httr)

--- a/metadata/03_tags.R
+++ b/metadata/03_tags.R
@@ -15,6 +15,8 @@
 
 library(gsheet)
 
+source("gsheet_retry.R")  ## retrying gsheet2tbl; see that file
+
 ##Multi-select normalisation for `sample` and `construct type`, applied after
 ##the sheet export and before write_csv. See tag_normalize.R and issue #1720.
 ##The Google Sheet itself is deliberately not modified.

--- a/metadata/gsheet_retry.R
+++ b/metadata/gsheet_retry.R
@@ -1,0 +1,47 @@
+## Retrying wrapper around gsheet::gsheet2tbl.
+##
+## The pipeline reads seven public Google Sheets. On 2026-09-04 a GitHub
+## Actions run of the metadata pipeline died at stage 03 on one of them:
+##
+##   Failed to open '.../export?id=1v3toO6OPts...&gid=126134123':
+##     The requested URL returned error: 400
+##   Error: cannot open the connection
+##
+## after a four-minute stall -- and `set -e` in run_pipeline.sh turned that one
+## refusal into a dead run, discarding the two and a half stages that had
+## already succeeded.
+##
+## It was transient, and that was established rather than assumed: a probe
+## fetched all seven sheets twice from a runner immediately afterwards and got
+## HTTP 200 every time, the failing sheet included, byte-identical to a local
+## fetch and in 0.4 seconds. Four other sheets had already fetched fine in the
+## same failing run. Nothing is wrong with the sheets, their sharing, or the
+## runner's route to them; Google simply refused one request.
+##
+## Unattended, that matters more than it used to. A human running the pipeline
+## sees the error and runs it again. A weekly cron or workflow throws the run
+## away and mails a failure, and the next attempt is a week later.
+##
+## This file deliberately defines a function called `gsheet2tbl`, masking the
+## package's, so that existing call sites get retries without being edited --
+## there are ten across seven scripts. Source it AFTER library(gsheet).
+gsheet2tbl <- function(url, ..., .attempts = 4L, .waits = c(5, 15, 45)) {
+  for (i in seq_len(.attempts)) {
+    result <- try(gsheet::gsheet2tbl(url, ...), silent = TRUE)
+    if (!inherits(result, "try-error")) {
+      if (i > 1L) message("  gsheet: succeeded on attempt ", i)
+      return(result)
+    }
+    if (i < .attempts) {
+      wait <- .waits[min(i, length(.waits))]
+      message("  gsheet: attempt ", i, " of ", .attempts, " failed, retrying in ",
+              wait, "s -- ", trimws(as.character(result)))
+      Sys.sleep(wait)
+    } else {
+      ## Out of attempts: fail exactly as the package would, so the caller's
+      ## error handling and the pipeline's logs are unchanged.
+      stop("gsheet2tbl failed after ", .attempts, " attempts for ", url, ":\n",
+           as.character(result), call. = FALSE)
+    }
+  }
+}


### PR DESCRIPTION
The fourth run of the metadata workflow got through stages 01, 02 and 03 — real biblio diffs, 2,537 tag rows, provenance written — then died fetching one of the seven public sheets:

```
Failed to open '.../export?id=1v3toO6OPts...&gid=126134123': error 400
Error: cannot open the connection
```

after a four-minute stall. Under `run_pipeline.sh`'s `set -e`, that single refusal discarded two and a half stages of completed work.

## It was transient, and I checked rather than assumed

A throwaway probe fetched all seven sheets twice from a runner right afterwards:

```
1v3toO6OPts_HIjcjHTOb9_v2Ne2oXZSTkGTeO6fUyrg  gid=126134123  HTTP 200  19048B  0.435s
```

**14/14 HTTP 200**, the failing sheet included, byte-identical to a local fetch, in 0.4 seconds. Four other sheets had already fetched fine within the failing run itself. So nothing is wrong with the sheets, their sharing, or the runner's route to them — Google simply refused one request.

## Why that now needs handling

A human running the pipeline sees the error and runs it again. A weekly unattended workflow throws the run away, mails a failure, and tries again in a week. Same flakiness, much higher cost.

## The change

`metadata/gsheet_retry.R` defines a function named `gsheet2tbl` that **masks the package's** and retries 4 times with 5/15/45s backoff before failing the way the package would. Masking rather than editing call sites is deliberate — it is sourced after `library(gsheet)` and every existing call gets retries.

Only **`02_biblio.R` (4 calls) and `03_tags.R` (1)** actually fetch sheets among the pipeline stages: 05/06/07's gsheet code is commented out, and `04_tables.R` is not a stage and calls `gsheet::` explicitly. My first pass assumed all seven files fetched, which a grep of uncommented lines corrected.

## Verified locally

- success path returns the real sheet, 67 × 13
- failure path retries, then raises an error naming the URL and the attempt count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FqXS9cQsmVsQiDV7ARS6F