### PR TITLE
data: emit `treat`, not `treatment`, in six processing scripts (#1730)

### DIFF
--- a/data/content_literacy_intervention.R
+++ b/data/content_literacy_intervention.R
@@ -10,7 +10,7 @@ df <- df |>
          s_itt_consented) |>
   rename(item = s_q_num,
          resp = s_correct,
-         treatment = s_itt_consented)
+         treat = s_itt_consented)
 
 ids <- as.data.frame(unique(df$s_id))
 ids <- ids |>
@@ -19,7 +19,7 @@ ids <- ids |>
 df <- df |>
   left_join(ids, by=c('s_id' = "unique(df$s_id)"))  |>
   # drop character item variable
-  select(id, treatment, item, resp) |>
+  select(id, treat, item, resp) |>
   # use item_id column as the item column
   arrange(id, item)
 

--- a/data/content_literacy_intervention_g1.R
+++ b/data/content_literacy_intervention_g1.R
@@ -45,13 +45,13 @@ df <- df |>
   select(id, s_itt_consented, item_id, resp) |>
   # use item_id column as the item column
   rename(item = item_id,
-         treatment = s_itt_consented) |>
+         treat = s_itt_consented) |>
   arrange(id, item) |>
   drop_na()
 
 # remove label from resp
 df$resp <- remove_labels(df$resp)
-df$treatment <- remove_labels(df$treatment)
+df$treat <- remove_labels(df$treat)
 
 
 # print response values

--- a/data/gilbert_hte/postprocessing.R
+++ b/data/gilbert_hte/postprocessing.R
@@ -12,7 +12,7 @@ f<-function(x) {
     resp<-x$score
     treat<-x$treat
     item<-x$item
-    data.frame(id=id,item=item,resp=resp,treatment=treat,pretest=pretest)
+    data.frame(id=id,item=item,resp=resp,treat=treat,pretest=pretest)
 }
 L<-lapply(L,f)
 

--- a/data/hte_irw.R
+++ b/data/hte_irw.R
@@ -9,7 +9,7 @@ df <- df |>
          s_correct,
          item_id) |>
   rename(id = s_id,
-         treatment = s_itt_2122,
+         treat = s_itt_2122,
          resp = s_correct)
 
 # create item IDs for each survey item

--- a/data/lifelab_healthliteracy.R
+++ b/data/lifelab_healthliteracy.R
@@ -36,7 +36,7 @@ for (i in 2:ncol(x)) {
 }
 
 df<-list()
-for (i in 1:length(items)) df[[i]]<-data.frame(id=id,treatment=treatment,item=names(items)[i],resp=items[[i]])
+for (i in 1:length(items)) df[[i]]<-data.frame(id=id,treat=treatment,item=names(items)[i],resp=items[[i]])
 df<-data.frame(do.call("rbind",df))
 
 save(df,file="lifelab_healthliteracy.Rdata")

--- a/data/pact_project.R
+++ b/data/pact_project.R
@@ -377,7 +377,7 @@ df <- df |>
   select(id, cond, item_id, resp) |>
   # use item_id column as the item column
   rename(item = item_id,
-         treatment = cond) |>
+         treat = cond) |>
   arrange(id, item)
 
 # print response values


### PR DESCRIPTION
Closes #1730.

### What was actually wrong

The README half of #1730 is already fixed — ced0fc2 rewrote the optional-columns bullet to say `treat`, and it now names `treatment` explicitly as a variant never to invent. That left the issue's open question: *do the eight `data/` scripts using `treatment` need migrating?*

### Inventory first

No published table is affected. Of the 4,213 tables in `metadata/metadata.csv`, **185 carry `treat` and 0 carry `treatment`**. So this is a reproducibility fix in the scripts, not a data correction.

Of the eight scripts:

| script | table status | action |
|---|---|---|
| `content_literacy_intervention_g1.R` | live, publishes `treat` | renamed |
| `pact_project.R` | live, publishes `treat` | renamed |
| `gilbert_hte/postprocessing.R` | live (`gilbert_meta_*`), publishes `treat` | renamed |
| `content_literacy_intervention.R` | unpublished (became `gilbert_meta_2`) | renamed |
| `hte_irw.R` | unpublished | renamed |
| `lifelab_healthliteracy.R` | unpublished | renamed |
| `handwriting_2006.R` | retired | left alone |
| `handwriting_2007.R` | retired | left alone |

The three live ones matter most: each backs a table that already publishes `treat`, so the script as written did not reproduce the table it claims to build. `gilbert_hte/postprocessing.R` was reading `x$treat` and renaming it *to* `treatment` on the way out.

### What I left alone, and why

Both `handwriting_*` tables are retired (they appear only in `metadata/retired_tags.csv`). `handwriting_2007.R` is worse than misnamed — it encodes the column as `'control'`/`'treatment'` strings and elsewhere as `''`, not 1/0. Renaming it would make a non-compliant script look compliant. Flagging rather than papering over.

### Verification

Every change is a one-token rename of an output column; `content_literacy_intervention.R` needed its downstream `select()` updated to match. No script was executed — none of the raw inputs are in the repo — so this is a static change, reviewed by reading each diff hunk against the published column list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HayHc1T73q9FrpVeWNKLyn