### PR TITLE
itemtext skill: record the two 2026-09-04 rights rulings, and close the question the docs still call open

### DIFF
--- a/itemtext/.claude/skills/irw-auto-itemtext/SKILL.md
+++ b/itemtext/.claude/skills/irw-auto-itemtext/SKILL.md
@@ -256,12 +256,53 @@ model knowledge of the instrument — the bar is on publishing the items, not on
 they were obtained.
 
 This is *narrower* than "the instrument is copyrighted". A commercial scale reproduced
-in full in an open-access paper's appendix is still extractable from that appendix; the
-item-text disclaimer covers a user's downstream reuse. What it does not cover is IRW
-republishing an instrument whose publisher has affirmatively refused it.
+in full in an open-access paper's appendix is generally still extractable from that
+appendix; the item-text disclaimer covers a user's downstream reuse. What it does not
+cover is IRW republishing an instrument whose publisher has affirmatively refused it —
+or, per the two rulings in the next section, one whose rights holder charges an enforced
+fee or states a no-redistribution clause. Those two override the appendix, and the
+TAS-20 is exactly that case: its wording was printed in full by a CC BY 4.0 PeerJ
+article, and IRW withdrew it anyway.
 
 Currently excluded under this rule: `himmelstein-shipley_vocabulary-2025`,
 `himmelstein-shipley_abstraction-2025`.
