### PR TITLE
Restore complete Su 2024 Xinxiang conversion outputs

### DIFF
--- a/data/su_2024_xinxiang_assessments.R
+++ b/data/su_2024_xinxiang_assessments.R
@@ -294,3 +294,97 @@ convert_scale_to_irw <- function(
   
   return(long_data)
 }
+# GAD-7 item map
+gad7_item_map <- tibble(
+  item = paste0("GAD_", 1:7),
+  resp_col = paste0("question", 1:7),
+  rt_col = paste0("time", 1:7)
+)
+
+gad7_item_map
+# 转换并导出 GAD-7
+gad7_long <- convert_scale_to_irw(
+  input_file = "gad7.csv",
+  item_map = gad7_item_map,
+  output_file = "su_2024_gad7.csv"
+)
+# ISI item map
+isi_item_map <- tibble(
+  item = paste0("ISI_", 1:7),
+  resp_col = paste0("question", 1:7),
+  rt_col = paste0("time", 1:7)
+)
+
+isi_item_map
+
+# 转换并导出 ISI
+isi_long <- convert_scale_to_irw(
+  input_file = "isi.csv",
+  item_map = isi_item_map,
+  output_file = "su_2024_isi.csv"
+)
+# PSS-14 item map
+pss_item_map <- tibble(
+  item = paste0("PSS_", 1:14),
+  resp_col = paste0("question", 1:14),
+  rt_col = paste0("time", 1:14)
+)
+
+pss_item_map
+
+# 转换并导出 PSS-14
+pss_long <- convert_scale_to_irw(
+  input_file = "pss.csv",
+  item_map = pss_item_map,
+  output_file = "su_2024_pss14.csv"
+)
+# =========================================================
+# 四个量表的总质量检查
+# =========================================================
+
+all_scales <- bind_rows(
+  phq9_long |> mutate(dataset = "PHQ-9"),
+  gad7_long |> mutate(dataset = "GAD-7"),
+  isi_long  |> mutate(dataset = "ISI"),
+  pss_long  |> mutate(dataset = "PSS-14")
+)
+
+overall_qc <- all_scales |>
+  group_by(dataset) |>
+  summarise(
+    rows = n(),
+    ids = n_distinct(id),
+    items = n_distinct(item),
+    min_resp = min(resp, na.rm = TRUE),
+    max_resp = max(resp, na.rm = TRUE),
+    missing_resp = sum(is.na(resp)),
+    missing_rt = sum(is.na(rt)),
+    zero_rt = sum(rt == 0, na.rm = TRUE),
+    negative_rt = sum(rt < 0, na.rm = TRUE),
+    min_rt = min(rt, na.rm = TRUE),
+    median_rt = median(rt, na.rm = TRUE),
+    mean_rt = mean(rt, na.rm = TRUE),
+    max_rt = max(rt, na.rm = TRUE),
+    .groups = "drop"
+  )
+
+overall_qc
+# 检查输出文件
+output_files <- c(
+  "su_2024_phq9.csv",
+  "su_2024_gad7.csv",
+  "su_2024_isi.csv",
+  "su_2024_pss14.csv"
+)
+
+file_check <- tibble(
+  file = output_files,
+  exists = file.exists(file.path(output_dir, output_files)),
+  size_bytes = file.info(file.path(output_dir, output_files))$size
+)
+
+file_check
+write_csv(
+  overall_qc,
+  file.path(output_dir, "su_2024_quality_check.csv")
+)

--- a/data/su_2024_xinxiang_assessments.R
+++ b/data/su_2024_xinxiang_assessments.R
@@ -1,3 +1,15 @@
+# Su et al. (2024), Temporal dynamics in psychological assessments:
+# a novel dataset with scales and response times. Scientific Data 11, 1046.
+# Paper: https://doi.org/10.1038/s41597-024-03888-8
+# Data: https://doi.org/10.5281/zenodo.10423537
+# Source: https://zenodo.org/records/10423537
+# License: CC BY 4.0 (data deposit), https://creativecommons.org/licenses/by/4.0/
+# Inputs: demographic.csv, phq9.csv, gad7.csv, isi.csv, pss.csv in raw/.
+# RT units: seconds, recorded to two decimal places (paper, Methods,
+# "Data generation process"). Preserve time1..N without a /1000 conversion.
+# PSS-14: retain the 1-5 item codes stored in the deposited pss.csv.
+# This restores reproducibility of existing IRW tables; no new data are added.
+
 library(tidyverse)
 library(janitor)
 library(readr)
