### PR TITLE
wvs_panasiuk: read whichever trend-file build the downloader got (#1871)

### DIFF
--- a/data/wvs_panasiuk_2025.R
+++ b/data/wvs_panasiuk_2025.R
@@ -3,7 +3,69 @@ rm(list = ls ())
 library(tidyverse)
 library(haven)
 
-df <- read_csv("WVS_TimeSeries_4_0.csv")
+# The trend file is behind a conditions-of-use acceptance at
+# https://www.worldvaluessurvey.org/WVSEVStrend.jsp that a person has to click
+# through -- there is no scriptable download. This script was written against
+# `WVS_TimeSeries_4_0.csv`, but the site now publishes **v4.1 only**, and in
+# SPSS / Stata / R / SAS -- there is no CSV any more. So rather than name one
+# file, take whichever the downloader actually got. Drop it anywhere in this
+# directory and re-run (irw#1871).
+wvs_read <- function(dir = ".") {
+  pat <- "(?i)^WVS_?(Trend|TimeSeries)_.*\\.(rds|rdata|csv|dta|sav)$"
+  hits <- list.files(dir, pattern = pat, full.names = TRUE)
+  if (length(hits) == 0) {
+    stop("No WVS trend file found in ", normalizePath(dir), ".\n",
+         "Accept the conditions of use at ",
+         "https://www.worldvaluessurvey.org/WVSEVStrend.jsp and download ",
+         "'WVS_Trend_1981_2022_v4.1 R (rds extension)' (or the Stata/SPSS/CSV ",
+         "build -- any of them is read here), then put it in this directory.")
+  }
+  if (length(hits) > 1) {
+    stop("More than one WVS trend file here, so which one is ambiguous:\n  ",
+         paste(basename(hits), collapse = "\n  "))
+  }
+  f <- hits[[1]]
+  message("Reading ", basename(f))
+  ext <- tolower(tools::file_ext(f))
+  out <- switch(
+    ext,
+    rds   = readRDS(f),
+    rdata = {
+      e <- new.env()
+      nm <- load(f, envir = e)
+      if (length(nm) != 1) stop(basename(f), " holds ", length(nm),
+                                " objects; expected one data frame")
+      get(nm, envir = e)
+    },
+    csv = readr::read_csv(f, show_col_types = FALSE),
+    dta = haven::read_dta(f),
+    sav = haven::read_sav(f),
+    stop("Do not know how to read a .", ext, " file")
+  )
+  # SPSS/Stata/rds builds carry haven labels. `wvs_na()` below compares against
+  # the bare codes -1..-5, and a labelled vector does not compare the way a
+  # numeric one does, so strip the labels rather than debug it downstream.
+  out <- haven::zap_labels(haven::zap_missing(as.data.frame(out)))
+  tibble::as_tibble(out)
+}
+
+df <- wvs_read()
+
+# v4.0 is what this script was written against and v4.1 is what is downloadable.
+# The item columns are picked up by prefix so a renamed item is harmless, but
+# these six carry the structure -- respondent, wave, date, country, sex, age --
+# and a silent rename in any of them would produce a table that looks fine and
+# is wrong. Fail here instead.
+wvs_required <- c("S006", "S002VS", "S012", "COUNTRY_ALPHA", "X001", "X003")
+wvs_absent <- setdiff(wvs_required, names(df))
+if (length(wvs_absent) > 0) {
+  stop("The trend file is missing ", length(wvs_absent),
+       " structural column(s): ", paste(wvs_absent, collapse = ", "), ".\n",
+       "This script was written against v4.0; if v4.1 renamed them, map the ",
+       "new names here rather than downstream. Columns present that look ",
+       "related: ",
+       paste(grep("^(S0|X0|COUNTRY)", names(df), value = TRUE), collapse = ", "))
+}
 
 # WVS codes every kind of non-response negatively -- -1 don't know, -2 no
 # answer, -3 not applicable, -4 not asked, -5 missing -- in *every* variable,


### PR DESCRIPTION
The script named `WVS_TimeSeries_4_0.csv`. The WVS site now publishes **v4.1
only**, in SPSS / Stata / R-rds / R-rdata / SAS — there is no CSV any more. So
whoever accepted the conditions of use would have downloaded a file this script
could not open, and found that out after the download rather than before it.

`wvs_read()` takes any of `.rds` / `.rdata` / `.csv` / `.dta` / `.sav` matching
the trend file's name, from the working directory. **Drop the download in and
re-run.**

| path | behaviour |
|---|---|
| no file | names the URL, the exact download to pick and where to put it — not `cannot open file` |
| two files | refuses rather than guessing which build is current |
| labelled build | `zap_labels`/`zap_missing` at read time |
| unknown extension | names it |

The labels matter: the SPSS/Stata/rds builds carry them, and `wvs_na()` compares
against the bare codes `-1..-5`, which a labelled vector does not do the way a
numeric one does. Better stripped at the door than debugged nine blocks
downstream.

### Structural-column check

Item columns are picked up by prefix, so a renamed item is harmless. But
`S006`, `S002VS`, `S012`, `COUNTRY_ALPHA`, `X001` and `X003` carry respondent,
wave, date, country, sex and age — a silent rename between v4.0 and v4.1 in any
of them would produce a table that looks fine and is wrong. It fails at the top
and lists the related columns the file does have, so mapping them is a
two-minute job rather than a hunt.

### Exercised

All four read paths — rds, csv, labelled dta, and a renamed structural column —
against fixtures. The existing `stop()` on a still-colliding `id` is unchanged.

**Still unverified end to end.** That needs the file, which is behind a
conditions-of-use acceptance a person has to click through; the download is a
POST to `AJDownload.jsp` that returns a 1-byte body without an accepted
session. This PR only makes sure the download is usable when it arrives.

Related: #1871, #1856, #1779

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTeyJTfJ5dT2Xcc5Zmv3js