### PR TITLE
metadata pipeline: write CSVs in a stable key order

### DIFF
--- a/.claude/skills/irw-site-update/scripts/canonicalize_csv.py
+++ b/.claude/skills/irw-site-update/scripts/canonicalize_csv.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Sort a pipeline output CSV into a stable, case-insensitive key order.
+
+Why this exists
+---------------
+The pipeline's outputs are committed (see the block in .gitignore), and the
+weekly diff -- both diff_csv.py's report and the pull request the workflow
+opens -- is the product. That only works if a run which changes nothing
+produces a byte-identical file.
+
+It did not. The first full GitHub Actions run produced a 30,668-line diff on
+biblio.csv in which **0 of 4,184 existing rows had any field changed**: 86
+tables were added and the rest was pure reordering, because the stages write
+rows in whatever order Redivis and the Google Sheets happened to return them.
+A diff like that is unreviewable, and stored weekly it defeats git's delta
+compression as well.
+
+metadata.csv looked fine in that same run (+91/-3), but that is luck rather
+than design: it is not sorted either, merely stable so far. Sorting makes the
+property something we control.
+
+Case-insensitive, deliberately
+------------------------------
+308 of the table names are not lowercase. A plain sort hoists every one of them
+into a block at the top, away from the neighbours a reader expects them beside
+-- and this is the same population behind the case-sensitive join bugs that
+have bitten this project before. `str.lower` keeps ALSECYPIAMH_WU_2022_CPS
+next to its lowercase siblings.
+
+The sort is stable, so rows sharing a key keep their relative order.
+
+Usage:
+    canonicalize_csv.py FILE --key table
+    canonicalize_csv.py FILE --key table,collection
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+# Some biblio rows carry embedded BibTeX with very long single fields.
+csv.field_size_limit(min(sys.maxsize, 2**31 - 1))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("path", type=Path)
+    ap.add_argument("--key", default="table",
+                    help="comma-separated key column(s) to sort by")
+    args = ap.parse_args()
+
+    if not args.path.is_file():
+        print(f"canonicalize: {args.path} does not exist, skipping")
+        return 0
+
+    keys = [k.strip() for k in args.key.split(",") if k.strip()]
+
+    with args.path.open(newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        fieldnames = reader.fieldnames
+        rows = list(reader)
+
+    if not fieldnames:
+        print(f"canonicalize: {args.path.name} is empty, skipping")
+        return 0
+
+    missing = [k for k in keys if k not in fieldnames]
+    if missing:
+        # Not fatal: a stage that changes its columns should not break the run
+        # before the diff has had a chance to report the change.
+        print(f"canonicalize: {args.path.name} has no column(s) "
+              f"{', '.join(missing)}; leaving order untouched")
+        return 0
+
+    before = [tuple(r.get(k) or "" for k in keys) for r in rows]
+    rows.sort(key=lambda r: tuple((r.get(k) or "").lower() for k in keys))
+    after = [tuple(r.get(k) or "" for k in keys) for r in rows]
+
+    if before == after:
+        print(f"canonicalize: {args.path.name} already in key order ({len(rows)} rows)")
+        return 0
+
+    tmp = args.path.with_suffix(args.path.suffix + ".tmp")
+    with tmp.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    tmp.replace(args.path)
+    print(f"canonicalize: {args.path.name} sorted by {args.key} ({len(rows)} rows)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/irw-site-update/scripts/run_pipeline.sh
+++ b/.claude/skills/irw-site-update/scripts/run_pipeline.sh
@@ -160,6 +160,18 @@ for stage in "${stages[@]}"; do
   # prevent) -- confirmed happening in practice 2026-07-28: stage 05 failed
   # and stages 02/03's real changes to biblio.csv/tags.csv were never
   # diffed or reported.
+  # Canonicalise before diffing. diff_csv.py joins on the key and never cared
+  # about row order, but git does: the outputs are committed now, and the
+  # stages emit rows in whatever order Redivis and the Sheets returned them.
+  # Without this a run that changes nothing still rewrites most of a file --
+  # the first full workflow run produced a 30,668-line diff on biblio.csv in
+  # which not one existing row had a changed field.
+  for f in ${STAGE_OUTPUTS[$stage]:-}; do
+    [[ -z "$f" ]] && continue
+    python3 "$SCRIPT_DIR/canonicalize_csv.py" "$METADATA_DIR/$f" \
+      --key "${DIFF_KEY[$f]:-table}"
+  done
+
   echo ""
   echo "-- Stage $stage diff --"
   for f in ${STAGE_OUTPUTS[$stage]:-}; do


### PR DESCRIPTION
The first fully-green workflow run opened #1928 — a **30,668-line diff** in which almost nothing had actually changed.

Parsing both versions of `biblio.csv`:

```
columns identical:  True
rows:               old=4184  new=4270
added tables:       86        removed: 0
common rows with ANY field differing:  0 of 4184  (0.0%)
row ORDER preserved:  False
```

**Zero existing rows changed.** The news was "86 new tables"; the other ~30,000 lines were pure reordering, because the stages emit rows in whatever order Redivis and the Sheets returned them.

That defeats the reason for committing the CSVs in #1912 — the PR diff was supposed to *be* the review surface — and stored weekly it defeats git's delta compression as well.

## The fix

`canonicalize_csv.py` sorts each stage's output by the same `DIFF_KEY` that `run_pipeline.sh` already uses for diffing (`table`, `collection`, or `table,collection`), running after the stage and before the diff. `diff_csv.py` joins on the key and never cared about order; git does.

**The sort is case-insensitive on purpose.** 308 table names are not lowercase, and a plain sort hoists every one into a block at the top, away from the neighbours a reader expects them beside — the same population behind the case-sensitive join bugs this project has hit before.

Also worth recording: `metadata.csv` looked fine in that run (+91/−3), but it is **not sorted either** — merely stable so far. This makes the property something we control rather than something upstream happens to give us.

## Verified on the real files

| | changed lines |
|---|---|
| before | 29,710 |
| after | **488** (486 added, 0 removed) |

86 tables added, 0 existing rows altered, nothing dropped. The script is idempotent, and if a key column is missing it says so and leaves the file alone rather than failing the run.

## Row order is safe downstream — checked, not assumed

- `upload_meta.py` does a **full replace** (delete the draft table and recreate, because Redivis uploads append) into a SQL table, and verifies with a **row count**.
- **Zero duplicate keys** in every output, so no `{row['table']: row}` or `drop_duplicates(keep='first')` can silently change which record survives.
- The order-sensitive consumers in `tags/` sort first themselves (`sorted(...)[0]`, `.sort_values(...).head(15)`).

The one non-invariant: `report_age_range_diff.py:74` takes the top 15 after sorting on a float share, so an exact tie could swap two rows in a report. Cosmetic, not data.

Closes #1928 (its content is regenerated on the next run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FqXS9cQsmVsQiDV7ARS6F