### PR TITLE
red_up.drafts: compare the content hash, not the row count (#1856)

### DIFF
--- a/red_up/drafts.py
+++ b/red_up/drafts.py
@@ -72,10 +72,19 @@ def inspect(owner: str, target, now: dt.datetime):
     )
 
     # Only count it as a backlog if the draft actually differs from the release.
+    # Compare the table's content `hash`, not its row count: every repair in
+    # irw#1856 -- NULLing an out-of-range value, restoring a dropped occasion
+    # column, renaming one -- keeps the row count identical by design, so a
+    # numRows comparison called a 33-table backlog "nothing pending" and ten
+    # verified fixes sat unreleased for two days. Fall back to numRows only if
+    # a table has no hash.
+    def _fingerprint(t):
+        return t.properties.get("hash") or ("rows", t.properties.get("numRows"))
+
     try:
-        d_tables = {t.name: t.properties.get("numRows")
+        d_tables = {t.name: _fingerprint(t)
                     for t in redivis.user(owner).dataset(target.name, version="next").list_tables()}
-        r_tables = {t.name: t.properties.get("numRows")
+        r_tables = {t.name: _fingerprint(t)
                     for t in redivis.user(owner).dataset(target.name, version="current").list_tables()} \
             if last is not None else {}
     except Exception as exc:

--- a/red_up/tests/test_red_up.py
+++ b/red_up/tests/test_red_up.py
@@ -294,9 +294,11 @@ class _Version:
 
 
 class _Table:
-    def __init__(self, name, rows):
+    def __init__(self, name, rows, hash_=None):
         self.name = name
         self.properties = {"numRows": rows}
+        if hash_ is not None:
+            self.properties["hash"] = hash_
 
 
 def _ms(days_ago, now):
@@ -314,7 +316,12 @@ def _fake_redivis(monkeypatch, versions, draft_tables, released_tables):
 
         def list_tables(self):
             src = draft_tables if self._v == "next" else released_tables
-            return [_Table(n, r) for n, r in src.items()]
+            out = []
+            for n, r in src.items():
+                # a value may be a bare row count, or (rows, hash)
+                rows, h = r if isinstance(r, tuple) else (r, None)
+                out.append(_Table(n, rows, h))
+            return out
 
     class _User:
         def dataset(self, name, version=None):
@@ -359,6 +366,32 @@ def test_drafts_ignores_a_draft_identical_to_the_release(monkeypatch):
     )
     r = _drafts.inspect("datapages", _target(), now)
     assert r["pending"] == 0, "an untouched draft is not a backlog, however old the release"
+
+
+def test_drafts_sees_a_repair_that_keeps_the_row_count(monkeypatch):
+    """The irw#1856 case: every repair preserves rows, so numRows sees nothing."""
+    now = _dt.datetime.now(_dt.timezone.utc)
+    _fake_redivis(
+        monkeypatch,
+        versions=[_Version("v47.0", True, _ms(2, now)), _Version("next", False, _ms(0.1, now))],
+        draft_tables={"ravens_deboeck2012": (11622, "aaa"), "untouched": (100, "same")},
+        released_tables={"ravens_deboeck2012": (11622, "bbb"), "untouched": (100, "same")},
+    )
+    r = _drafts.inspect("datapages", _target(), now)
+    assert r["changed"] == ["ravens_deboeck2012"]
+    assert r["pending"] == 1
+
+
+def test_drafts_falls_back_to_rows_without_a_hash(monkeypatch):
+    now = _dt.datetime.now(_dt.timezone.utc)
+    _fake_redivis(
+        monkeypatch,
+        versions=[_Version("v1.0", True, _ms(3, now)), _Version("next", False, _ms(0.1, now))],
+        draft_tables={"a__items": 10, "b__items": 20},
+        released_tables={"a__items": 10, "b__items": 99},
+    )
+    r = _drafts.inspect("datapages", _target(), now)
+    assert r["changed"] == ["b__items"]
 
 
 def test_drafts_reports_no_draft(monkeypatch):


### PR DESCRIPTION
Every repair in #1856 preserves the row count by design. The overdue-draft
monitor decided "changed" by comparing `numRows` between `next` and `current`,
so it reported `item_response_warehouse` as **"draft matches v47.0 -- nothing
pending"** while the draft actually differed on **33 tables**.

Ten of those are #1856's own: `KTEEM_Schoen_2019-2022`, `ravens_deboeck2012`,
`motion`, `rr98_accuracy`, the five `bfi_goldberg_1992_*`, and
`gilbert_meta_31`. They were uploaded 2026-09-03, the monitor said there was
nothing to release, and v47.0 went out without them -- while the session
recorded them as live. The other 23 are `project_kids_*` from an unrelated
workstream, equally unnoticed.

Redivis exposes a per-table content `hash`. Comparing that catches all 33.
`numRows` stays as the fallback for a table without one.

Two tests: the #1856 shape (same rows, different hash) and the no-hash
fallback. 33 pass.

Related: #1856

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTeyJTfJ5dT2Xcc5Zmv3js