### PR TITLE
itemtext: raise the round cap to batch_027, and identify the round's batch by difference

### DIFF
--- a/itemtext/extraction_batches/round_prompt_v1.md
+++ b/itemtext/extraction_batches/round_prompt_v1.md
@@ -14,7 +14,7 @@ itemtext/BATCH_PROCESS.md if you need context beyond this prompt.
 Run: ls -d itemtables/batch_* 2>/dev/null | sort -V
 
 Stop, self-cancel, and log if ANY of these hold:
-- itemtables/batch_025 already exists (round cap reached)
+- itemtables/batch_027 already exists (round cap reached)
 - zero rows with status=="pending" in extraction_batches/queue_state.csv (queue exhausted)
 - extraction_batches/circuit_breaker.flag exists (a prior round tripped it; human review pending)
 

--- a/itemtext/extraction_batches/run_round.sh
+++ b/itemtext/extraction_batches/run_round.sh
@@ -183,13 +183,29 @@ mkdir -p "$LOG_DIR"
     exit 1
   fi
   if [[ -d "$ITEMTEXT/itemtables/$cap" ]]; then
-    echo "SKIP: round cap reached ($cap exists). Raise it in Step 0 of BOTH"
-    echo "BATCH_PROCESS.md and round_prompt_v1.md to run more rounds. Note the"
-    echo "off-by-one: the cap allows rounds UP TO AND INCLUDING that batch."
+    echo "SKIP: round cap reached ($cap exists). Raise it in Step 0 of"
+    echo "round_prompt_v1.md, which is the only copy of the prompt, to run more"
+    echo "rounds. Note the off-by-one: the cap allows rounds UP TO AND"
+    echo "INCLUDING that batch."
     exit 0
   fi
 
   echo "Guards clear: $pending pending, cap $cap not yet reached."
+
+  # Record which batch directories exist BEFORE the agent runs, so the checks
+  # after it can identify the batch this round actually created by difference.
+  #
+  # They used to infer it with `ls -d itemtables/batch_* | sort -V | tail -1`,
+  # which silently means "some other batch" the moment a directory that sorts
+  # after the runner's own lands in the tree. Hand-built ranges do exactly that
+  # -- itemtext#1945 claims batch_201-205 -- and so does any named batch, e.g.
+  # batch_enem_2023. Neither post-round check crashes when that happens; both
+  # just stop protecting, which is worse. The failed/blocked-wrote-a-CSV warning
+  # filters on `$batch == basename($batch_dir)` and matches nothing, and the
+  # round-completed check tests for an audit_report.csv that the other batch
+  # supplies. Difference is immune to naming and sort order alike.
+  _batches_before="$(ls -d "$ITEMTEXT"/itemtables/batch_* 2>/dev/null | sort)"
+
   echo "Launching round agent at $(date -Is)."
   echo
 
@@ -207,6 +223,19 @@ mkdir -p "$LOG_DIR"
   rc="${PIPESTATUS[0]}"
   echo
   echo "Round agent exited $rc at $(date -Is)."
+
+  # The batch this round created: present now, absent before. If the round made
+  # none (it stood down, or died before Step 3) this is empty, and every check
+  # below is written to treat empty as "no batch to vouch for" rather than
+  # falling back to a guess.
+  batch_dir="$(comm -13 <(printf '%s\n' "$_batches_before") \
+                        <(ls -d "$ITEMTEXT"/itemtables/batch_* 2>/dev/null | sort) \
+               | tail -1)"
+  if [[ -n "$batch_dir" ]]; then
+    echo "This round built: $(basename "$batch_dir")"
+  else
+    echo "This round built no new batch directory."
+  fi
 
   # A 429 does NOT fail the round. When subagents are killed by a rate limit or a
   # spend cap the orchestrator finishes and exits 0, so nothing above notices and
@@ -227,7 +256,6 @@ mkdir -p "$LOG_DIR"
   # failed or blocked that nevertheless HAS a __items.csv on disk. That is the
   # thing the batch_019 rescue was about, it needs no transcript parsing, and it
   # cannot false-positive on the agent talking about rate limits.
