### PR TITLE
ARCHITECTURE.md: stop recording package version numbers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,13 +19,18 @@ confusing thing about this project's layout, so it is stated first:
 |---|---|---|
 | `src` | `ben-domingue/irw` | Per-dataset processing scripts, the metadata pipeline, automated dataset finding |
 | `irw_site` | `datapages/irw` | The Quarto site published at [itemresponsewarehouse.org](https://itemresponsewarehouse.org) |
-| `Rpkg` | `itemresponsewarehouse/Rpkg` | The `irw` **R** package (v1.0.1) |
-| `Python-pkg` | `itemresponsewarehouse/Python-pkg` | The `irw` **Python** package (v0.0.2) |
+| `Rpkg` | `itemresponsewarehouse/Rpkg` | The `irw` **R** package |
+| `Python-pkg` | `itemresponsewarehouse/Python-pkg` | The `irw` **Python** package |
 
 `src` is on a personal account, the site on `datapages`, and the two client
 packages on the `itemresponsewarehouse` org. There is no technical reason for
 this; it is history. Neither package is on CRAN or PyPI — both install from
 GitHub.
+
+Package versions are deliberately not written here: they moved four times in a
+week and both numbers in this table were wrong within days of being typed. Read
+them from `Rpkg/DESCRIPTION` and `Python-pkg/pyproject.toml`, which cannot go
+stale.
 
 ## 2. Redivis
 


### PR DESCRIPTION
The repository table said Rpkg v1.0.1 and Python-pkg v0.0.2. Actual versions are 1.1.2 and 0.1.0 — Rpkg alone cut three releases on 2026-09-02.

Bumping them recreates the problem. This file already makes the argument in §2 about shard counts: a number written into prose is wrong the day it changes. The table's job is who owns what; `Rpkg/DESCRIPTION` and `Python-pkg/pyproject.toml` are authoritative for versions and cannot go stale.

The Python-pkg number mattered more than a stale figure usually does — 0.0.2 is the release whose `filter()` was a no-op returning 4,229 of 4,230 tables for every query. See #1702 (item 5) and datapages/irw#140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZ6oSYm4Jao4AWFbAy8JyJ