### PR TITLE
Add irw_text_2 as the second item-text shard

### DIFF
--- a/metadata/redivis_config.R
+++ b/metadata/redivis_config.R
@@ -41,7 +41,8 @@ IRW_CORE_DATASETS <- c(
 ## See ARCHITECTURE.md section 2, and Rpkg/inst/developer/warehouses.md for the
 ## checklist to follow when adding one.
 IRW_TEXT_DATASETS <- c(
-  "irw_text"
+  "irw_text",
+  "irw_text_2"
 )
 
 ## Auxiliary (non-core) datasets, by the `source` name the irw package uses.

--- a/red_up/tests/test_red_up.py
+++ b/red_up/tests/test_red_up.py
@@ -47,17 +47,30 @@ class Registry(unittest.TestCase):
         owner, targets = load_registry()
         self.assertEqual(owner, "datapages")
         names = [t.name for t in targets]
-        self.assertEqual(
-            names[:6],
-            [f"item_response_warehouse{s}" for s in ("", "_2", "_3", "_4", "_5", "_6")])
-        # Item text comes first among the non-core targets and is a shard list;
-        # the other four are the plain aux datasets.
-        self.assertEqual([t.name for t in text_shards(targets)], ["irw_text"])
-        self.assertEqual(
-            sorted(names[6:]),
-            ["irw_competitions", "irw_meta", "irw_nominal", "irw_simsyn", "irw_text"])
-        self.assertEqual(newest_shard(targets).name, "item_response_warehouse_6")
-        self.assertEqual(newest_text_shard(targets).name, "irw_text")
+        core = [t.name for t in targets if t.kind == "core"]
+        text = [t.name for t in text_shards(targets)]
+        aux = [t.name for t in targets
+               if t.kind == "aux" and not t.is_itemtext]
+
+        # Both families are shard lists that grow, so assert their shape rather
+        # than a frozen tail -- pinning the newest name here means every future
+        # shard breaks this test for no reason.
+        self.assertEqual(core[0], "item_response_warehouse")
+        self.assertEqual(core[1:],
+                         [f"item_response_warehouse_{i}" for i in range(2, len(core) + 1)])
+        self.assertEqual(text[0], "irw_text")
+        self.assertEqual(text[1:],
+                         [f"irw_text_{i}" for i in range(2, len(text) + 1)])
+
+        # The four plain aux datasets are a fixed set; item text is not among
+        # them, because it is declared as IRW_TEXT_DATASETS.
+        self.assertEqual(sorted(aux),
+                         ["irw_competitions", "irw_meta", "irw_nominal", "irw_simsyn"])
+
+        # Core first, then text shards, then the rest -- the menu order.
+        self.assertEqual(names, core + text + aux)
+        self.assertEqual(newest_shard(targets).name, core[-1])
+        self.assertEqual(newest_text_shard(targets).name, text[-1])
 
     def test_item_text_declared_twice_is_refused(self):
         # The three "single source of truth" files drifted once (#1733).
@@ -240,7 +253,8 @@ class TargetGuessing(unittest.TestCase):
         # real output, so a majority rule would send those to a shard.
         files = [Path("provenance.csv"), Path("notes.csv"), Path("audit.csv"),
                  Path("x__items.csv")]
-        self.assertEqual(guess_target(files, self.targets).name, "irw_text")
+        self.assertEqual(guess_target(files, self.targets).name,
+                         newest_text_shard(self.targets).name)
 
     def test_plain_csvs_go_to_the_newest_shard(self):
         self.assertEqual(guess_target([Path("a.csv")], self.targets).name,


### PR DESCRIPTION
`irw_text_2` was created and released as **v1.0** (reference id `ae47`) on 2026-09-05, carrying one table: `dvivdtws_ppmial_marcatto_2023_dtw__items` (110 rows).

**Until the config names the shard, that table is invisible to every client** — an unlisted shard is skipped silently, not loudly, which is exactly the trap the runbook warns about. Before this change both clients listed 745 tables and could not see it.

This is step 3–4 of the cutover runbook in `Rpkg/inst/developer/warehouses.md`, and it ships as three one-line edits **together**: `IRW_TEXT_DATASETS` here, `.irw_itemtext_specs` in Rpkg, `ITEMTEXT_REFS` in Python-pkg. A config naming a shard the other two do not is the drift recorded as ben-domingue/irw#1733.

## Verified live, after the change

- Both clients list **746** item text tables (745 + the new one).
- Both resolve `dvivdtws_ppmial_marcatto_2023_dtw` from shard 2; R fetch returns its 110 rows.
- Both still resolve `gilbert_meta_49` from shard 1.
- Python opens the shards newest-first: `['irw_text_2:ae47', 'irw_text:07b6']`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Sea8uEZ5ntsJLL1dtHLCP

red_up now defaults `*__items.csv` to `irw_text_2`, still scans `irw_text` for an existing copy, and offers *update it where it lives* for anything already there — so an existing table is never shadowed.

Two registry tests pinned `irw_text` as the only text shard and as the guess target. Both now assert the **invariant** instead: shard lists grow, and a test hard-coding the newest name breaks on every future shard for no reason. 58 pass.