+
+## Rights on the wording: two triggers, and both are quote tests
+
+Settled by Ben on 2026-09-04. These are about the *instrument's* rights holder, and they
+apply on top of, not instead of, the standing exclusion above.
+
+**Start from the distinction that makes the check worth doing: the deposit licence is not
+the instrument licence.** A CC BY 4.0 or CC0 deposit governs the *response data*. It says
+nothing about who owns the *item wording*, which for a published scale belongs to its
+authors or publisher. This is common, not exotic — of the 60 tables claimed in irw#1945,
+nine were named instruments sitting under permissive deposits (DERS, SWLS, HEXACO-PI-R,
+Need for Cognition, RWA, a social-desirability scale, the SCBCS, FAD+, EstCRM
+self-efficacy).
+
+**Block ONLY on something you can quote from the rights holder:**
+
+1. **An enforced licence fee.** Ruled on the TAS-20 ($40/study, enforced — a 2021
+   *Molecular Autism* retraction). Generalises to any fee-licensed instrument. Withdrew
+   `cucchi_2018_tas20` and `rmet_higgins_2022_tas`; blocked `ruiz_parra_2023_tas20`.
+2. **An explicit no-redistribution clause.** Ruled on the DSES
+   (`CV_OASIS_ODSIS_PPE_Novak_2020_DSES`, "Permission of author required to distribute or
+   copy"). This settles the question the WHOQOL ruling left open: yes, a quotable clause
+   overrides the source deposit's licence, for any instrument.
+
+**Silence is permission.** An instrument being merely copyrighted, commercially sold, well
+known, or reproduced somewhere without an explicit grant is **not** a block. If you cannot
+find and quote a restriction, extract it normally. Do not block on suspicion, and do not
+open a negotiation with a rights holder — see the Shipley rule above.
+
+These two end in `blocked`, not `excluded`, because a licence can change and a fee can be
+paid; the Shipley exclusion is permanent. Put the quoted sentence and its URL in
+`notes.csv` and in `provenance.csv`. **A rights block with no quote in it is not a rights
+block.** Do not rely on the `wording_rights` column to record this — it takes only `NC`,
+cannot express either trigger, and is currently set on zero tables (irw#1955).
+
+Everything shipped before 2026-09-04 predates both rulings and has never been checked
+against them; that re-audit is irw#1954, still owed.
 
 ## Before doing anything
 

--- a/itemtext/.claude/skills/irw-auto-itemtext/references/itemtext_standard.md
+++ b/itemtext/.claude/skills/irw-auto-itemtext/references/itemtext_standard.md
@@ -18,7 +18,7 @@ per-table tabs (instrument, sections, items, responses) on `table` / `section_id
 | `item_text` | Literal text of the specific prompt or question associated with an `item`. |
 | `correct_response` | Scoring key for a given `item`. Blank when there is no correct answer; multiple correct answers are semicolon-separated (e.g. `A;C`). |
 | `option_text` | Literal text for a specific response option available for an item. May legitimately be missing for behavior-scored items. |
-| `wording_rights` | `NC` when the instrument's rights holder states a non-commercial restriction on the wording, even though IRW copied it from an openly licensed source. Omitted entirely when there is no such restriction. |
+| `wording_rights` | `NC` when the instrument's rights holder states a non-commercial restriction on the wording, even though IRW copied it from an openly licensed source. Omitted entirely when there is no such restriction. **Known gap (irw#1955): the value space is `NC` only, so it cannot express an enforced fee or a no-redistribution clause — the two 2026-09-04 triggers — and as of 2026-09-04 it is set on zero live tables. Do not rely on it to find rights-affected tables; record the quoted term in `provenance.csv` and `public_note` as well.** |
 | `resp` | Response value assigned to a specific `option_text` — must match the numeric/ordinal values already present in the live response-level IRW dataset (`irw::irw_fetch(table)$resp`). |
 | `instructions_translated`, `section_prompt_translated`, `item_text_translated`, `option_text_translated` | English translation of the correspondingly named field. Present only for instruments administered in a language other than English. |
 
@@ -181,13 +181,31 @@ WHOQOL wording came from openly licensed deposits — CC0 in the COACH case — 
 ruling it would ship. Ben ruled otherwise: a rights holder's explicit no-redistribution term is
 honoured even where the copy came from an open source.
 
-**What this does NOT do is generalise itself.** It is a ruling about the WHOQOL, reached by reading
-that instrument's actual terms. It leaves an open question that a later ruling should settle
-deliberately rather than by drift: whether *any* quotable no-redistribution clause should override
-the source licence, which would reverse the ECR-R decision for a whole class of instruments. Do not
-extend this to another instrument without asking — and note that finding the terms took a text proxy,
-because `cpcr.aut.ac.nz` returns 403 to a direct fetch and Manchester's user-information PDF fails on
-a TLS certificate mismatch. Absence of a retrievable clause is not absence of a clause.
+**This has since been generalised — the open question was settled on 2026-09-04.** As written, the
+WHOQOL ruling was a decision about one instrument, and it deliberately left open whether *any*
+quotable no-redistribution clause should override the source licence. Ben answered that on
+2026-09-04, ruling on the DSES (`CV_OASIS_ODSIS_PPE_Novak_2020_DSES`, "Permission of author required
+to distribute or copy"): **yes, it generalises.** A quotable no-redistribution clause from the rights
+holder outranks the deposit's licence, whatever that licence is. You no longer need to ask before
+applying this to another instrument.
+
+Note that finding the WHOQOL terms took a text proxy, because `cpcr.aut.ac.nz` returns 403 to a
+direct fetch and Manchester's user-information PDF fails on a TLS certificate mismatch. **Absence of
+a retrievable clause is not absence of a clause** — that caution still stands, and is why the rule
+below is stated as a quote test rather than an inference.
+
+**The second 2026-09-04 ruling: an enforced licence fee also disqualifies.** Ruled on the TAS-20
+($40 per study, enforced — there is a 2021 *Molecular Autism* retraction over it). This generalises
+too, to any fee-licensed instrument. It withdrew `cucchi_2018_tas20` and `rmet_higgins_2022_tas` and
+blocked `ruiz_parra_2023_tas20`. It applies even where the source published the items under an open
+licence: `cucchi_2018_tas20`'s wording came from a CC BY 4.0 PeerJ article that printed all 20 items.
+
+**Both triggers are quote tests, and silence is permission.** Block only on something you can quote
+from the rights holder — an enforced fee, or an explicit no-redistribution clause. An instrument
+being merely copyrighted, commercially sold, well known, or reproduced somewhere without an explicit
+grant is **not** a block. If you cannot find and quote a restriction, extract normally; do not block
+on suspicion, and do not open a negotiation with a rights holder. Record the quoted sentence and its
+URL — a rights block with no quote in it is not a rights block.
 
 **But the instrument-level restriction is recorded, not ignored.** Where the rights
 holder states one, set `wording_rights=NC` on every row of that table and add an


### PR DESCRIPTION
The skill predates both 2026-09-04 rulings. The problem turned out to be sharper than "they're missing" — **the docs actively told an agent the opposite.**

`references/itemtext_standard.md` parked the DSES question as unresolved:

> *"whether **any** quotable no-redistribution clause should override the source licence... Do not extend this to another instrument without asking"*

That is exactly what @ben-domingue answered on 2026-09-04, ruling that it **does** generalise. Until now the reference instructed agents not to apply a rule that has been in force for a day.

### Changes

- **`itemtext_standard.md`** — the WHOQOL "does not generalise itself" paragraph now records that it since did, via the DSES, and adds the second trigger: an enforced licence fee, ruled on the TAS-20. Keeps *"absence of a retrievable clause is not absence of a clause"*, which is precisely why both are stated as quote tests rather than inferences.
- **`SKILL.md`** — a new section after the Shipley standing exclusion covering the deposit-licence-is-not-the-instrument-licence distinction, both triggers, and the narrow test.
- **The Shipley section had a sentence that is now wrong in one direction.** It said a commercial scale reproduced in an open-access appendix is still extractable, unqualified. The TAS-20 is the counterexample: its wording was printed in full by a CC BY 4.0 PeerJ article and IRW withdrew it anyway. Qualified rather than removed — it is still the right default.
- **`wording_rights` is documented as unable to carry either trigger.** It takes only `NC`, so it cannot express a fee, and it is set on zero live tables (#1955). The quote goes in `provenance.csv` and `public_note`; the column is not a way to find affected tables.

### The narrowness is deliberate, and stated twice

**Silence is permission.** Merely copyrighted, commercially sold, well known, or reproduced without an explicit grant is **not** a block. An earlier draft of this guidance, posted to #1945 and corrected there, used "rights do not clearly permit redistribution" as the test — which would have over-blocked most of the nine published instruments in that batch of 60.

These two triggers end in `blocked`, not `excluded`: a licence can change and a fee can be paid, whereas the Shipley bar is permanent.

Also notes that everything shipped before 2026-09-04 has never been checked against either ruling — #1954, still owed.

**Relationship to the reverted #1957:** that PR put this in `round_prompt_v1.md`. This one puts it in the skill instead, which every extraction agent reads in full and which is where the existing rights rules already live. The prompt is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTbw36z8HQrU9YW3tTrL6i