### PR TITLE
queue_state: account for the three batch_022 siblings missing from the queue (#1831)

### DIFF
--- a/itemtext/extraction_batches/queue_state.csv
+++ b/itemtext/extraction_batches/queue_state.csv
@@ -1400,3 +1400,6 @@ sun_2025_morality_study2_colleaguerespect,pending,,
 sun_2025_morality_study2_colleaguetrust,pending,,
 wang_onlineriskexp_2025_interpersonalsecurity,pending,,
 wang_onlineriskexp_2025_negativeatt,pending,,
+ecps_sahm_2024_emotion,done,batch_022,2026-09-04T11:00:00-07:00
+ecps_sahm_2024_support,done,batch_022,2026-09-04T11:00:00-07:00
+ecps_sahm_2024_trust,done,batch_022,2026-09-04T11:00:00-07:00


### PR DESCRIPTION
**Three rows.** Reduced from 20 after batch_022 merged.

The other 17 were set to `done,batch_022` directly on main, so this branch's copies of them differed only by timestamp and were pure conflict — dropped.

These three are the remainder, and they were **never in `queue_state.csv` at all**: `ecps_sahm_2024_emotion`, `_support` and `_trust` are live tables that fell outside #1831's scope and were added to batch_022 because they are the same study, the same administered instrument and the same `_0neutral` coding as the eight ecps tables the issue did list.

With no row, nothing accounts for them, and a regenerated queue would enter them as `pending` and re-extract work that is already on main.

Recorded `done` with `batch=batch_022` and the timestamp main already used for the rest of the batch, per `round_prompt_v1.md` Step 5 ("Table wrote a CSV AND `audit_batch.R` says PASS or WARN -> `status=done`").

Queue after this: **1,404 rows · 1,110 pending · 205 done · 54 excluded · 23 blocked · 12 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
