### PR TITLE
metadata pipeline: review guide and change summary in the PR body

### DIFF
--- a/.claude/skills/irw-site-update/scripts/summarize_changes.py
+++ b/.claude/skills/irw-site-update/scripts/summarize_changes.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Summarise what a pipeline run changed, as markdown for the PR body.
+
+A line-count diff is the wrong unit for these files: one added table can be
+dozens of lines when its BibTeX spans them, and a changed field is easy to miss
+inside a large addition. This reports what a reviewer actually needs -- rows
+added, rows REMOVED, and existing rows whose content changed -- keyed the same
+way run_pipeline.sh diffs them.
+
+Removals are called out separately because they are the alarming case: every
+run so far has removed nothing, and a table vanishing from metadata.csv means
+it disappeared from Redivis.
+
+Usage:  summarize_changes.py --ref HEAD --dir metadata
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import subprocess
+import sys
+from pathlib import Path
+
+csv.field_size_limit(min(sys.maxsize, 2**31 - 1))
+
+# Same keys run_pipeline.sh diffs on; `table` unless stated.
+KEYS = {
+    "collections.csv": ["collection"],
+    "collection_members.csv": ["table", "collection"],
+}
+
+FILES = [
+    "metadata.csv", "biblio.csv", "tags.csv", "nominal_tags.csv",
+    "itemtext_metadata.csv", "collections.csv", "collection_members.csv",
+    "comps_metadata.csv", "nominal_metadata.csv", "simsyn_metadata.csv",
+    "comps_biblio.csv", "nominal_biblio.csv", "simsyn_biblio.csv",
+]
+
+
+def rows(text: str, keys: list[str]):
+    out = {}
+    for r in csv.DictReader(io.StringIO(text)):
+        out[tuple((r.get(k) or "") for k in keys)] = r
+    return out
+
+
+def committed(ref: str, path: str) -> str | None:
+    p = subprocess.run(["git", "show", f"{ref}:{path}"],
+                       capture_output=True, text=True)
+    return p.stdout if p.returncode == 0 else None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ref", default="HEAD")
+    ap.add_argument("--dir", default="metadata", type=Path)
+    args = ap.parse_args()
+
+    lines, alarms = [], []
+    for name in FILES:
+        path = args.dir / name
+        if not path.is_file():
+            continue
+        old_text = committed(args.ref, str(path))
+        if old_text is None:
+            lines.append(f"| `{name}` | _new file_ | | |")
+            continue
+        keys = KEYS.get(name, ["table"])
+        old, new = rows(old_text, keys), rows(path.read_text(encoding="utf-8"), keys)
+        added, removed = len(set(new) - set(old)), len(set(old) - set(new))
+        changed = sum(1 for k in set(old) & set(new) if old[k] != new[k])
+        if not (added or removed or changed):
+            continue
+        mark = " **&larr; removals**" if removed else ""
+        lines.append(f"| `{name}` | {added} | {removed}{mark} | {changed} |")
+        if removed:
+            gone = sorted("/".join(k) for k in (set(old) - set(new)))[:10]
+            alarms.append(f"- `{name}` lost {removed} row(s): " +
+                          ", ".join(f"`{g}`" for g in gone) +
+                          (" ..." if removed > 10 else ""))
+
+    if not lines:
+        print("_No keyed changes in any output._")
+        return 0
+
+    print("| file | rows added | rows removed | existing rows changed |")
+    print("|---|---:|---:|---:|")
+    print("\n".join(lines))
+    if alarms:
+        print("\n**Rows disappeared upstream — check these before merging:**\n")
+        print("\n".join(alarms))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/metadata-pipeline.yml
+++ b/.github/workflows/metadata-pipeline.yml
@@ -152,12 +152,32 @@ jobs:
           {
             echo "Weekly metadata pipeline run for **$date**."
             echo
-            echo "The diff on this pull request is the review surface: it is what changed"
-            echo "in the metadata since last week. **Nothing here is published.** Merging"
-            echo "commits metadata to the repository, not to the warehouse -- run"
-            echo "\`upload_meta.py\` by hand afterwards, against the CSVs a \`git pull\` puts"
-            echo "back on your disk."
+            echo "## What changed"
             echo
+            python3 .claude/skills/irw-site-update/scripts/summarize_changes.py \
+              --ref HEAD --dir metadata
+            echo
+            echo "## How to review this"
+            echo
+            echo "1. **Rows removed.** Additions are normal growth; a *removal* means a"
+            echo "   table disappeared from Redivis, and that is the line worth stopping"
+            echo "   on. Every run so far has removed nothing."
+            echo "2. **Existing rows changed.** The real signal. A changed"
+            echo "   \`n_participants\`, \`density\` or \`responses_per_participant\` on a"
+            echo "   table that already existed means the underlying data moved --"
+            echo "   either a legitimate re-upload or something wrong upstream."
+            echo "3. **Diff size.** Expect hundreds of lines. Tens of thousands means row"
+            echo "   canonicalisation has regressed (see canonicalize_csv.py) -- do not"
+            echo "   try to read it, file it as a bug."
+            echo
+            echo "Known noise, safe to skim: \`collections.csv\` definitions rewrite"
+            echo "themselves most runs because they embed live coverage counts in their"
+            echo "prose. \`n_tables\` is the field there that means something."
+            echo
+            echo "## Merging publishes nothing"
+            echo
+            echo "This commits metadata to the repository, not to the warehouse. To push"
+            echo "to Redivis afterwards: \`git pull\`, then run \`upload_meta.py\` by hand."
             echo "Stage 09 (hero_stats.json) is not run here; it writes into \`irw_site\`."
             echo "The full run log is attached to the workflow run as \`pipeline-log\`."
             echo


### PR DESCRIPTION
The weekly PR is the review surface, but it arrives as a wall of CSV with nothing saying what to look at. This puts the guidance on the thing being reviewed, rather than somewhere you have to remember to look.

## A summary table, computed from the actual diff

`summarize_changes.py` reports **rows added, rows removed, and existing rows whose content changed**, keyed the way `run_pipeline.sh` diffs each file.

Line counts are the wrong unit here — one added table can be dozens of lines when its BibTeX spans them, and a changed field is easy to lose inside a large addition.

**Removals get their own callout, naming the tables.** That is the alarming case: every run so far has removed nothing, and a table vanishing from `metadata.csv` means it went away on Redivis.

Sample, from a simulated run:

```
| file           | rows added | rows removed        | existing rows changed |
|----------------|-----------:|--------------------:|----------------------:|
| `metadata.csv` |          1 | 1 **← removals**    |                     1 |

**Rows disappeared upstream — check these before merging:**
- `metadata.csv` lost 1 row(s): `16_personalityfactors`
```

## The review order, in the body

1. **Rows removed** — additions are normal growth; removals mean a table disappeared upstream.
2. **Existing rows changed** — the real signal. A changed `n_participants`, `density` or `responses_per_participant` on a table that already existed means the underlying data moved.
3. **Diff size** — hundreds of lines is normal; tens of thousands means canonicalisation regressed, and is a bug report rather than something to read.

Plus: `collections.csv` definitions churn harmlessly because they embed live coverage counts in their prose (`n_tables` is the field there that means something), and merging publishes nothing — `upload_meta.py` stays manual.

## Verified

- simulated 1 added / 1 removed / 1 changed → reports exactly that and names the lost table
- unchanged tree → `_No keyed changes in any output._`
- working tree restored clean afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FqXS9cQsmVsQiDV7ARS6F