@@ -384,7 +396,10 @@ file_check <- tibble(
 )
 
 file_check
+# QC summaries are not IRW response tables; keep them out of output/*.csv.
+qc_dir <- file.path(output_dir, "qc")
+dir.create(qc_dir, showWarnings = FALSE)
 write_csv(
   overall_qc,
-  file.path(output_dir, "su_2024_quality_check.csv")
+  file.path(qc_dir, "su_2024_quality_check.csv")
 )


### PR DESCRIPTION
Running the committed Xinxiang conversion from a fresh working directory produces only PHQ-9 because the calls for GAD-7, ISI and PSS-14 are missing. This restores those calls and the four-scale QC summary, adds verified source documentation, and writes the QC artifact to `output/qc/su_2024_quality_check.csv`. The four response CSVs remain directly under `output/`.

This repairs the provenance of four existing IRW tables. It does not add or re-upload data.

### Source and RT units

The script now cites [Su et al. (2024), Scientific Data 11, 1046](https://doi.org/10.1038/s41597-024-03888-8) and the specific [Zenodo data release, DOI 10.5281/zenodo.10423537](https://zenodo.org/records/10423537). The deposit explicitly licenses the data under **CC BY 4.0**. All five local input files match the sizes and MD5 checksums published by that Zenodo record.

**The source RT fields are already in seconds.** The paper's Table 1 (PDF page 3) defines `timeX` for each of the four CSVs as “Time taken (in seconds) for the participant to answer the Xth question.” Methods → Data generation process also states two-decimal precision. The converter preserves these values; dividing by 1,000 would change the documented units incorrectly.

The following medians pool all participant–item RT records within each scale, rather than participant total completion times or averages of item medians. They were independently recomputed from the raw exports and agree exactly with the rebuilt outputs and QC CSV.

| Table | Rows | Participants | Items | Observed response range | Median RT (seconds) |
|---|---:|---:|---:|---|---:|
| `su_2024_gad7` | 170,044 | 24,292 | 7 | 0–3 | 2.20 |
| `su_2024_isi` | 170,044 | 24,292 | 7 | 0–4 | 2.65 |
| `su_2024_phq9` | 218,628 | 24,292 | 9 | 0–3 | 3.00 |
| `su_2024_pss14` | 340,088 | 24,292 | 14 | 1–5 | 3.22 |

One coding clarification: the deposited PSS question fields contain **1–5**, which this conversion preserves. The paper's supplementary table describes a 0–56 total and reverse-scoring examples, but does not provide a mapping for the released CSV codes. This repair does not subtract 1, reverse-score items or infer a total-score transformation.

### Validation

- Re-ran the revised script with `Rscript --vanilla` in a new directory containing copies of the five source files. Exactly four response CSVs are written at the top level, with the QC CSV under `output/qc/`.
- All four response files are byte-for-byte identical to the existing local outputs. The relocated QC file also has identical content; only its destination changes. The earlier baseline reproduction produced PHQ-9 alone.
- Independently compared all **898,804 participant–item records**, including responses, RTs and five demographic covariates (**6,291,628 fields**): zero differences; participant sets, item counts, complete response distributions and missingness are preserved. Original row ordering is unchanged.
- The 57 `irw_validate` tests, 58 `red_up` tests, R validator smoke test and modified-script contract check pass locally. All 979 files in the original workspace retain their recorded hashes and modification times.

Full-data reproduction used R 4.5.3. Local Python tests used Python 3.12 for `irw_validate` and the existing Python 3.14 environment for `red_up`; GitHub CI uses the repository's Python 3.12 workflow. Source/participant records and generated tables are not included in this PR. Earlier root-level QC artifacts are not automatically deleted from existing working directories; the output-layout check above uses a fresh directory.

The PR remains **Draft** for review.
