### PR TITLE
Issue triage: give PRIORITIES.md's categories a way to be found

### DIFF
--- a/PRIORITIES.md
+++ b/PRIORITIES.md
@@ -4,11 +4,29 @@ Set 2026-09-02 by ben-domingue. Advisory: he overrules it, and a direct request
 always wins. This file exists so a session can place a new piece of work without
 asking, not to override judgment.
 
-**The problem it solves.** There are 200+ open issues, 245 of them labelled
-`data queue`, 18 roadmap items and 8 open pull requests. A list that long does
-not tell anyone what matters, and re-deriving a priority order every morning is
-itself the cost. So this ranks *kinds* of work rather than listing issues, and
-the list below will still be right when every issue number in it is closed.
+**The problem it solves.** There are ~390 open issues, 207 of them labelled
+`data queue`, and 17 roadmap items. A list that long does not tell anyone what
+matters, and re-deriving a priority order every morning is itself the cost. So
+this ranks *kinds* of work rather than listing issues, and the list below will
+still be right when every issue number in it is closed.
+
+**Where the issue list is.** Ranking without a way to *find* the ranked work is
+half a tool, so as of 2026-09-06 the categories below exist as labels:
+`p1-trust`, `p2-gate`, `p3-reach`, `p4-volume`, `p5-later`, one per open issue
+across all three code repos. Two queries do most of the work:
+
+- **`label:wrong-now`** — the narrow class from `ARCHITECTURE.md` §4: the
+  released data would give a *wrong* answer, not merely an incomplete one. This
+  is the one worth opening daily.
+- **milestone `Queue: one-offs`** — self-contained fixes, one session or less
+  each, no decision needed, no dependency on anything else. Pull from the top.
+
+`metadata/build_issue_triage.py` holds the assignment and
+`metadata/apply_issue_labels.py` applies it, so the next pass edits a list instead
+of re-reading 400 issues. Both are idempotent; the CSV between them is a derived
+artifact and is not committed.
+`data queue` issues are deliberately unlabelled — acquisition is not-now as a
+*class*, and 207 identical labels would say nothing.
 
 ## The order
 
@@ -33,23 +51,24 @@ copy of the uploader was in hand, while the other twelve copies stayed broken.
 The test for whether something belongs here: if you fix the instance and nothing
 changes about how the next one is caught, it was category 1 work, not category 2.
 
-**3. Reach — item 3 first, then 4 and 5.**
+**3. Reach — items 4 and 5, and the gate on them is gone.**
 
 Reworked 2026-09-03. **Item 6 is retired**: its intent was user-contributed
 vignettes, which never materialised. Its one live sub-action — give the
