### PR TITLE
check_cov_range: error rather than warn, as a test (#1856)

### DIFF
--- a/irw_validate/extra.py
+++ b/irw_validate/extra.py
@@ -12,6 +12,7 @@ question being asked.
 """
 from __future__ import annotations
 
+import os
 import re
 
 import pandas as pd
@@ -74,13 +75,35 @@ def check_shape(df: pd.DataFrame, table: str = "") -> list:
     return out
 
 
+def _cov_range_severity() -> str:
+    """`error` by default since 2026-09-05; `IRW_COV_RANGE_SEVERITY` overrides.
+
+    The override exists because promoting a gate is a judgement about a corpus
+    that keeps changing, and the person who needs to reverse it may not be the
+    person who can ship a release.
+    """
+    value = os.environ.get("IRW_COV_RANGE_SEVERITY", "error").strip().lower()
+    return value if value in ("error", "warn", "info") else "error"
+
+
 def check_cov_range(df: pd.DataFrame, table: str = "") -> list:
     """`cov_age` must actually hold ages (#1779).
 
-    Severity is deliberately `warn`, not `error`. 81 tables are already live
-    with this defect; blocking would fail them all on their next re-upload
-    before anyone has decided what the repair is. Promote it once #1779 is
-    closed.
+    **Promoted from `warn` to `error` on 2026-09-05** ("let's test error for
+    now" -- Ben, irw#1856). The objection to erroring was that it would fail
+    all 81 known tables on their next re-upload before anyone had decided the
+    repair. That objection expired: 72 of the 81 are repaired, and the only
+    live tables it now refuses are the nine `wvs_panasiuk_*`, which are blocked
+    on a source file and are not going to be re-uploaded by accident.
+
+    The argument for erroring is that warning has already been tried. This check
+    has warned since it was written, and 81 tables served a `cov_age` of 1999
+    for as long as they were published; a warning in a scrolling upload log is
+    not a notification. `irw_filter()` reads every value here as an age.
+
+    This is a **test**, so it is reversible in one place: set
+    `IRW_COV_RANGE_SEVERITY=warn` in the environment to put it back without a
+    deploy, and see `_severity()` below.
     """
     out = []
     if "cov_age" not in df.columns:
@@ -98,7 +121,7 @@ def check_cov_range(df: pd.DataFrame, table: str = "") -> list:
         else:
             why = "out of range for a human age in years"
         out.append(Finding(
-            "cov_range", "warn",
+            "cov_range", _cov_range_severity(),
             f"cov_age spans {lo:g}-{hi:g}, outside "
             f"[{AGE_RANGE[0]}, {AGE_RANGE[1]}] -- looks like {why}. "
             "irw_filter() treats every value here as an age (#1779).",

--- a/irw_validate/tests/test_validate.py
+++ b/irw_validate/tests/test_validate.py
@@ -138,6 +138,27 @@ class ExtraChecks(unittest.TestCase):
         cov = [f for f in report.findings if f.check == "cov_range"]
         self.assertIn("date or days-since-epoch", cov[0].message)
 
+    def test_cov_age_out_of_range_blocks_the_upload(self):
+        """Promoted from warn to error 2026-09-05 (irw#1856)."""
+        df = F(id=list(range(1, 5)), item=["a"] * 4, resp=[1, 2, 3, 4],
+               cov_age=[34, 41, 999, 28])
+        report = validate_frame(df, profile="upload")
+        self.assertIn("cov_range", [f.check for f in report.errors])
+        self.assertFalse(report.ok, "an out-of-range cov_age must refuse the upload")
+
+    def test_cov_range_severity_can_be_dialled_back(self):
+        """The promotion is a test, so it reverses without a deploy."""
+        import os
+        os.environ["IRW_COV_RANGE_SEVERITY"] = "warn"
+        try:
+            df = F(id=list(range(1, 5)), item=["a"] * 4, resp=[1, 2, 3, 4],
+                   cov_age=[34, 41, 999, 28])
+            report = validate_frame(df, profile="upload")
+            self.assertIn("cov_range", [f.check for f in report.warnings])
+            self.assertTrue(report.ok)
+        finally:
+            del os.environ["IRW_COV_RANGE_SEVERITY"]
+
     def test_plausible_ages_pass(self):
         df = F(id=[1, 2, 3], item=["a"] * 3, resp=[1, 2, 3], cov_age=[18, 45, 92])
         report = validate_frame(df, profile="upload")

--- a/red_up/tests/test_red_up.py
+++ b/red_up/tests/test_red_up.py
@@ -578,13 +578,20 @@ class ValidatorGate(unittest.TestCase):
         report = self._check(path, "ok_2024_scale")
         self.assertTrue(report.ok, report.errors)
 
-    def test_a_cov_age_sentinel_warns_without_blocking(self):
+    def test_a_cov_age_sentinel_blocks_the_upload(self):
+        """Was warn-only until 2026-09-05; promoted to error by irw#1856.
+
+        The old policy was that an already-live defect must not block. It held
+        while nobody had decided the repair; 72 of the 81 are now repaired, so
+        the gate refuses the defect at the door instead of adding a line to a
+        log that 81 tables' worth of bad ages already scrolled past.
+        """
         rows = "\n".join(f"{i},q{j},{(i + j) % 5 + 1},{999 if i == 1 else 40}"
                          for i in range(1, 40) for j in range(1, 5))
         path = self._csv("sentinel_2024_scale.csv", "id,item,resp,cov_age\n" + rows + "\n")
         report = self._check(path, "sentinel_2024_scale")
-        self.assertTrue(report.ok, "an already-live defect must not block (#1779)")
-        self.assertTrue(any("cov_range" in w for w in report.warnings), report.warnings)
+        self.assertFalse(report.ok, "an out-of-range cov_age must refuse the upload")
+        self.assertTrue(any("cov_range" in e for e in report.errors), report.errors)
 
     def test_metadata_is_exempt_from_the_format_validator(self):
         """The regression that made every irw_meta upload a no-op (#1703).


### PR DESCRIPTION
Ben's call on 2026-09-05: **"let's test error for now"** — the question #1856
asks be decided once.

`check_cov_range` has warned since it was written, and 81 tables served a
`cov_age` of 1999 for as long as they were published. A line in a scrolling
upload log is not a notification, and `irw_filter()` reads every value in that
column as an age.

The objection to erroring was that it would fail all 81 on their next
re-upload before anyone had decided the repair. That objection has expired: 72
of the 81 are repaired, and the only live tables it refuses today are the nine
`wvs_panasiuk_*`, which are blocked on a source file and are not going to be
re-uploaded by accident.

### It reverses without a deploy

This is a test, so `IRW_COV_RANGE_SEVERITY=warn` in the environment puts it
back. That override exists because promoting a gate is a judgement about a
corpus that keeps changing, and whoever needs to reverse it may not be whoever
can ship a release.

### What changed

- `check_cov_range` emits `_cov_range_severity()` instead of a literal `warn`.
- `red_up`'s gate test asserted the old policy **in its name** —
  `test_a_cov_age_sentinel_warns_without_blocking`, message "an already-live
  defect must not block". It now asserts the new one and records why it
  changed.
- Two new tests: an out-of-range `cov_age` makes `report.ok` false, and the env
  override dials it back.

120 pass.

### Not included: the id-uniqueness gate

It is the other half of the same question, but **it does not exist yet as
code** — I checked. A frame where one `id` carries two ages and two sexes
across different items validates clean today:

```
ok: True
findings: [('imputed_values*', 'warn'), ('resp_scale_mixed', 'warn'), ('sample_floor', 'warn')]
```

What refuses a collision today is `dup_id_item`/`excess_occ`, and those only
fire when the *same* item repeats — they miss the AOMT/PEMAIW shape entirely,
which is two people numbered from 1 in separate input files. Building the gate
is #1703 item 1 and a separate decision, since it would refuse the 27 collision
tables at re-upload.

Related: #1856, #1779, #1703

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTeyJTfJ5dT2Xcc5Zmv3js