### PR TITLE
gilbert_meta_31: cov_age is months, and 0 is missing (#1856)

### DIFF
--- a/data/gilbertmeta.R
+++ b/data/gilbertmeta.R
@@ -45,6 +45,21 @@ irw_clean <- function(data, num){
       rename(resp = score)
   }
   
+  # Dataset 31's `cov_age` is baseline age in **months**, not years, and a
+  # recorded 0 means missing -- both confirmed by Josh Gilbert on 2026-09-05
+  # (irw#1856). Untouched it shipped a median age of 108 and a maximum of 219
+  # on an ASER primary-school sample, and `irw_filter()` read every one of
+  # those as a year. `datastandard.md` requires `cov_age` in years.
+  #
+  # Handled here rather than at source so a re-run cannot reintroduce it. If the
+  # upstream `datasets_list.Rdata` is ever changed to years, delete this block
+  # -- the guard below will fail loudly rather than halve the ages twice.
+  if(num == 31 && "cov_age" %in% names(out)){
+    stopifnot(max(out$cov_age, na.rm = TRUE) > 120)   # still months?
+    out <- out |>
+      mutate(cov_age = ifelse(cov_age == 0, NA_real_, cov_age / 12))
+  }
+
   # get the output file
   out <- out |> 
     remove_all_labels() |> 


### PR DESCRIPTION
Josh Gilbert [confirmed both](https://github.com/ben-domingue/irw/issues/1856#issuecomment-5552158963)
on 2026-09-05: dataset 31's `cov_age` is baseline age in **months**, and a
recorded 0 means missing.

Untouched, the table shipped a median age of **108** and a maximum of **219**
on an ASER primary-school sample — `aser_read_2/3/4` and `aser_math_2/3/4`,
12,560 children. `irw_filter()` reads every value in that column as a year, so
an age-stratified subgroup silently absorbed them.

Converted: **3.17 to 18.25 years, median 9.0**, with the 228 rows (21
respondents) at exactly 0 now NULL.

### Why in the script rather than at source

Josh offered to change it upstream. Fixing it here means a re-run cannot
reintroduce it and the correction is version-controlled alongside the table it
produces. The `stopifnot` fails loudly if `datasets_list.Rdata` is ever switched
to years — halving the ages twice is the failure mode worth being noisy about.

The corrected table is uploaded to the `next` draft and verified there: 146,583
rows, 12,560 ids, 228 nulls, no zeros, range 3.17–18.25.

### The rest of the family is fine

`gilbert_meta_31` was caught only because months pushed it past 120. A younger
sample recorded in months would land inside `[0, 120]` and read as a plausible
adult age — the same defect, silent — so I profiled all 55 `gilbert_meta_*`
tables that carry `cov_age`.

31 is the only one in months. The others run a median of 6–15 for the school
samples and 25–70 for the adult ones, all plausible as years.

Two things worth a follow-up question to Josh, not assumed here:

- `gilbert_meta_65`, `66`, `67` have **no `cov_age` values at all** (column
  present, entirely null).
- `gilbert_meta_56`, `68`, `69` carry **67, 498 and 416 zeros**. If 0 is his
  missing code generally, those are the same defect.

Related: #1856, #1779

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTeyJTfJ5dT2Xcc5Zmv3js