-dictionary the same write path as tags (#1732) — is promoted to item 6b and
-stands on its own. Its one real conclusion, that no Google Sheets service account
-should be provisioned, lives in `ARCHITECTURE.md` §3.
+dictionary the same write path as tags (#1732) — was promoted to item 6b and
+shipped on 2026-09-06 (PR #2000).
 
-Items 4 (findability) and 5 (the packages) are both **postponed behind item 3**
-(#1705), the version manifest. A per-table landing page that cannot name the
-version it describes is indexed against data that moves; and the package cache
-worth having (5.5) is keyed by table *and* version. So item 3 gates this whole
-category — and it is also the standing answer to the export cap:
-**manifest → cache → quota relief**.
+**Correction, 2026-09-06.** This section used to postpone items 4 (findability)
+and 5 (the packages) behind item 3, the version manifest, on the grounds that a
+landing page which cannot name its version is indexed against data that moves and
+that the package cache worth having (5.5) is keyed by table *and* version. Both
+arguments were right and **item 3 closed on 2026-09-03** (#1705). The
+postponement therefore has no reason left. The standing answer to the export cap
+— **manifest → cache → quota relief** — is now one built step and two unbuilt
+ones, not three unbuilt ones.
 
-This category still receives no time, which remains the strongest argument for
-raising it.
+This category still receives no time. That was defensible while item 3 gated it
+and is not defensible now, which makes it the strongest argument for raising it.
 
 **4. Volume — coverage of tags and item text.**
 
@@ -112,7 +131,12 @@ This file ranks; it does not enumerate. For the actual work:
 
 - **The 17 numbered proposals and their sub-items** — ben-domingue/irw#1702, and
   one issue per item at #1703–#1719. Check there before starting anything in a
-  numbered area; several already carry a ruling.
+  numbered area; several already carry a ruling. Items 2, 3 and 6 are closed;
+  items 8–10 and 12–15 and 17 are marked `Deferred` on Project 4 and have no
+  attached issues, which is what not-this-year looks like on the board.
+- **Which issues are in a category** — the `p1`–`p5` labels, and
+  `metadata/build_issue_triage.py`, which assigns them. That script is the
+  enumeration this file refuses to be.
 - **Which dataset to process next** — `CLAUDE.md` §Processing Priorities and
   `processing_notes/DataProcessingInstructions.md`. Different question, different
   answer: that is about picking among candidates, this is about picking among

--- a/PRIORITIES.md
+++ b/PRIORITIES.md
@@ -21,6 +21,13 @@ across all three code repos. Two queries do most of the work:
 - **milestone `Queue: one-offs`** — self-contained fixes, one session or less
   each, no decision needed, no dependency on anything else. Pull from the top.
 
+For *what to start next* rather than what exists, read **Project 4** filtered to
+`Status: Todo`: its `Depends on` column carries the ordering, and the structural
+issues with no roadmap number (#2001, #1955, #1342, #1942, #1856) are on it
+alongside the seventeen items. The ordering deliberately lives there rather than
+in a document — a work order written as prose is stale the week after it is
+written, which is `ARCHITECTURE.md`'s rule 2.
+
 `metadata/build_issue_triage.py` holds the assignment and
 `metadata/apply_issue_labels.py` applies it, so the next pass edits a list instead
 of re-reading 400 issues. Both are idempotent; the CSV between them is a derived

--- a/metadata/apply_issue_labels.py
+++ b/metadata/apply_issue_labels.py
@@ -1,0 +1,84 @@
+"""Apply metadata/issue_triage.csv to GitHub. Dry-run unless --apply is passed.
+
+Run metadata/build_issue_triage.py first — the CSV is a derived, uncommitted
+build artifact, and the assignments that produce it live in that script.
+
+Adds the labels a row calls for and removes priority labels it does not, so the
+file stays the single description of the triage rather than an append-only log.
+Labels outside the vocabulary below are never touched.
+
+Note: `gh issue view` is broken repo-wide on ben-domingue/irw by GitHub's
+Projects-classic GraphQL deprecation. `gh issue list` and `gh issue edit` are
+unaffected, which is why this reads through the former and writes through the latter.
+"""
+
+import argparse, csv, json, subprocess, sys
+from pathlib import Path
+
+CSV = Path(__file__).with_name("issue_triage.csv")
+
+PRIORITIES = {"p1-trust", "p2-gate", "p3-reach", "p4-volume", "p5-later"}
+FLAGS = {"wrong-now", "research-output", "queue-ingested?", "lookhere_ben"}
+ROADMAP = {"y3-1", "y3-2", "y3-4", "y3-5", "y3-7", "y3-11"}
+
+# `lookhere_ben` predates this file and ben-domingue applies it by hand. This
+# script may add it and must never take it off, or a triage run would silently
+# clear a flag he set himself.
+ADD_ONLY = {"lookhere_ben"}
+
+OWNED = PRIORITIES | FLAGS | ROADMAP
+
+
+def current_labels(repo):
+    out = subprocess.run(
+        ["gh", "issue", "list", "-R", repo, "--state", "open", "--limit", "600",
+         "--json", "number,labels"],
+        capture_output=True, text=True, check=True).stdout
+    return {i["number"]: {lab["name"] for lab in i["labels"]}
+            for i in json.loads(out)}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true",
+                    help="write to GitHub (default is a dry run)")
+    args = ap.parse_args()
+
+    rows = list(csv.DictReader(CSV.open()))
+    have = {}
+    changed = 0
+
+    for row in rows:
+        repo, n = row["repo"], int(row["issue"])
+        if repo not in have:
+            have[repo] = current_labels(repo)
+        if n not in have[repo]:
+            print(f"  skip {repo}#{n}: not open")
+            continue
+
+        want = set(filter(None, [row["priority"], row["roadmap"]]))
+        want |= set(row["flags"].split())
+        now = have[repo][n] & OWNED
+
+        add = sorted(want - have[repo][n])
+        remove = sorted((now - want) - ADD_ONLY)
+        if not add and not remove:
+            continue
+        changed += 1
+        verb = "apply" if args.apply else "would"
+        print(f"  {verb} {repo}#{n}: +{','.join(add) or '-'} -{','.join(remove) or '-'}")
+        if args.apply:
+            cmd = ["gh", "issue", "edit", str(n), "-R", repo]
+            for lab in add:
+                cmd += ["--add-label", lab]
+            for lab in remove:
+                cmd += ["--remove-label", lab]
+            subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+    print(f"{changed} issue(s) {'changed' if args.apply else 'would change'}"
+          f" of {len(rows)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/metadata/build_issue_triage.py
+++ b/metadata/build_issue_triage.py
@@ -1,0 +1,180 @@
+"""Regenerate metadata/issue_triage.csv — one row per open issue, one priority each.
+
+The categories are PRIORITIES.md's, not new ones: p1-trust > p2-gate > p3-reach >
+p4-volume > p5-later. `wrong-now` is the narrower ARCHITECTURE.md section 4 class —
+the released data would give a *wrong* answer, not merely an incomplete one — and is
+the query worth opening daily.
+
+Explicit assignments below come from the 2026-09-06 triage pass, which read every
+non-acquisition issue. Everything else is assigned by rule from its existing labels,
+so a new issue lands somewhere sensible without being re-read.
+
+`data queue` issues are deliberately left unlabelled: PRIORITIES.md section 5 ranks
+acquisition as not-now as a class, and 240 identical labels would say nothing.
+
+The CSV this writes is derived and is **not** committed: it changes every time an
+issue is opened or closed, so a tracked copy would churn without recording
+anything. The durable half is the assignment lists in this file. Regenerate, then
+run apply_issue_labels.py:
+
+    python3 metadata/build_issue_triage.py
+    python3 metadata/apply_issue_labels.py            # dry run
+    python3 metadata/apply_issue_labels.py --apply
+"""
+
+import csv, json, subprocess, sys
+from pathlib import Path
+
+REPOS = ["ben-domingue/irw", "itemresponsewarehouse/Rpkg",
+         "itemresponsewarehouse/Python-pkg"]
+OUT = Path(__file__).with_name("issue_triage.csv")
+
+# Acquisition labels — exempt from the priority vocabulary (see module docstring).
+QUEUE_LABELS = {"data queue", "data search", "data--needs license",
+                "backlog-search", "request data", "data-joao"}
+
+# The roadmap master issue. Deliberately unlabelled: it is the plan, not work to
+# schedule, and tagging it p5-later would read as "the roadmap is not now".
+EXEMPT = {("ben-domingue/irw", 1702)}
+
+# --- explicit assignments, 2026-09-06 triage -------------------------------
+
+P1_WRONG_NOW = [2002, 2001, 1996, 1973, 1972, 1971, 1969, 1965, 1964, 1960, 1952,
+                1951, 1950, 1942, 1929, 1927, 1925, 1924, 1898, 1875, 1864, 1856,
+                1849, 1842, 1816, 1754, 1694, 1342]
+# Wrong, but the affected share is not yet known — an audit, not a repair.
+P1_OTHER = [1955, 1954, 1897, 1690, 1571, 1474]
+P2 = [1992, 1985, 1970, 1962, 1961, 1940, 1863, 1837, 1828, 1817, 1810, 1792,
+      1745, 1733, 1731, 1730, 1729, 1812]
+P3 = [1889, 1870, 1775, 1439, 1406, 1700]
+P4 = [1956, 1930, 1853, 1831, 1809, 1807, 1801, 1800, 1799, 1777, 1650, 1649, 1646]
+P5 = [1728, 1688]
+
+ROADMAP = {
+    "y3-1":  [1703, 1992, 1961, 1733, 1810, 1856, 1842, 1816],
+    "y3-2":  [1863, 1837, 1864],
+    "y3-4":  [1706, 1889, 1439, 1406],
+    "y3-5":  [1707],
+    # Item 7 is "extract the unextracted". Per-table defects in tables that already
+    # have item text are corpus trust and deliberately do NOT get this label —
+    # routing them here is what made item 7 look unfinishable.
+    "y3-7":  [1709, 1853, 1831, 1799, 1800, 1801, 1809, 1777, 1650, 1646, 1807],
+    "y3-11": [1713],
+}
+
+# Roadmap item issues, by the lens Project 4 already records for each.
+ROADMAP_ITEMS = {1703: "p2-gate", 1706: "p3-reach", 1707: "p3-reach",
+                 1709: "p4-volume", 1713: "p3-reach",
+                 1710: "p5-later", 1711: "p5-later", 1712: "p5-later",
+                 1714: "p5-later", 1715: "p5-later", 1716: "p5-later",
+                 1717: "p5-later", 1718: "p5-later", 1719: "p5-later"}
+
+# Data queue issues whose source identifier resembles a table already in the
+# warehouse, but only on string similarity — labelled, never closed.
+QUEUE_INGESTED = [1538, 1275, 1266, 1061, 748, 143, 64, 46]
+
+# Blocked on a decision from ben-domingue rather than on work. Each is one
+# question; none needs a session. Two of them gate steps in the structural
+# sequence: #1342 (repair the PISA recode rather than filter) and #1955
+# (`wording_rights` cannot express a fee, so neither rights re-audit can run).
+DECISION = [1342, 1955, 2002, 1694, 1754, 1952, 1950, 1849, 1690, 1864, 1992,
+            1940, 1792, 1889, 1870, 1775, 1801, 1650, 1649, 1700, 1728, 1406]
+
+# The lens PRIORITIES.md deliberately did not choose.
+RESEARCH_LABELS = {"research project", "summer 2026 project"}
+
+# Package repos: parity and porting work is reach; nothing there serves wrong data.
+PKG = {("itemresponsewarehouse/Rpkg", 155): "p2-gate",
+       ("itemresponsewarehouse/Rpkg", 149): "p3-reach",
+       ("itemresponsewarehouse/Rpkg", 147): "p3-reach",
+       ("itemresponsewarehouse/Rpkg", 156): "p3-reach",
+       ("itemresponsewarehouse/Python-pkg", 42): "p2-gate",
+       ("itemresponsewarehouse/Python-pkg", 28): "p3-reach",
+       ("itemresponsewarehouse/Python-pkg", 27): "p3-reach",
+       ("itemresponsewarehouse/Python-pkg", 26): "p3-reach",
+       ("itemresponsewarehouse/Python-pkg", 25): "p5-later",
+       ("itemresponsewarehouse/Python-pkg", 24): "p5-later",
+       ("itemresponsewarehouse/Python-pkg", 23): "p5-later",
+       ("itemresponsewarehouse/Python-pkg", 22): "p3-reach",
+       ("itemresponsewarehouse/Python-pkg", 3): "p3-reach"}
+
+EXPLICIT = {}
+for ns, p in ((P1_WRONG_NOW, "p1-trust"), (P1_OTHER, "p1-trust"), (P2, "p2-gate"),
+              (P3, "p3-reach"), (P4, "p4-volume"), (P5, "p5-later")):
+    for n in ns:
+        EXPLICIT[("ben-domingue/irw", n)] = p
+EXPLICIT.update(PKG)
+
+
+def fetch(repo):
+    out = subprocess.run(
+        ["gh", "issue", "list", "-R", repo, "--state", "open", "--limit", "600",
+         "--json", "number,title,labels"],
+        capture_output=True, text=True, check=True).stdout
+    return json.loads(out)
+
+
+def classify(repo, issue):
+    """Return (priority, flags, roadmap, note). priority may be '' for exemptions."""
+    n = issue["number"]
+    labels = {lab["name"] for lab in issue["labels"]}
+    key = (repo, n)
+    flags, note = [], ""
+
+    if key in EXEMPT:
+        return "", [], "", "roadmap master; the plan, not work to schedule"
+
+    if labels & QUEUE_LABELS:
+        if n in QUEUE_INGESTED:
+            return "", ["queue-ingested?"], "", "medium-confidence match to a live table; verify before closing"
+        return "", [], "", "acquisition queue; not-now as a class (PRIORITIES.md section 5)"
+
+    priority = EXPLICIT.get(key)
+    if priority:
+        note = "2026-09-06 triage"
+        if n in P1_WRONG_NOW:
+            flags.append("wrong-now")
+    elif n in ROADMAP_ITEMS and repo == "ben-domingue/irw":
+        priority, note = ROADMAP_ITEMS[n], "roadmap item, lens from Project 4"
+    elif labels & RESEARCH_LABELS:
+        priority, note = "p5-later", "research output: the lens not chosen"
+        flags.append("research-output")
+    elif repo != "ben-domingue/irw":
+        # The package repos hold no data, so nothing there can serve a wrong answer.
+        # An untriaged package issue is client work until someone says otherwise.
+        priority, note = "p3-reach", "by rule: untriaged package issue"
+    else:
+        # Everything else is an untriaged dataset offer of some kind — `trials`,
+        # `1mode/competition`, `nominal`, `simulated`, or an unlabelled paper link.
+        priority, note = "p5-later", "by rule: acquisition-adjacent, never triaged"
+
+    if repo == "ben-domingue/irw" and n in DECISION:
+        flags.append("lookhere_ben")
+
+    roadmap = ""
+    for lab, ns in ROADMAP.items():
+        if repo == "ben-domingue/irw" and n in ns:
+            roadmap = lab
+            break
+    return priority, flags, roadmap, note
+
+
+def main():
+    rows = []
+    for repo in REPOS:
+        for issue in fetch(repo):
+            p, flags, roadmap, note = classify(repo, issue)
+            rows.append({"repo": repo, "issue": issue["number"], "priority": p,
+                         "flags": " ".join(flags), "roadmap": roadmap,
+                         "title": issue["title"], "note": note})
+    rows.sort(key=lambda r: (r["repo"], -r["issue"]))
+    with OUT.open("w", newline="") as fh:
+        w = csv.DictWriter(fh, ["repo", "issue", "priority", "flags", "roadmap",
+                                "title", "note"])
+        w.writeheader()
+        w.writerows(rows)
+    print(f"wrote {OUT} ({len(rows)} rows)")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Companion to the 2026-09-06 issue triage pass ([summary on #1702](https://github.com/ben-domingue/irw/issues/1702)). The GitHub-side changes — labels, the `Queue: one-offs` milestone, 41 closures, Project 4's Decision column — are already applied; this is the tooling and the doc correction that go with them.

## What this adds

`metadata/build_issue_triage.py` assigns one of `p1-trust` / `p2-gate` / `p3-reach` / `p4-volume` / `p5-later` to every open issue across the three code repos, plus `wrong-now` for the narrow `ARCHITECTURE.md` §4 class and `lookhere_ben` for the 22 issues blocked on a decision rather than on work. `metadata/apply_issue_labels.py` applies it — dry-run by default, idempotent, and `lookhere_ben` is add-only so a triage run can never clear a flag set by hand.

The CSV between them is derived and deliberately uncommitted: it changes whenever an issue opens or closes, so a tracked copy would churn without recording anything. The durable half is the assignment lists in the builder.

## Why PRIORITIES.md changed

Three corrections, one of which mattered:

- It postponed items 4 (findability) and 5 (the packages) behind item 3, the version manifest. **Item 3 closed on 2026-09-03** (#1705), so that postponement had no reason left and the file still said so three days later.
- "18 roadmap items" → 17; the issue counts were stale.
- Added a short *Where the issue list is* section, since a ranking with no way to find the ranked work is half a tool.

## Verification

- Every open non-`data queue` issue in all three repos carries exactly **one** `p*` label (161 issues; zero violations). `data queue` is exempt on purpose — acquisition is not-now as a class, and 207 identical labels would say nothing.
- `apply_issue_labels.py` run twice reports `0 issue(s) would change`.
- `gh issue list --label wrong-now` returns 28 issues, each read and confirmed data-*wrong* rather than incomplete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGBwb4GBGMHQMaHcHSiA71