### PR TITLE
Refresh published biblio rows from the dictionary (#2001)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,15 @@ metadata/**/*.txt
 ##Rows held back because their table is not published yet (#1732). Committed for
 ##the same reason: it is the only place "waiting on a publish" is written down.
 !metadata/biblio_pending.csv
+##Which published biblio cells the dictionary corrected on this run (#2001).
+##Committed because it is the first run's review surface -- 336 cells across 223
+##tables is a list a person can read, where the same change in biblio.csv is a
+##223-row diff. It is not per-run noise: the Redivis biblio table is the
+##baseline every week, so this file only moves when the sheet does.
+!metadata/biblio_refresh_log.csv
+!metadata/comps_biblio_refresh_log.csv
+!metadata/nominal_biblio_refresh_log.csv
+!metadata/simsyn_biblio_refresh_log.csv
 .env
 .Rproj.user
 .DS_Store

--- a/metadata/02_biblio.R
+++ b/metadata/02_biblio.R
@@ -190,6 +190,10 @@ getrows<-function(l) {
         irw_dict <- u$dict
         write_dict_provenance(u$provenance, l$file.prov)
     }
+    ## The refresh log sits beside the CSV it explains: biblio.csv ->
+    ## biblio_refresh_log.csv. Derived rather than configured so all four
+    ## sources get one without four more list entries.
+    file.refresh <- if (is.null(l$file.refresh)) sub("\\.csv$", "_refresh_log.csv", file.out) else l$file.refresh
     ## Read the current biblio file
     user <- redivis$user(user)
     dataset <- user$dataset(dataset)
@@ -238,6 +242,17 @@ getrows<-function(l) {
     biblio<-biblio[!test,]
     ##no csv
     biblio$table<-gsub(".csv","",fixed=TRUE,biblio$table)
+    ## Refresh the five dictionary-owned columns on EVERY row, not just the new
+    ## ones (#2001). new_data_rows above is, by construction, the rows biblio
+    ## does not have; without this a correction typed into the sheet for an
+    ## already-published table reaches nobody. Fills blanks, prefers the
+    ## dictionary on conflict, and never blanks a biblio value from an empty
+    ## dictionary cell. See refresh_biblio_from_dict() in dict_union.R.
+    refreshed <- refresh_biblio_from_dict(biblio, irw_dict, name, log.file = file.refresh)
+    biblio <- refreshed$biblio
+    ## Runs before apply_data_doi(): the refresh never blanks a paper DOI, and
+    ## the deposit-DOI retirement below is the one thing entitled to.
+
     ## Save the updated biblio to a CSV file
     ## Custom licence terms, for EVERY row rather than only the new ones.
     ##

--- a/metadata/dict_union.R
+++ b/metadata/dict_union.R
@@ -489,3 +489,126 @@ apply_custom_license_terms <- function(biblio, dict, label = "core") {
             " row(s) carry custom licence terms")
     biblio
 }
+
+##---------------------------------------------------------------------------
+##Refresh published biblio rows from the dictionary (issue #2001).
+##
+##getrows() builds `new_data_rows` as the dictionary rows ABSENT from the live
+##Redivis biblio table (or lacking BibTeX) and binds them on. A dictionary row
+##that already has a biblio row is never re-read, so a correction typed into the
+##sheet for an already-published table reaches nobody. Measured 2026-09-05: 226
+##of 4,261 rows disagree on at least one of the five columns below -- 62 pure
+##fills, 163 genuine conflicts.
+##
+##The rule:
+##
+##  FILL BLANKS, PREFER THE DICTIONARY ON CONFLICT, AND NEVER BLANK A BIBLIO
+##  VALUE FROM AN EMPTY DICTIONARY CELL.
+##
+##That last clause is not hypothetical -- `cdm_timss03` holds a paper DOI in
+##biblio that the dictionary lacks -- and without it this repeats the pattern
+##that removed provenance for four live su_2024_* tables.
+##
+##BibTeX is deliberately NOT refreshed: seed_from_local() caches it because
+##regenerating costs a DOI fetch plus a Claude call per row, and the model does
+##not return byte-identical BibTeX twice.
+##
+##Note on a truncated sheet: this cannot damage biblio. A short read yields
+##FEWER matches, and a blank dictionary cell is skipped rather than written, so
+##the failure mode is "no change", not "wrong change". That is why there is no
+##minimum-rows oracle here, unlike drop_dead_dict_rows().
+
+##biblio's column name -> the dictionary's, most-preferred spelling first. The
+##four dictionary sheets have drifted on the licence column: core spells it
+##`Derived License`, comps/nom/sim `Derived_License` (confirmed 2026-08-02).
+BIBLIO_REFRESH_COLS <- list(
+    Description     = "Description",
+    Reference_x     = "Reference",
+    DOI__for_paper_ = "DOI (for paper)",
+    URL__for_data_  = "URL (for data)",
+    Derived_License = c("Derived License", "Derived_License")
+)
+
+##Comparison normalisation, per column. Two values that differ only here are
+##treated as equal, so the first run rewrites 226 rows rather than 4,261.
+##
+##  DOI      -- dict_norm_doi(), the repo's one definition, pinned to
+##              doi_hygiene.py by a parity test. A resolver prefix is not a
+##              different DOI.
+##  licence  -- "CC BY 4.0" / "cc by 4.0" is a spelling difference, not a
+##              relicensing.
+##  the rest -- whitespace only. Case IS significant in a Description; an
+##              instrument name that changed case changed.
+biblio_norm <- function(x, col) {
+    if (identical(col, "DOI__for_paper_")) return(dict_norm_doi(x))
+    x <- gsub("\\s+", " ", trimws(as.character(x)))
+    if (identical(col, "Derived_License")) x <- tolower(x)
+    x
+}
+
+##Strip the .csv some dictionary rows still carry, so the key matches biblio's
+##(getrows() strips it from biblio before writing).
+biblio_key <- function(x) sub("\\.csv$", "", dict_key(x))
+
+##The dictionary column backing one biblio column, or NULL when the sheet has
+##none. Returning NULL rather than failing: comps/nom/sim are independently
+##maintained and a sheet that has never had a column is not an error.
+dict_source_column <- function(dict, candidates) {
+    for (cl in candidates) if (cl %in% names(dict)) return(as.character(dict[[cl]]))
+    NULL
+}
+
+refresh_biblio_from_dict <- function(biblio, dict, label = "core", log.file = NULL) {
+    key <- biblio_key(dict$table)
+    keep <- !dict_blank(key) & !duplicated(key)
+    if (sum(!keep) > 0) {
+        message(label, ": ", sum(!keep), " duplicate/nameless dictionary row(s) ",
+                "ignored for the refresh (first occurrence wins)")
+    }
+    dict <- dict[keep, , drop = FALSE]
+    key  <- key[keep]
+
+    idx <- match(biblio_key(biblio$table), key)
+
+    changes <- list()
+    for (bcol in names(BIBLIO_REFRESH_COLS)) {
+        if (!bcol %in% names(biblio)) next
+        dvals <- dict_source_column(dict, BIBLIO_REFRESH_COLS[[bcol]])
+        if (is.null(dvals)) next
+
+        new <- dvals[idx]                      ##NA where the dictionary has no row
+        old <- as.character(biblio[[bcol]])
+        ##A blank dictionary cell never wins -- including for a table the
+        ##dictionary does not mention at all, which is the same case here.
+        move <- !dict_blank(new) &
+                (dict_blank(old) | biblio_norm(old, bcol) != biblio_norm(new, bcol))
+        move[is.na(move)] <- FALSE
+        if (!any(move)) next
+
+        changes[[bcol]] <- data.frame(
+            table  = biblio$table[move],
+            column = bcol,
+            kind   = ifelse(dict_blank(old[move]), "fill", "conflict"),
+            was    = old[move],
+            now    = new[move],
+            stringsAsFactors = FALSE)
+        biblio[[bcol]][move] <- new[move]
+    }
+
+    log <- if (length(changes)) do.call(rbind, changes) else
+        data.frame(table = character(0), column = character(0), kind = character(0),
+                   was = character(0), now = character(0), stringsAsFactors = FALSE)
+    log <- log[order(log$table, log$column), , drop = FALSE]
+    message(label, ": refreshed ", nrow(log), " cell(s) across ",
+            length(unique(log$table)), " table(s) from the dictionary (",
+            sum(log$kind == "fill"), " fill, ", sum(log$kind == "conflict"),
+            " conflict)")
+    ##Always written, even when empty -- "nothing drifted" is a useful statement,
+    ##and it makes the first run reviewable as a list rather than only as a
+    ##226-row diff of biblio.csv.
+    if (!is.null(log.file)) {
+        readr::write_csv(log, log.file)
+        message("  wrote ", nrow(log), " refresh row(s) to ", log.file)
+    }
+    list(biblio = biblio, log = log)
+}

--- a/metadata/tests/manual_dict_test.R
+++ b/metadata/tests/manual_dict_test.R
@@ -218,6 +218,54 @@ if (MODE == "tier-b") {
     check(nrow(held) == 1L && held$table[1] == "not_yet_published_2026",
           "it is written to biblio_pending.csv instead of vanishing")
 
+    ##---------------------------------------------------------------- #2001 ---
+    ##The refresh, on the real 4,000-odd rows. Fixtures cannot show this: the
+    ##question is how many published rows the sheet actually contradicts, and
+    ##whether any of the writes are ones we did not intend.
+    rlog <- tempfile(fileext = ".csv")
+    on.exit(unlink(rlog), add = TRUE)
+    ref <- suppressMessages(refresh_biblio_from_dict(biblio, dict, "core", log.file = rlog))
+    log <- ref$log
+    cat("\n  refresh: ", nrow(log), " cell(s) across ", length(unique(log$table)),
+        " table(s) -- ", sum(log$kind == "fill"), " fill, ",
+        sum(log$kind == "conflict"), " conflict\n", sep = "")
+    for (cl in unique(log$column)) {
+        cat("    ", cl, ": ", sum(log$column == cl), "\n", sep = "")
+    }
+
+    check(nrow(ref$biblio) == nrow(biblio), "the refresh adds no rows and drops none")
+    check(identical(biblio$table, ref$biblio$table), "and does not reorder them")
+    check(identical(biblio$BibTex, ref$biblio$BibTex), "BibTex is untouched")
+
+    ##The clause that matters. Not hypothetical: cdm_timss03 holds a paper DOI
+    ##that the dictionary lacks, and the orphan-biblio deletion (#1993) is what
+    ##this looks like when it goes wrong.
+    blanked <- character(0)
+    for (cl in names(BIBLIO_REFRESH_COLS)) {
+        if (!cl %in% names(biblio)) next
+        lost <- !dict_blank(biblio[[cl]]) & dict_blank(ref$biblio[[cl]])
+        if (any(lost)) blanked <- c(blanked, paste0(cl, " x", sum(lost)))
+    }
+    check(length(blanked) == 0L, "no published value is blanked by the refresh")
+    if (length(blanked)) cat("     blanked:", paste(blanked, collapse = ", "), "\n")
+
+    ##Every logged change must be a real change under the comparison rule --
+    ##i.e. the run is idempotent, and a second one would be a no-op.
+    again <- suppressMessages(refresh_biblio_from_dict(ref$biblio, dict, "core"))
+    check(nrow(again$log) == 0L, "a second refresh changes nothing (idempotent)")
+
+    cat("\n  The log is at ", rlog, " for this run; in production it is\n",
+        "  biblio_refresh_log.csv, beside the CSV it explains.\n", sep = "")
+    if (nrow(log)) {
+        cat("\n  first 10 changes:\n")
+        show <- head(log, 10)
+        for (i in seq_len(nrow(show))) {
+            cat("    ", show$table[i], " [", show$column[i], ", ", show$kind[i], "]\n",
+                "      was: ", substr(show$was[i], 1, 90), "\n",
+                "      now: ", substr(show$now[i], 1, 90), "\n", sep = "")
+        }
+    }
+
     cat("\n  A real batch sits in that held state between the table upload and\n",
         " the publish click. biblio_pending.csv is how you see it.\n", sep = "")
 }

--- a/metadata/tests/test_dict_union.R
+++ b/metadata/tests/test_dict_union.R
@@ -419,6 +419,174 @@ local({
     check(nrow(out) == 3L, "the join adds no rows and drops none")
 })
 
+cat("refresh_biblio_from_dict -- #2001\n")
+
+##A biblio frame in the shape getrows() has by the time the refresh runs: the
+##Redivis column names, .csv already stripped from `table`.
+fake_biblio <- function(...) {
+    rows <- list(...)
+    d <- as.data.frame(do.call(rbind, rows), stringsAsFactors = FALSE)
+    names(d) <- c("table", "DOI__for_paper_", "Reference_x", "URL__for_data_",
+                  "Derived_License", "Description", "BibTex")
+    d
+}
+biblio_row <- function(table, doi = "", reference = "", url = "", derived = "",
+                       description = "", bibtex = "@misc{x}") {
+    c(table, doi, reference, url, derived, description, bibtex)
+}
+refresh <- function(b, d) suppressMessages(refresh_biblio_from_dict(b, d))
+
+THE_TEST_THAT_MATTERS <- function() {
+    ##An empty dictionary cell must never blank a published biblio value. This
+    ##is `cdm_timss03` today -- biblio holds a paper DOI the dictionary lacks --
+    ##and it is the orphan-deletion pattern that removed provenance for four
+    ##live su_2024_* tables.
+    b <- fake_biblio(biblio_row("a_2020", doi = "10.1007/s10763-018-9916-9",
+                                description = "published text"))
+    for (empty in list(NA_character_, "", "NA")) {
+        d <- fake_sheet(sheet_row("a_2020"))
+        d$`DOI (for paper)`[1] <- empty
+        d$Description[1]       <- empty
+        out <- refresh(b, d)$biblio
+        check(out$DOI__for_paper_[1] == "10.1007/s10763-018-9916-9" &&
+              out$Description[1] == "published text",
+              paste0("a dictionary cell holding ",
+                     if (is.na(empty)) "NA" else paste0("'", empty, "'"),
+                     " never blanks a published value"))
+    }
+}
+THE_TEST_THAT_MATTERS()
+
+local({
+    ##The 163 conflicts: the dictionary is the corrected side.
+    b <- fake_biblio(biblio_row("rmet_higgins_2022_tas",
+                                description = "the paper's title, in the wrong field"))
+    d <- fake_sheet(sheet_row("rmet_higgins_2022_tas",
+                              description = "Toronto Alexithymia Scale"))
+    res <- refresh(b, d)
+    check(res$biblio$Description[1] == "Toronto Alexithymia Scale",
+          "the dictionary wins a conflict on an already-published row")
+    check(nrow(res$log) == 1L && res$log$kind[1] == "conflict",
+          "the change is logged as a conflict")
+    check(res$log$was[1] == "the paper's title, in the wrong field" &&
+          res$log$now[1] == "Toronto Alexithymia Scale",
+          "the log carries both sides, so the first run is reviewable as a list")
+})
+
+local({
+    ##The 62 fills.
+    b <- fake_biblio(biblio_row("a_2020"))
+    d <- fake_sheet(sheet_row("a_2020", description = "Big Five Inventory"))
+    res <- refresh(b, d)
+    check(res$biblio$Description[1] == "Big Five Inventory",
+          "a blank biblio cell is filled from the dictionary")
+    check(res$log$kind[1] == "fill", "the change is logged as a fill")
+})
+
+local({
+    ##Churn control. A run that rewrote every row for a resolver prefix or a
+    ##case difference would bury the 226 real changes in a 4,261-row diff.
+    b <- fake_biblio(biblio_row("a_2020", doi = "https://doi.org/10.1/x",
+                                derived = "CC BY 4.0",
+                                description = "Spatial  reasoning "))
+    d <- fake_sheet(sheet_row("a_2020", doi = "doi: 10.1/x", derived = "cc by 4.0",
+                              description = "Spatial reasoning"))
+    res <- refresh(b, d)
+    check(nrow(res$log) == 0L,
+          "a DOI resolver prefix, a licence spelling and whitespace are not changes")
+    check(res$biblio$DOI__for_paper_[1] == "https://doi.org/10.1/x",
+          "an unchanged cell keeps the published bytes")
+})
+
+local({
+    ##Case IS significant in a description: an instrument name that changed case
+    ##changed. (DOIs and licences are the two exceptions above.)
+    b <- fake_biblio(biblio_row("a_2020", description = "dreem"))
+    d <- fake_sheet(sheet_row("a_2020", description = "DREEM"))
+    check(nrow(refresh(b, d)$log) == 1L, "a case change in a Description is a change")
+})
+
+local({
+    b <- fake_biblio(biblio_row("A_2020", description = "old"))
+    d <- fake_sheet(sheet_row("a_2020", description = "new"))
+    check(refresh(b, d)$biblio$Description[1] == "new",
+          "the key match is case-insensitive (307 tables depend on this)")
+})
+
+local({
+    ##getrows() strips .csv from biblio before writing; some dictionary rows
+    ##still carry it.
+    b <- fake_biblio(biblio_row("a_2020", description = "old"))
+    d <- fake_sheet(sheet_row("a_2020"))
+    d$table[1] <- "a_2020.csv"; d$table.lower[1] <- "a_2020.csv"
+    d$Description[1] <- "new"
+    check(refresh(b, d)$biblio$Description[1] == "new",
+          "a dictionary row still carrying .csv matches the stripped biblio row")
+})
+
+local({
+    ##A truncated sheet must be able to say "no change", never "wrong change".
+    b <- fake_biblio(biblio_row("a_2020", description = "published"),
+                     biblio_row("b_2020", description = "published"))
+    d <- fake_sheet(sheet_row("b_2020", description = "published"))
+    res <- refresh(b, d)
+    check(res$biblio$Description[1] == "published" && nrow(res$log) == 0L,
+          "a biblio row the dictionary does not mention is left alone")
+    check(nrow(res$biblio) == 2L, "the refresh adds no rows and drops none")
+})
+
+local({
+    ##BibTeX is cached on purpose -- regenerating costs a DOI fetch plus a
+    ##Claude call, and the model does not return byte-identical BibTeX twice.
+    b <- fake_biblio(biblio_row("a_2020", bibtex = "@misc{cached}"))
+    d <- fake_sheet(sheet_row("a_2020", description = "x"))
+    check(refresh(b, d)$biblio$BibTex[1] == "@misc{cached}",
+          "the refresh never touches BibTex")
+})
+
+local({
+    ##comps/nom/sim spell the licence column with an underscore.
+    b <- fake_biblio(biblio_row("a_2020", derived = "CC0 1.0"))
+    d <- fake_sheet(sheet_row("a_2020"))
+    names(d)[names(d) == "Derived License"] <- "Derived_License"
+    d$Derived_License[1] <- "CC BY 4.0"
+    check(refresh(b, d)$biblio$Derived_License[1] == "CC BY 4.0",
+          "both dictionary spellings of the licence column are read")
+})
+
+local({
+    ##A sheet with no such column at all is a sheet, not an error.
+    b <- fake_biblio(biblio_row("a_2020", url = "http://example.org"))
+    d <- fake_sheet(sheet_row("a_2020"))
+    d[["URL (for data)"]] <- NULL
+    check(refresh(b, d)$biblio$URL__for_data_[1] == "http://example.org",
+          "a dictionary with no URL column leaves the biblio URL alone")
+})
+
+local({
+    ##The dictionary has known duplicate rows (dictionary_duplicates_2026-08-24).
+    b <- fake_biblio(biblio_row("a_2020", description = "old"))
+    d <- fake_sheet(sheet_row("a_2020", description = "first"),
+                    sheet_row("a_2020", description = "second"))
+    res <- refresh(b, d)
+    check(res$biblio$Description[1] == "first" && nrow(res$biblio) == 1L,
+          "a duplicated dictionary row does not duplicate or double-write biblio")
+})
+
+local({
+    ##The log is written even when nothing drifted: "nothing changed" is a
+    ##different and more useful statement than a missing file.
+    tmplog <- tempfile(fileext = ".csv")
+    on.exit(unlink(tmplog), add = TRUE)
+    b <- fake_biblio(biblio_row("a_2020", description = "same"))
+    d <- fake_sheet(sheet_row("a_2020", description = "same"))
+    suppressMessages(refresh_biblio_from_dict(b, d, "core", log.file = tmplog))
+    check(file.exists(tmplog), "an empty refresh still writes its log")
+    check(identical(names(readr::read_csv(tmplog, show_col_types = FALSE)),
+                    c("table", "column", "kind", "was", "now")),
+          "the empty log keeps the full header")
+})
+
 ##------------------------------------------------------------------ result ---
 cat("\n")
 if (failures > 0L) { cat(failures, "FAILURE(S)\n"); quit(status = 1L) }


### PR DESCRIPTION
Closes #2001.

`02_biblio.R` builds `new_data_rows` as the dictionary rows **absent from** the live Redivis `biblio` table and binds them on. A dictionary row that already has a biblio row is never re-read — so a correction typed into the sheet for an already-published table reaches nobody, and nothing reports the drift.

## The change

`refresh_biblio_from_dict()` (in `dict_union.R`, so it is offline-testable like the other carry-throughs) re-reads five columns for **every** row: `Description`, `Reference`, `DOI (for paper)`, `URL (for data)`, `Derived License`.

> Fill blanks, prefer the dictionary on conflict, and never blank a biblio value from an empty dictionary cell.

BibTeX is deliberately not refreshed — `seed_from_local()` caches it because regenerating costs a DOI fetch plus a Claude call per row, and the model does not return byte-identical BibTeX twice.

Called before `apply_data_doi()`: the refresh never blanks a paper DOI, and the deposit-DOI retirement is the one thing entitled to.

## Measured against production (tier-b, live sheet + committed `biblio.csv`)

**336 cells across 223 tables — 109 fills, 227 conflicts.**

| column | cells |
|---|---|
| `Description` | 138 |
| `DOI (for paper)` | 81 |
| `Reference` | 46 |
| `URL (for data)` | 69 |
| `Derived License` | 2 |

Assertions that passed on the real data: no row added, dropped or reordered; `BibTex` byte-identical; **no published value blanked**; and a second run is a no-op.

## What the DOI conflicts turn out to be

Worth reading, because they are not noise — biblio is carrying a *fabricated distinct DOI per shard* where the dictionary has the one real paper:

```
enem_2023_1mil_ch   10.46814/lajdv3n5-020 -> 10.46814/lajdv3n5-018
enem_2023_1mil_cn   10.46814/lajdv3n5-021 -> 10.46814/lajdv3n5-018
enem_2023_1mil_lc   10.46814/lajdv3n5-019 -> 10.46814/lajdv3n5-018
...
goksel_2026_embarrassment_liking       10.1037/pspa0000488 -> 10.1037/pspa0000477
goksel_2026_embarrassment_appeasement  10.1037/pspa0000486 -> 10.1037/pspa0000477
```

Sequential suffixes across sibling tables, one per shard. And the ten `ECPS_Sahm_2024_*` rows publish the **OSF deposit DOI in the paper column** — the exact case #1690 split the columns for.

One to look at rather than take on faith: `andrich_mudfold`, `…0104 -> …0105`. Same class, but a single row with no sibling pattern to corroborate it.

## Review surface

Each changed cell is written to `biblio_refresh_log.csv` (`table, column, kind, was, now`), tracked in git. 336 lines a person can read beats the same change as a 223-row diff of `biblio.csv`. The file is always written, even when empty — "nothing drifted" is a useful statement — and it only moves when the sheet does, since the Redivis table is the baseline every week.

## Tests

`tests/test_dict_union.R` gains 20 checks, led by the one that matters: **a dictionary cell holding `NA` / `""` / `"NA"` never blanks a published value**, in all three spellings. That is `cdm_timss03` today, and it is the orphan-deletion pattern that removed provenance for four live `su_2024_*` tables.

Also covered: churn control (a resolver prefix, a licence spelling and whitespace are not changes, and an unchanged cell keeps its published bytes); case-insensitive keys; a dictionary row still carrying `.csv`; both spellings of the licence column; a sheet missing a column entirely; duplicate dictionary rows; and `BibTex` untouched.

`tests/manual_dict_test.R tier-b` gains the production replay quoted above.

## Not in this PR

`biblio.csv` itself. Regenerating it needs the Redivis read, so the 336 cells land in the weekly pipeline PR — which is what #2001 asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjpFgj7bT9GJ8UeF5hMLdE