### PR TITLE
Make item text a shard list, ahead of the 1000-table cap

### DIFF
--- a/.github/workflows/version-manifest.yml
+++ b/.github/workflows/version-manifest.yml
@@ -1,6 +1,6 @@
 # Daily refresh of metadata/version_manifest.tsv (roadmap item 3.0, #1705).
 #
-# This job records which released Redivis version of each of the eleven datasets
+# This job records which released Redivis version of each registered dataset
 # was live at each point in the corpus' history. The R and Python packages read
 # the committed file from raw.githubusercontent, so a refresh that never lands
 # is a refresh no user ever sees, and a version released today but recorded next

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,28 +32,40 @@ GitHub.
 All data lives on Redivis under the account **`datapages`**. Everything else in
 this repository reads that from one place:
 
-> `IRW_OWNER`, `IRW_CORE_DATASETS` and `IRW_AUX_DATASETS` in
-> [`metadata/redivis_config.R`](metadata/redivis_config.R) are authoritative for
-> the owner and the dataset names.
+> `IRW_OWNER`, `IRW_CORE_DATASETS`, `IRW_TEXT_DATASETS` and `IRW_AUX_DATASETS`
+> in [`metadata/redivis_config.R`](metadata/redivis_config.R) are authoritative
+> for the owner and the dataset names.
+
+> **Redivis caps any single dataset at 1000 tables.** That cap is the reason
+> sharding exists, and it applies to *every* dataset, not just the response data.
 
 **Core shards** hold the response data. A *shard* here is simply one of several
 Redivis datasets with identical structure, named `item_response_warehouse`,
-`item_response_warehouse_2`, and so on — a new one is added whenever the warehouse
-outgrows the last. Which shard a given table is in is not predictable
+`item_response_warehouse_2`, and so on — a new one is added when the last hits
+the cap. Which shard a given table is in is not predictable
 from its name, so the client packages search them **newest-first** and return the
 first match — meaning a name present in more than one shard resolves to its most
 recent copy.
 
-**Auxiliary datasets** hold everything that is not response data: `irw_meta` (all
-metadata, biblio, tags and collections tables), `irw_text` (item text), plus one
-each for the `simsyn`, `competitions` and `nominal` sources.
+**Item text shards the same way**, for the same reason: `irw_text`, `irw_text_2`,
+… in `IRW_TEXT_DATASETS`, searched newest-first, first match wins. A table stays
+reachable from whichever shard already holds it, so tables are never moved
+between shards — moving one *creates* the shadowing problem rather than solving
+it. `Rpkg/inst/developer/warehouses.md` carries the checklist for adding a shard
+of either kind.
+
+**Auxiliary datasets** hold everything else: `irw_meta` (all
+metadata, biblio, tags and collections tables), plus one
+each for the `simsyn`, `competitions` and `nominal` sources. These are single
+datasets rather than shard lists only because none is near the cap.
 
 How many of each exist today is *not* recorded here, deliberately — that number
 grows, and a count written into prose is wrong the day it changes. `redivis_config.R`
 is the answer:
 
 ```r
-source("metadata/redivis_config.R"); IRW_CORE_DATASETS; IRW_AUX_DATASETS
+source("metadata/redivis_config.R")
+IRW_CORE_DATASETS; IRW_TEXT_DATASETS; IRW_AUX_DATASETS
 ```
 
 Until August 2026 all of this lived under the personal Redivis account
@@ -66,7 +78,10 @@ older scripts still work.
 > source of truth. They are reconcilable — this repo carries plain dataset
 > *names*, the two packages additionally carry version *hashes* — but a new shard
 > must be added in all three, and nothing currently checks that they agree. They
