### PR TITLE
Drop the eight hours-per-day items from oxfordcovid_xue_2024_at (#1996)

### DIFF
--- a/data/oxfordcovid_xue_2024.r
+++ b/data/oxfordcovid_xue_2024.r
@@ -197,11 +197,19 @@ save(swemws_df, file="oxfordcovid_xue_2024_swemws.Rdata")
 write.csv(swemws_df, "oxfordcovid_xue_2024_swemws.csv", row.names=FALSE)
 
 # ---------- Activitiy and Technology Questionnaire ----------
+# Eight items on this form (five media_*, three activity_exercise_*) are free-text
+# hours-per-day quantities, not scale responses: the deposit's dictionary gives them
+# Field_Type "text" with no response options, and the section prompt invites decimals
+# ("e.g. 2.5 if you did 2 and a half hours"). They are dropped here, leaving the 36
+# radio items -- six reasons x six media, each 1 Never .. 5 Always. See #1996.
+hours_items <- c("media_playing", "media_social_media", "media_messaging", "media_video",
+                 "media_playing_voice", "activity_exercise_inside",
+                 "activity_exercise_outside", "activity_exercise_outside2")
 at_df <- arc_df |>
-  select(id, wave, starts_with("cov"), starts_with("media"), starts_with("activity"), -starts_with("covid"), -ends_with("complete"), -ends_with("timestamp"), -media_tv)
+  select(id, wave, starts_with("cov"), starts_with("media"), starts_with("activity"), -starts_with("covid"), -ends_with("complete"), -ends_with("timestamp"), -media_tv, -all_of(hours_items))
 at_df <- pivot_longer(at_df, -c(id, wave, starts_with("cov")), names_to="item", values_to="resp")
 at_df <- at_df %>%
-  filter(!is.na(resp) & resp == floor(resp) & resp <= 5)
+  filter(!is.na(resp))
 
 save(at_df, file="oxfordcovid_xue_2024_at.Rdata")
 write.csv(at_df, "oxfordcovid_xue_2024_at.csv", row.names=FALSE)


### PR DESCRIPTION
Closes the script half of #1996.

## What was wrong

`data/oxfordcovid_xue_2024.r:204` was the only one of the script's sixteen response filters carrying extra conditions:

```r
filter(!is.na(resp) & resp == floor(resp) & resp <= 5)
```

It deleted **12,985 of 192,922** non-missing responses (6.7% of the table). Every one came from eight free-text items asking *hours per day* — the deposit's dictionary gives them `Field_Type` `text` with no response options, and their section prompt invites decimals ("e.g. 2.5 if you did 2 and a half hours"). So `resp == floor(resp)` deleted exactly the answers the question asked for: 89.6% of the loss was non-integer, and the raw median is 0.5. On those eight items the loss was **23.0%**. The 36 `radio` items lost nothing.

## What this does

Ben's call: the eight are **not the kind of data IRW carries** — they are unrelated time-use quantities that share only a form, not a scale. They are dropped rather than repaired, and the filter goes back to plain `!is.na(resp)`.

What remains is the battery the filter never touched: six reasons (socialise / fun / news / work / avoidance / nothing else to do) × six media, each `1 Never … 5 Always`.

| | published | after |
|---|---|---|
| rows | 179,937 | **136,467** |
| items | 44 | **36** |
| `resp` | 0–5, mixed integer and continuous | **1–5 integer** |
| ids | 1,518 | 1,516 |

## Verification

Both rules were replayed against `ARC_raw_data.csv` from the deposit. The old rule reproduces the published row count exactly (179,937), and **every row on a retained item is identical** between the two — nothing is added, nothing is altered.

Two ids leave: `1454` and `2036` answered only hours items on this form and never touched the Likert battery, so they have no remaining responses.

## Not done here

1. **Re-upload `oxfordcovid_xue_2024_at`.** Until then the live table still carries the eight items and the truncated hours data. #1996 stays open for this.
2. **Item text.** `batch_201`'s `oxfordcovid_xue_2024_at__items.csv` (PR #1997, unmerged, `uploaded` still `NA`) ships 228 rows over 44 items; the 48 rows for the eight hours items need removing before it goes up, leaving 180 rows over 36. Nothing is live yet, so this is a file edit on that branch, not a re-upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gU4mnkERu64DkSXkvbnCt