### PR TITLE
enkavi_2019_stopsignal: itemcov_delay is the frequency block (#1969)

### DIFF
--- a/data/enkavi_2019_conflict_tasks.py
+++ b/data/enkavi_2019_conflict_tasks.py
@@ -142,10 +142,21 @@ def _prep_navon(df):
 
 
 def _prep_stopsignal(df):
+    # `condition` is the stop-signal FREQUENCY manipulation, not the delay
+    # (#1969). It carries exactly two levels and they are the frequency
+    # blocks: 40.0% of trials are stop trials under `high` and 20.0% under
+    # `low`, verified against the deposit.
+    #
+    # The delay is `SS_delay`, a separate column in the same file with 18
+    # distinct values (0-850 ms) present under both levels. It is NOT carried
+    # here and cannot be an itemcov_: the SSD is staircased trial by trial, so
+    # it varies within an item and within a person, which is exactly what the
+    # invariance check below exists to refuse. Carrying it would need a
+    # trial-level slot the standard does not have.
     df["shape_id"] = df["stimulus"].str.extract(r"/(\w+)\.png")
     return (
         ["condition", "SS_trial_type", "shape_id"],
-        {"itemcov_delay": "condition", "itemcov_trial_type": "SS_trial_type"},
+        {"itemcov_ss_frequency": "condition", "itemcov_trial_type": "SS_trial_type"},
     )
 
 


### PR DESCRIPTION
Fixes the script for #1969. **The published table still needs a re-upload** — left for @ben-domingue.

## Confirmed against the deposit

`_prep_stopsignal` mapped `itemcov_delay` to the source's `condition` column. `condition` is the stop-signal **frequency** manipulation:

| `condition` | rows | stop trials |
|---|---|---|
| `high` | 156,600 | **40.0%** |
| `low` | 156,600 | **20.0%** |

Two levels, and they are the frequency blocks. Renamed to `itemcov_ss_frequency`.

## Why `SS_delay` is not restored in its place

The real delay is `SS_delay` — a separate column in the same file, 18 distinct values (0–850 ms), present under both levels of `condition`. It cannot be carried as an `itemcov_`:

```
items: 16   violating invariance: 16   max distinct SSD within an item: 18
```

The SSD is staircased trial by trial, so it varies within an item *and* within a person. `datastandard.md` requires `itemcov_*` to be "consistent within each item across all rows for that item", and this script's own assertion enforces it — adding `SS_delay` as `itemcov_delay` would fail the build, correctly.

So the honest statement is that the delay is **not carried**, and carrying it needs a trial-level slot the standard does not have. That is a standard decision, not a repair, so it is not made here. Worth a separate issue if you want the SSD in the corpus — it is the informative variable for anyone modelling this task.

## Scope

Only `enkavi_2019_stopsignal`. The issue reads the shared script as making this family-wide, but the other seven entries in `TASKS` build through their own prep functions and none of them names a delay — `itemcov_delay` appeared exactly once in the file.

## Verified

Rebuilt the table end to end:

```
cols: id, item, resp, wave, position, rt, itemcov_ss_frequency, itemcov_trial_type
itemcov_ss_frequency: high 201900, low 201900
rows 403800  ids 523  items 16
```

Invariance assertion and the id+item+wave+position uniqueness assertion both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjpFgj7bT9GJ8UeF5hMLdE