-> have already drifted once (#1733).
+> have already drifted once (#1733). Each file now carries *two* shard lists,
+> core and item text (`IRW_CORE_DATASETS`/`IRW_TEXT_DATASETS`,
+> `.irw_datasource_specs$core`/`.irw_itemtext_specs`,
+> `MAIN_REFS`/`ITEMTEXT_REFS`), so adding a shard means six edits, not three.
 
 ## 3. Google Sheets
 
@@ -192,10 +207,12 @@ draft is touched, and the draft version's own `createdAt` resets on each upload.
 `red_up` replaced thirteen near-identical copies of one script, each hardcoding
 a different dataset, so the destination used to be decided by which file you
 happened to run. It reads the dataset list from `metadata/redivis_config.R`,
-defaults by filename (`*__items.csv` → `irw_text`, otherwise the newest shard),
-checks every shard for an existing table of the same name before writing —
-because a copy in a newer shard *shadows* the older one rather than replacing
-it — and verifies each table with a `count(*)` afterwards.
+defaults by filename (`*__items.csv` → the newest item-text shard, otherwise the
+newest core shard), checks every shard of both kinds for an existing table of the
+same name before writing — because a copy in a newer shard *shadows* the older one
+rather than replacing it — and verifies each table with a `count(*)` afterwards.
+When a name is already in use somewhere that could not legally hold the file, it
+stops rather than routing across families.
 
 `irw_site` also reads one file directly off disk rather than from Redivis:
 `data/hero_stats.json`, written into that repository by `metadata/09_hero_status.R`.

--- a/itemtext/.claude/skills/irw-auto-itemtext/SKILL.md
+++ b/itemtext/.claude/skills/irw-auto-itemtext/SKILL.md
@@ -198,7 +198,8 @@ The output claims to be what the study administered. Three rules:
   `references/itemtext_standard.md`), so a table carrying them is uploadable without any
   further sign-off. `validate_items.R` checks that required columns are *present* and
   tolerates extras, so the gate is unaffected. The uploader hands the CSV to Redivis, which
-  infers fields from the file — the first such upload is what widens `irw_text` to hold them.
+  infers fields from the file — the first such upload is what widens the item-text
+  dataset to hold them.
   Whether the already-uploaded tables get backfilled is still open (irw#1777) —
   `ALSECYPIAMH_WU_2022_SDQ` and `altahla_2024_whoqol` ship English for non-English
   administrations, and `burkert_2019_whoqol_bref` ships German with no translation. The rule
@@ -785,7 +786,8 @@ write.csv(items, file = "itemtables/<table>__items.csv", row.names = FALSE)
 Written into `itemtext/itemtables/` (not the `itemtext/` root) — this is where the
 upload step expects to find files (`red_up itemtables`). Don't upload automatically;
 that's a separate, explicit step (see "Uploading", below) since it pushes to the shared
-`datapages/irw_text:next` Redivis dataset.
+item-text dataset on Redivis (`datapages/irw_text:next` today; see the note on shards
+under "Uploading").
 
 ### Step 6b — Logging discrepancies (no Sheets-write tool available)
 
@@ -1008,9 +1010,10 @@ convention across the 422 published tables (the `NA` token, as `write.csv` emits
 anomalies, coverage gaps, and `option_text` padded with its own `resp` value.
 
 **Note for uploads:** the uploader walks a directory recursively. `red_up` excludes
-every file that is not `*__items.csv` when the target is `irw_text` and lists what it
-excluded, so `notes.csv`, `provenance.csv` and `audit_report.csv` are safe — but read
-that exclusion list rather than assuming, and check the target line says `irw_text`.
+every file that is not `*__items.csv` when the target is an item-text shard and lists
+what it excluded, so `notes.csv`, `provenance.csv` and `audit_report.csv` are safe — but
+read that exclusion list rather than assuming, and check the target line names an
+item-text dataset (`irw_text`, or a later `irw_text_N` — see "Uploading").
 
 ## Idempotency & caching
 
@@ -1134,8 +1137,11 @@ on to the next candidate rather than forcing a fabricated match.
 red_up itemtables
 ```
 
-`red_up` sees `*__items.csv` and defaults to `datapages/irw_text:next`; it shows the
-target and the full file list, marks each table NEW or UPDATE, and asks before writing
+`red_up` sees `*__items.csv` and defaults to the **newest item-text shard** —
+`datapages/irw_text:next` today. Redivis caps a dataset at 1000 tables, so item text
+shards the way response data does (`irw_text`, `irw_text_2`, …); read the target line
+rather than expecting a particular name, and do not "correct" it to `irw_text` if it
+names a later shard. It shows the target and the full file list, marks each table NEW or UPDATE, and asks before writing
 anything. It uploads only to the draft version, and verifies each table's row count with
 a `count(*)` afterwards. Only run this when the user explicitly asks to upload — it's a
 shared-system write, same caution as any other Redivis upload in this repo. See

--- a/itemtext/BATCH_PROCESS.md
+++ b/itemtext/BATCH_PROCESS.md
@@ -16,7 +16,7 @@ extraction) — this file covers the batching layer. The round's own prompt is
 | `itemtables/batch_NNN/` | `{table}__items.csv` (validated output), `notes.csv`, `provenance.csv`, `verification_merged.csv`, `audit_report.csv`. |
 | `mapping_verification.csv` | Permanent, cross-batch record of how each table's item↔text mapping was verified (`route`, `status`, `evidence`). One row per table, ever. Fed by each batch's `verification_merged.csv`. |
 | `itemtables/pending_index_notes.csv` | Standing cumulative log of tables that could not be automated, for the index workbook. Columns `table,note,status`; `status` is one of `pending`/`blocked`/`excluded`/`note_only`/`resolved` (see SKILL.md Step 6b). Append across batches; never reset. |
-| `itemtables/clean/` | Vetted tables staged for upload. **Only `*__items.csv` may live here** — an uploader walks recursively, and this directory exists because stray `.csv` files were once uploaded as tables. `red_up` now excludes non-`__items` files when the target is `irw_text` and names what it excluded, but keep the directory clean anyway. Ben clears it after uploading. |
+| `itemtables/clean/` | Vetted tables staged for upload. **Only `*__items.csv` may live here** — an uploader walks recursively, and this directory exists because stray `.csv` files were once uploaded as tables. `red_up` now excludes non-`__items` files when the target is an item-text shard and names what it excluded, but keep the directory clean anyway. Ben clears it after uploading. |
 
 Everything except `queue_state.csv` is rederived from disk each round, so a round
 that dies partway (API limit, crash) is safely resumable — the next firing sees

--- a/itemtext/language_backfill/README.md
+++ b/itemtext/language_backfill/README.md
@@ -143,9 +143,14 @@ created 78 duplicate tables. Caught by ben-domingue before upload.
 **Check before any upload**, against the raw Redivis names rather than the R
 package's:
 
+Item text is a shard list, so check every shard rather than naming one -- a
+table that lives in an older shard is still an existing table.
+
 ```r
-nm <- vapply(redivis::user("datapages")$dataset("irw_text:07b6")$list_tables(),
-             function(t) t$name, character(1))
+source("../../metadata/redivis_config.R")   # IRW_OWNER, IRW_TEXT_DATASETS
+nm <- unlist(lapply(IRW_TEXT_DATASETS, function(ds)
+  vapply(redivis::user(IRW_OWNER)$dataset(ds)$list_tables(),
+         function(t) t$name, character(1))))
 fs <- sub("\\.csv$", "", list.files("staged", pattern = "__items\\.csv$"))
 sum(!fs %in% nm)   # must be 0 - anything else creates new tables
 ```

--- a/metadata/redivis_config.R
+++ b/metadata/redivis_config.R
@@ -10,7 +10,7 @@
 ##   source("redivis_config.R")
 ##
 ## History: all IRW datasets lived under the personal account "bdomingu" until
-## August 2026, when the five auxiliary datasets (irw_meta, irw_text, irw_simsyn,
+## August 2026, when the five non-core datasets (irw_meta, irw_text, irw_simsyn,
 ## irw_competitions, irw_nominal) were transferred to "datapages" to join the six
 ## core warehouses already there. Short dataset IDs were unchanged. Redivis
 ## auto-resolves references to a previous owner, so a future move means editing
@@ -32,10 +32,26 @@ IRW_CORE_DATASETS <- c(
   "item_response_warehouse_6"
 )
 
+## Item-text shards, oldest to newest.
+##
+## Redivis caps any dataset at 1000 tables, which is why response data is
+## sharded -- and item text shards on the same rule. Clients search these
+## newest-first and return the first match, exactly as they do for the core
+## warehouses, so a table keeps resolving from whichever shard already holds it.
+## See ARCHITECTURE.md section 2, and Rpkg/inst/developer/warehouses.md for the
+## checklist to follow when adding one.
+IRW_TEXT_DATASETS <- c(
+  "irw_text"
+)
+
 ## Auxiliary (non-core) datasets, by the `source` name the irw package uses.
+##
+## Item text is deliberately NOT here: it is a shard list (IRW_TEXT_DATASETS
+## above), and this vector is named, so it could only ever hold one text entry.
+## Naming the dataset in both places would duplicate it within a single file --
+## the very thing ARCHITECTURE.md section 2 warns about.
 IRW_AUX_DATASETS <- c(
   meta = "irw_meta",
-  text = "irw_text",
   sim  = "irw_simsyn",
   comp = "irw_competitions",
   nom  = "irw_nominal"

--- a/red_up/README.md
+++ b/red_up/README.md
@@ -28,9 +28,13 @@ sub-items 1.1 and 1.2.
 anything else. The old scripts `chdir`'d into their own directory first, so
 `python3 upload.py .` never meant your shell's directory.
 
-**Picks a default dataset.** Any `*__items.csv` present ⇒ `irw_text`;
-otherwise the newest shard. The menu shows every dataset in
+**Picks a default dataset.** Any `*__items.csv` present ⇒ the newest item-text
+shard; otherwise the newest core shard. The menu shows every dataset in
 `metadata/redivis_config.R` — Enter takes the default.
+
+Both response data and item text are **shard lists**, because Redivis caps a
+dataset at 1000 tables (`ARCHITECTURE.md` §2). A second item-text shard is a
+one-line edit to `IRW_TEXT_DATASETS`; nothing in this package changes.
 
 **Excludes what does not belong.** Once a dataset is chosen, files of the wrong
 kind are listed and skipped rather than uploaded. This is the guard against the
@@ -45,6 +49,12 @@ return the first match. So uploading an existing table into a *newer* shard
 does not replace it — it **shadows** it, leaving two divergent copies with no
 error and no suspicious row count. Any such file is flagged `ELSEWHERE` and
 defaults to updating the dataset it already lives in.
+
+Every shard of *both* kinds is scanned, so a stray `__items` table that has
+landed in a warehouse is still reported. A cross-family match never becomes a
+cross-family upload, though: the offered home must itself be able to hold the
+file, and when none can, the file is skipped for a human rather than routed
+somewhere plausible-looking.
 
 **Replaces properly.** Redivis uploads *append*. `replace_on_conflict` only
 replaces an upload of the same name; rows inherited from the previously
@@ -63,7 +73,7 @@ a human click after reviewing the diff (`ARCHITECTURE.md` §4).
 
 | Thing | Source |
 |---|---|
-| Owner and dataset names | `metadata/redivis_config.R`, *parsed*, not restated |
+| Owner and dataset names | `metadata/redivis_config.R`, *parsed*, not restated (`IRW_CORE_DATASETS`, `IRW_TEXT_DATASETS`, `IRW_AUX_DATASETS`) |
 | Write token | `irw_secrets.load_write_token()` → `~/.config/irw/redivis-write.env` |
 | Required columns | `datastandard.md` |
 

--- a/red_up/cli.py
+++ b/red_up/cli.py
@@ -25,7 +25,8 @@ from .auth import authenticate
 from .checks import check_all, check_schema, validate_for_target
 from .discover import Discovery, discover, table_name
 from .push import open_draft, push_one
-from .targets import ConfigError, Target, guess_target, load_registry
+from .targets import (ConfigError, Target, eligible, guess_target,
+                      load_registry)
 
 #: irw_meta holds a fixed set of pipeline outputs, not arbitrary tables. The
 #: map lives in the irw-site-update skill's upload_meta.py; uploading anything
@@ -77,8 +78,28 @@ def choose_target(targets: list[Target], default: Target, assume: bool) -> Targe
         print("  not a valid choice")
 
 
+def _home_for(item: planning.Item, targets: list[Target]) -> str | None:
+    """The newest dataset already holding this table that may actually take it.
+
+    `found_in` spans both shard families, so the newest match is not always a
+    legal destination: an `__items` table that has strayed into a warehouse
+    shard would otherwise be "updated" right back into the warehouse, and a
+    response table found in a text shard likewise. `eligible()` is the same gate
+    the chosen target is held to, so ask it about the home as well.
+
+    Returns None when nothing that already holds the name may receive it, which
+    is a situation to stop on rather than guess at.
+    """
+    by_name = {t.name: t for t in targets}
+    for name in reversed(item.found_in):
+        known = by_name.get(name)
+        if known is not None and eligible(item.path, known) is None:
+            return name
+    return None
+
+
 def resolve_elsewhere(items: list[planning.Item], target: Target,
-                      assume: bool) -> None:
+                      targets: list[Target], assume: bool) -> None:
     """Ask, per file, what to do about a table that already exists elsewhere.
 
     The default is 'update it where it already lives'. Uploading into the
@@ -89,7 +110,14 @@ def resolve_elsewhere(items: list[planning.Item], target: Target,
         if item.status != planning.ELSEWHERE:
             continue
         where = ", ".join(item.found_in)
-        home = item.found_in[-1]     # newest dataset already holding it
+        home = _home_for(item, targets)
+        if home is None:
+            # Every dataset holding this name would reject the file. Never
+            # silently pick one; say so and skip.
+            item.dataset, item.status = None, planning.SKIP
+            item.note = (f"name already used in {where}, none of which may hold "
+                         f"this file -- resolve by hand")
+            continue
         if assume or not sys.stdin.isatty():
             item.dataset = home
             continue
@@ -218,9 +246,16 @@ def main(argv: list[str] | None = None) -> int:
 
     authenticate()
 
-    # Scan every core shard plus the target, so a table that already lives
-    # somewhere else is caught before it is duplicated rather than after.
-    scan = [t.name for t in targets if t.kind == "core"]
+    # Scan every shard -- core and item text -- plus the target, so a table that
+    # already lives somewhere else is caught before it is duplicated rather than
+    # after. Both families shadow newest-first, so both must be looked at.
+    #
+    # Deliberately both families rather than only the target's: `itemtables/clean/`
+    # exists because __items tables have strayed into warehouse shards before,
+    # and a run that does not look cannot report it. The cost is one extra
+    # parallel list_tables call on a response-data run. What must NOT follow from
+    # a cross-family match is a cross-family *upload* -- see `_home_for`.
+    scan = [t.name for t in targets if t.kind == "core" or t.is_itemtext]
     if target.name not in scan:
         scan.append(target.name)
     print(f"checking {len(scan)} datasets for existing tables ...")
@@ -234,7 +269,7 @@ def main(argv: list[str] | None = None) -> int:
             if item.table not in META_TABLES:
                 item.status, item.dataset = planning.EXCLUDED, None
                 item.note = f"not one of {target.name}'s {len(META_TABLES)} tables"
-    resolve_elsewhere(items, target, args.yes)
+    resolve_elsewhere(items, target, targets, args.yes)
     show(items, target, owner, found.skipped)
 
     if args.strict and any(i.report.warnings for i in items if i.dataset):

--- a/red_up/manifest.py
+++ b/red_up/manifest.py
@@ -4,8 +4,8 @@ An IRW-based paper cannot currently be replicated, because the data underneath
 it moves. Redivis versions each dataset independently -- `irw_meta` is at v19.x
 while `irw_simsyn` has had two releases ever -- so there is no corpus-wide
 number to cite. This module writes one down: a git-tracked file recording, for
-every point in the corpus' history, the released version of all eleven
-datasets. That is a lockfile, the same shape as `renv.lock`, and it is what
+every point in the corpus' history, the released version of every dataset
+registered in `redivis_config.R`. That is a lockfile, the same shape as `renv.lock`, and it is what
 `irw_version()` in the R and Python packages resolves against. See #1705.
 
     python3 -m red_up.manifest                 # refresh: append anything new
@@ -17,8 +17,8 @@ datasets. That is a lockfile, the same shape as `renv.lock`, and it is what
 Exit codes: 0 ok - 1 the file is stale or a rebuild would renumber - 2 bad input.
 
 **Why a full snapshot rather than a log of releases.** Every IRW version
-carries a row per dataset, so the file repeats itself and grows by eleven lines
-a release. The alternative -- one line per release, with clients deriving the
+carries a row per dataset, so the file repeats itself and grows by one line per
+dataset a release. The alternative -- one line per release, with clients deriving the
 snapshot by carrying values forward -- is a quarter the size and was rejected:
 the question a person actually asks is "what was everything pinned to at v333",
 and it should be answerable by looking, not by reimplementing a carry-forward in

--- a/red_up/targets.py
+++ b/red_up/targets.py
@@ -17,9 +17,14 @@ from pathlib import Path
 #: Filenames matching this go to the item-text dataset, never to a shard.
 ITEMS_SUFFIX = "__items.csv"
 
-#: How each aux dataset is labelled in the menu. Keys are the `source` names
-#: `redivis_config.R` uses. Note "pairs" is `irw_competitions`: there is no
-#: `irw_pairs` dataset and never has been.
+#: How each non-core dataset is labelled in the menu. Keys are the `source`
+#: names `redivis_config.R` uses. Note "pairs" is `irw_competitions`: there is
+#: no `irw_pairs` dataset and never has been.
+#:
+#: "text" is the odd one out: item text is a *shard list*
+#: (`IRW_TEXT_DATASETS`), not an entry in `IRW_AUX_DATASETS`, for the same
+#: reason the core warehouses are a list -- Redivis caps a dataset at 1000
+#: tables. Its label still lives here so the menu reads uniformly.
 AUX_LABELS = {
     "text": "item text (__items.csv)",
     "meta": "metadata tables",
@@ -112,11 +117,35 @@ def load_registry(config_path: Path | None = None) -> tuple[str, list[Target]]:
         name=targets[-1].name, label="response data (newest shard)", kind="core"
     )
 
+    # Item-text shards, appended before the other aux datasets so the menu
+    # still reads text / meta / nominal / pairs / sim.
+    text_shards = [
+        Target(name=value, label=AUX_LABELS["text"], kind="aux", source="text")
+        for _, value in _parse_char_vector(text, "IRW_TEXT_DATASETS")
+    ]
+    if not text_shards:
+        raise ConfigError("IRW_TEXT_DATASETS is empty")
+    if len(text_shards) > 1:
+        text_shards[-1] = Target(
+            name=text_shards[-1].name,
+            label=f"{AUX_LABELS['text']} -- newest shard",
+            kind="aux", source="text",
+        )
+    targets.extend(text_shards)
+
     aux = dict(
         (key, value)
         for key, value in _parse_char_vector(text, "IRW_AUX_DATASETS")
         if key
     )
+    if "text" in aux:
+        # Declared in two places, which is how the three "single source of
+        # truth" files drifted before (#1733). Refuse rather than pick one.
+        raise ConfigError(
+            "redivis_config.R declares item text twice: `text` is a key in "
+            "IRW_AUX_DATASETS and IRW_TEXT_DATASETS also exists. Item text is a "
+            "shard list -- remove the `text =` entry from IRW_AUX_DATASETS."
+        )
     unknown = set(aux) - set(AUX_LABELS)
     if unknown:
         raise ConfigError(
@@ -124,7 +153,7 @@ def load_registry(config_path: Path | None = None) -> tuple[str, list[Target]]:
             f"{sorted(unknown)}. Add them to AUX_LABELS in targets.py."
         )
     for source, label in AUX_LABELS.items():
-        if source in aux:
+        if source != "text" and source in aux:
             targets.append(
                 Target(name=aux[source], label=label, kind="aux", source=source)
             )
@@ -139,8 +168,25 @@ def newest_shard(targets: list[Target]) -> Target:
     return core[-1]
 
 
+def text_shards(targets: list[Target]) -> list[Target]:
+    """Every item-text shard, oldest to newest."""
+    return [t for t in targets if t.is_itemtext]
+
+
+def newest_text_shard(targets: list[Target]) -> Target | None:
+    """The shard new item text goes to by default."""
+    shards = text_shards(targets)
+    return shards[-1] if shards else None
+
+
 def itemtext_target(targets: list[Target]) -> Target | None:
-    return next((t for t in targets if t.is_itemtext), None)
+    """The item-text destination: the newest shard.
+
+    Uploading into an *older* text shard would be the shadowing bug in reverse
+    -- clients resolve newest-first, so a table written to shard 1 while shard 2
+    holds a copy stays invisible.
+    """
+    return newest_text_shard(targets)
 
 
 #: Columns a table must have to belong in a given destination.

--- a/red_up/tests/test_red_up.py
+++ b/red_up/tests/test_red_up.py
@@ -14,6 +14,7 @@ from unittest import mock
 import unittest
 from pathlib import Path
 
+from red_up import cli
 from red_up import plan as planning
 from red_up.checks import check_all, check_schema, scan, validate_for_target
 from red_up.discover import discover, table_name
@@ -25,6 +26,8 @@ from red_up.targets import (
     guess_target,
     load_registry,
     newest_shard,
+    newest_text_shard,
+    text_shards,
 )
 
 RESPONSE = "id,item,resp\n1,a,1\n2,a,0\n"
@@ -47,10 +50,29 @@ class Registry(unittest.TestCase):
         self.assertEqual(
             names[:6],
             [f"item_response_warehouse{s}" for s in ("", "_2", "_3", "_4", "_5", "_6")])
+        # Item text comes first among the non-core targets and is a shard list;
+        # the other four are the plain aux datasets.
+        self.assertEqual([t.name for t in text_shards(targets)], ["irw_text"])
         self.assertEqual(
             sorted(names[6:]),
             ["irw_competitions", "irw_meta", "irw_nominal", "irw_simsyn", "irw_text"])
         self.assertEqual(newest_shard(targets).name, "item_response_warehouse_6")
+        self.assertEqual(newest_text_shard(targets).name, "irw_text")
+
+    def test_item_text_declared_twice_is_refused(self):
+        # The three "single source of truth" files drifted once (#1733).
+        # Declaring item text in both places here is the same failure in one
+        # file, so it must raise rather than silently pick one.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "redivis_config.R"
+            path.write_text(
+                'IRW_OWNER <- "datapages"\n'
+                'IRW_CORE_DATASETS <- c("a")\n'
+                'IRW_TEXT_DATASETS <- c("irw_text")\n'
+                'IRW_AUX_DATASETS <- c(text = "irw_text")\n')
+            with self.assertRaises(ConfigError) as caught:
+                load_registry(path)
+            self.assertIn("twice", str(caught.exception))
 
     def test_pairs_is_competitions(self):
         # There is no irw_pairs dataset and never has been; "pairs" is the
@@ -73,9 +95,121 @@ class Registry(unittest.TestCase):
             path.write_text(
                 'IRW_OWNER <- "datapages"\n'
                 'IRW_CORE_DATASETS <- c(\n  "a",\n  # "retired_shard",\n  "b"\n)\n'
-                'IRW_AUX_DATASETS <- c(text = "irw_text")\n')
+                'IRW_TEXT_DATASETS <- c("irw_text")\n'
+                'IRW_AUX_DATASETS <- c(meta = "irw_meta")\n')
             _, targets = load_registry(path)
-            self.assertEqual([t.name for t in targets], ["a", "b", "irw_text"])
+            self.assertEqual([t.name for t in targets],
+                             ["a", "b", "irw_text", "irw_meta"])
+
+
+class TwoTextShards(unittest.TestCase):
+    """The path that matters once `irw_text` hits Redivis' 1000-table cap.
+
+    None of this is reachable through the live config yet -- IRW_TEXT_DATASETS
+    has one entry. These tests exist so the second shard is a config edit on the
+    day it is needed rather than a code change made under pressure.
+    """
+
+    CONFIG = (
+        'IRW_OWNER <- "datapages"\n'
+        'IRW_CORE_DATASETS <- c("w1", "w2")\n'
+        'IRW_TEXT_DATASETS <- c("irw_text", "irw_text_2")\n'
+        'IRW_AUX_DATASETS <- c(meta = "irw_meta")\n'
+    )
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        path = Path(self.tmp.name) / "redivis_config.R"
+        path.write_text(self.CONFIG)
+        _, self.targets = load_registry(path)
+
+    def test_both_shards_are_registered_oldest_first(self):
+        self.assertEqual([t.name for t in text_shards(self.targets)],
+                         ["irw_text", "irw_text_2"])
+
+    def test_new_item_text_defaults_to_the_newest_shard(self):
+        # Writing to the older shard would be invisible: clients resolve
+        # newest-first, so a copy in irw_text_2 would shadow it.
+        self.assertEqual(newest_text_shard(self.targets).name, "irw_text_2")
+        self.assertEqual(
+            guess_target([Path("x__items.csv")], self.targets).name, "irw_text_2")
+
+    def test_response_data_is_unaffected_by_text_shards(self):
+        self.assertEqual(newest_shard(self.targets).name, "w2")
+        self.assertEqual(guess_target([Path("a.csv")], self.targets).name, "w2")
+
+    def test_every_shard_accepts_item_text_and_only_item_text(self):
+        for shard in text_shards(self.targets):
+            self.assertIsNone(eligible(Path("x__items.csv"), shard))
+            self.assertIsNotNone(eligible(Path("plain.csv"), shard))
+
+    def test_a_table_already_in_the_older_shard_is_flagged_elsewhere(self):
+        # The whole point: re-uploading into irw_text_2 would not replace the
+        # copy in irw_text, it would shadow it. `found_in[-1]` is what
+        # resolve_elsewhere() offers as the default "update it where it lives".
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write(Path(tmp), "x__items.csv", ITEMS)
+            reports = check_all([(path, table_name(path))])
+        target = newest_text_shard(self.targets)
+        index = {"x__items": ["irw_text"]}
+        items = planning.build(reports, target, index)
+        self.assertEqual(items[0].status, planning.ELSEWHERE)
+        self.assertEqual(items[0].found_in[-1], "irw_text")
+
+    def test_a_table_already_in_the_newest_shard_is_an_update(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write(Path(tmp), "x__items.csv", ITEMS)
+            reports = check_all([(path, table_name(path))])
+        items = planning.build(reports, newest_text_shard(self.targets),
+                               {"x__items": ["irw_text", "irw_text_2"]})
+        self.assertEqual(items[0].status, planning.UPDATE)
+        self.assertEqual(items[0].dataset, "irw_text_2")
+
+
+class ElsewhereRouting(unittest.TestCase):
+    """A cross-family name match must never become a cross-family upload.
+
+    `found_in` spans core and item-text shards, so the newest dataset holding a
+    name is not always one that may receive the file. Defaulting to it would
+    write item text into a warehouse shard -- silently, under --yes.
+    """
+
+    def setUp(self):
+        _, self.targets = load_registry()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def _item(self, name, body, found_in):
+        path = write(Path(self.tmp.name), name, body)
+        reports = check_all([(path, table_name(path))])
+        item = planning.Item(report=reports[0], status=planning.ELSEWHERE,
+                             dataset=None, found_in=found_in)
+        return item
+
+    def test_item_text_is_not_routed_into_a_warehouse_shard(self):
+        # The warehouse shard is the *newer* match, so the old "newest wins"
+        # rule would have picked it and written item text into a warehouse.
+        item = self._item("x__items.csv", ITEMS,
+                          ["irw_text", "item_response_warehouse_3"])
+        target = next(t for t in self.targets if t.is_itemtext)
+        cli.resolve_elsewhere([item], target, self.targets, assume=True)
+        self.assertEqual(item.dataset, "irw_text")
+
+    def test_no_eligible_home_skips_instead_of_guessing(self):
+        # The name exists only in a warehouse shard, which cannot hold __items.
+        item = self._item("y__items.csv", ITEMS, ["item_response_warehouse_3"])
+        target = next(t for t in self.targets if t.is_itemtext)
+        cli.resolve_elsewhere([item], target, self.targets, assume=True)
+        self.assertEqual(item.status, planning.SKIP)
+        self.assertIsNone(item.dataset)
+        self.assertIn("resolve by hand", item.note)
+
+    def test_response_data_is_not_routed_into_a_text_shard(self):
+        item = self._item("z.csv", RESPONSE, ["irw_text"])
+        target = newest_shard(self.targets)
+        cli.resolve_elsewhere([item], target, self.targets, assume=True)
+        self.assertEqual(item.status, planning.SKIP)
 
 
 class Discovery(unittest.TestCase):
@@ -229,7 +363,7 @@ class Planning(unittest.TestCase):
             reports = self._reports(tmp, ["older"])
             index = {"older": ["item_response_warehouse", "item_response_warehouse_3"]}
             items = planning.build(reports, self.shard, index)
-            resolve_elsewhere(items, self.shard, assume=True)
+            resolve_elsewhere(items, self.shard, self.targets, assume=True)
             self.assertEqual(items[0].dataset, "item_response_warehouse_3")
 
     def test_a_published_over_length_name_is_grandfathered(self):


### PR DESCRIPTION
Redivis caps any dataset at **1000 tables**. That is why response data is sharded across `item_response_warehouse_1..6` — but the reason was written down nowhere, and nothing anticipated the same cap binding on `irw_text`.

It will. `irw_text` holds **742 released tables** today and the extraction queue still has **1,049 pending**, so the cap binds after ~258 more — roughly 21 rounds at 12 tables each, well before the queue empties. Nothing would warn first: `red_up` would simply fail an upload one day, mid-batch.

This makes the code shard-aware **while the list still has one entry**, so it is a no-op today and the second shard becomes a one-line config edit rather than a code change made under pressure. No Redivis dataset is created or changed here.

## What changed

- **`redivis_config.R`** gains `IRW_TEXT_DATASETS` beside `IRW_CORE_DATASETS`, and loses the `text =` entry from `IRW_AUX_DATASETS` — naming the dataset in both places would duplicate it inside a single file, the thing `ARCHITECTURE.md` §2 warns about. `targets.py` is the only reader of `IRW_AUX_DATASETS` anywhere, and it now raises if `text` reappears there.
- **`red_up`** builds one `Target` per text shard, defaults `*__items.csv` to the newest, and — the substantive fix — scans text shards as well as core ones for an existing table. Without that, re-uploading into `irw_text_2` would *shadow* the copy in `irw_text` rather than replace it, silently.
- **`ARCHITECTURE.md`** records the cap as a fact about every dataset, since that was the missing piece rather than any particular count. No shard count in prose, per §2's existing convention.

## A bug found on the way

`resolve_elsewhere()` took the newest dataset holding a name **with no eligibility check**. So an `__items` table found in a warehouse shard would be "updated" straight back into the warehouse — under `--yes`, silently. This predates the change, but the wider scan would have doubled it. The offered home must now be able to hold the file, and when none can, the file is skipped for a human instead of routed somewhere plausible-looking.

## Verification

- 58 offline tests pass, including six that drive the **two-shard path before a second shard exists**: registry order, newest-first default, `ELSEWHERE` against an older shard, and the cross-family routing guard.
- Proved a no-op: the registry still yields the same 11 targets in the same order, and a live `--dry-run` on the staged batch still reads `target: datapages.irw_text:next` over the same 7 datasets.

The cutover runbook lives in `Rpkg/inst/developer/warehouses.md` (companion PR). Ships alongside `itemresponsewarehouse/Rpkg` and `itemresponsewarehouse/Python-pkg` on the same branch name.

Refs #1709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Sea8uEZ5ntsJLL1dtHLCP