-  batch_dir="$(ls -d "$ITEMTEXT"/itemtables/batch_* 2>/dev/null | sort -V | tail -1)"
   if [[ -n "$batch_dir" ]]; then
     mismatch=""
     while IFS=, read -r tbl status batch _rest; do
@@ -267,15 +295,20 @@ mkdir -p "$LOG_DIR"
   # try to repair anything -- reconciling a half-finished round is a human decision,
   # and the work is usually salvageable rather than lost.
   left="$(awk -F, 'NR>1 && $2=="in_progress"' "$QUEUE" | wc -l)"
-  batch_dir="$(ls -d "$ITEMTEXT"/itemtables/batch_* 2>/dev/null | sort -V | tail -1)"
-  if [[ "$left" -gt 0 || ! -f "$batch_dir/audit_report.csv" ]]; then
+  if [[ "$left" -gt 0 || -z "$batch_dir" || ! -f "$batch_dir/audit_report.csv" ]]; then
     echo
     echo "ERROR: the agent exited 0 but the round did NOT complete."
     [[ "$left" -gt 0 ]] && echo "  - $left row(s) still in_progress"
-    [[ -f "$batch_dir/audit_report.csv" ]] || echo "  - no audit_report.csv in $batch_dir (Step 4 never finished)"
+    [[ -n "$batch_dir" ]] || echo "  - no new batch directory was created (Step 3 never finished)"
+    [[ -z "$batch_dir" || -f "$batch_dir/audit_report.csv" ]] || echo "  - no audit_report.csv in $batch_dir (Step 4 never finished)"
     echo
-    echo "Do not re-run. The extraction work is probably intact -- check $batch_dir,"
-    echo "run the Step 4 gates, and close the round out by hand per BATCH_PROCESS.md."
+    if [[ -n "$batch_dir" ]]; then
+      echo "Do not re-run. The extraction work is probably intact -- check $batch_dir,"
+      echo "run the Step 4 gates, and close the round out by hand per BATCH_PROCESS.md."
+    else
+      echo "Do not re-run. No batch directory to inspect; reconcile queue_state.csv"
+      echo "by hand per BATCH_PROCESS.md before another round claims tables."
+    fi
     exit 1
   fi
 


### PR DESCRIPTION
Unblocks the round runner, and fixes the bug @xingyi-zhang reported in #1945.

**Cap 025 → 027.** `batch_025` exists, so every firing has been standing down at Step 0 with "round cap reached". 1,086 tables remain pending. Two more rounds, matching the recent step size (021, 022, 024, 025).

**`run_round.sh` no longer guesses which batch the round built.** Both post-round checks rediscovered it with `ls -d itemtables/batch_* | sort -V | tail -1` — "whatever sorts last", not "what this round created". #1945 claims a hand-built `batch_201`–`batch_205`, and any such directory (or a named one like `batch_enem_2023`) outranks anything the runner produces. Neither check crashes; both silently stop protecting:

- the failed/blocked-wrote-a-CSV warning filters on `$batch == basename($batch_dir)`, so it matches no queue row;
- the round-completed check tests for `$batch_dir/audit_report.csv`, which a finished hand-built batch supplies — so a half-finished round passes.

Now the runner snapshots the batch directories before launching the agent and takes the difference afterwards. Immune to sort order and naming alike. An empty result means "the round built nothing" and is reported as a Step 3 failure rather than silently falling back to another batch.

The cap check at Step 0 tests a named directory and was never affected.

Also corrects the cap-reached message, which told the reader to raise the cap in *both* `BATCH_PROCESS.md` and `round_prompt_v1.md`. `BATCH_PROCESS.md:125` says the prompt file is the only copy, and it is.

Verified the difference logic against three cases: a `batch_201` present alongside the round's own output (picks the round's), a round that creates nothing (empty), and an empty tree beforehand (picks the only one). `bash -n` clean.

Ordering note: the cap bump is what lets a round run again, and the fix is what keeps its checks honest once a 201+ directory lands — so these should merge together, before the next firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTbw36z8HQrU9YW3tTrL6i