### PR TITLE
dominguez_2018_jcs: item_17 is a subscale mean, not an item (#1965)

### DIFF
--- a/data/dominguez_2018_job_crafting.py
+++ b/data/dominguez_2018_job_crafting.py
@@ -23,12 +23,55 @@ SI_URL = ("https://journals.plos.org/plosone/article/file"
 UA = {"User-Agent": "IRW-Finder/1.0 (ben.domingue@gmail.com)"}
 
 # (output name, list of column indices, valid_max)
+#
+# JCS omits column 25, headed "Item 17". That column does not hold Item 17's
+# responses: for 200 of the 202 respondents it holds the MEAN of columns
+# 26-29, byte-identical to the block's own Subtotal in column 30, and 141 of
+# its 202 values are non-integers on a 1-5 Likert (4.25, 2.75, 3.5, ...).
+# A subscale-mean formula was filled one column too far left in the deposited
+# workbook and overwrote the item. The last two rows escaped the fill -- they
+# carry an integer response, and for those two the Subtotal is correctly a
+# five-item mean -- which is what identifies it as a fill rather than a
+# deliberate aggregate. See #1965.
+#
+# Item 17's responses are therefore not recoverable from this deposit for
+# anyone but those two respondents, so the item is dropped rather than
+# published as a truncated mean. (`resp.astype(int)` was silently turning
+# 4.25 into 4, which is why it read as a plausible response.)
+#
+# The workbook's own `Total JCS` (column 31) averages all 21 columns including
+# the damaged one, so the paper's JCS totals inherit the same defect. Not
+# something this script can repair.
 SCALES = {
     "dominguez_2018_jcs": ([6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 19, 20, 21,
-                             22, 23, 25, 26, 27, 28, 29], 5),
+                             22, 23, 26, 27, 28, 29], 5),
     "dominguez_2018_uwes": (list(range(32, 49)), 6),
     "dominguez_2018_mbi": (list(range(56, 78)), 6),
     "dominguez_2018_itl": ([85, 86, 87], 5),
+}
+
+# The source's own item numbers, where they are not simply 1..n. JCS keeps the
+# workbook's numbering across the gap: `item_18`..`item_21` stay the paper's
+# items 18-21 rather than sliding down to fill 17-20. Positional renumbering
+# would silently change what every label after the gap refers to, and change
+# the join key for anyone already using the table.
+ITEM_NUMBERS = {
+    "dominguez_2018_jcs": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+                            16, 18, 19, 20, 21],
+}
+
+# Aggregate columns that must never enter an item set, as (out_name, column,
+# what it is). Checked at build time so a future edit to SCALES cannot
+# reintroduce one, and so this file states the evidence rather than asserting
+# the conclusion.
+AGGREGATE_COLS = {
+    11: "JCS subscale mean (items 1-5)",
+    18: "JCS subscale mean (items 6-11)",
+    24: "JCS subscale mean (items 12-16)",
+    25: "JCS subscale mean (items 18-21), mis-headed `Item 17` -- #1965",
+    30: "JCS subscale mean (items 18-21), duplicate of column 25",
+    31: "Total JCS",
+    88: "Intention To Leave total",
 }
 
 COV_COLS = {
@@ -56,9 +99,16 @@ def convert():
     os.makedirs(OUT_DIR, exist_ok=True)
     for out_name, (item_cols, valid_max) in SCALES.items():
         item_cols = [c for c in item_cols]
+        bad = [c for c in item_cols if c in AGGREGATE_COLS]
+        assert not bad, (f"{out_name}: aggregate column(s) in the item set: " +
+                         ", ".join(f"{c} ({AGGREGATE_COLS[c]})" for c in bad))
+        assert len(item_cols) == len(set(item_cols)), f"{out_name}: duplicate column"
+        assert len(ITEM_NUMBERS.get(out_name, item_cols)) == len(item_cols), \
+            f"{out_name}: ITEM_NUMBERS does not match the column list"
         cols = ["id"] + cov_cols + item_cols
         sub = data[cols].copy()
-        item_names = {c: f"item_{i+1}" for i, c in enumerate(item_cols)}
+        numbers = ITEM_NUMBERS.get(out_name, range(1, len(item_cols) + 1))
+        item_names = {c: f"item_{n}" for c, n in zip(item_cols, numbers)}
         sub = sub.rename(columns=item_names)
         item_col_names = list(item_names.values())
 
@@ -68,6 +118,12 @@ def convert():
         long = long.dropna(subset=["resp"]).reset_index(drop=True)
         # isolated data-entry error check: drop values outside documented scale
         long = long[(long["resp"] >= 0) & (long["resp"] <= valid_max)]
+        # A non-integer value on a Likert item is an aggregate that has been
+        # mistaken for a response, not a response -- astype(int) below would
+        # truncate it into a plausible one, which is how #1965 stayed hidden.
+        frac = long.loc[long["resp"] % 1 != 0]
+        assert frac.empty, (f"{out_name}: {len(frac)} non-integer response(s) in "
+                            f"{sorted(frac['item'].unique())}")
         long["resp"] = long["resp"].astype(int)
 
         out_cols = ["id", "item", "resp"] + cov_cols


### PR DESCRIPTION
Fixes the script for #1965. **The published table still needs a re-upload**, and the batch_027 item table with it — left for @ben-domingue.

## What column 25 actually is

The issue reports `item_17 = FLOOR(mean(item_18..21))` for 200/202 ids, r = 0.93. The underlying defect is sharper than that, and the sharper version is what makes the fix unambiguous.

Column 25 of the workbook is headed **"Item 17"**, under the *Increasing challenging Job Demands* subscale. It does not hold Item 17's responses:

| check | result |
|---|---|
| `col25 == mean(col26..29)` exactly | **200 of 202** |
| `col25 == col30` (the block's own `Subtotal`) | **200 of 202** |
| non-integer values on a 1–5 Likert | **141 of 202** (4.25, 2.75, 3.5, 2.25, …) |

The r = 0.93 in the issue is an artifact of the `FLOOR`; against the unrounded mean the correlation is **0.999**, because it *is* the mean.

**The two exceptions are the tell.** Rows 200 and 201 carry an integer (3, 2) in column 25, and for exactly those two rows column 30 is a correct *five*-item mean (2.8, 1.8) rather than a copy of column 25. So this is a subscale-mean formula filled one column too far left in the deposited workbook, overwriting the item — the last two respondents were added after the fill and escaped it. It is not a deliberate aggregate column that the ingest mistook for an item.

## Why it read as plausible

`long["resp"].astype(int)` was truncating 4.25 → 4, so every value landed inside the documented 1–5 range and passed the range filter. A non-integer response now fails the build:

```
assert frac.empty, f"{out_name}: {len(frac)} non-integer response(s) in {items}"
```

## Numbering

`item_17` is dropped; **`item_18`–`item_21` keep their numbers**. The script named items positionally (`item_{i+1}`), so simply removing the column would have slid items 18–21 down into 17–20 — silently changing what four labels refer to, and changing the join key for anyone already using the table. `ITEM_NUMBERS` now carries the workbook's own numbering across the gap.

## Guards

`AGGREGATE_COLS` names all seven aggregate columns in the sheet (three subscale means, the mis-headed one, its duplicate, `Total JCS`, and the ITL total) with what each one is, and refuses any of them in an item set. Re-adding column 25 fails with:

```
AssertionError: dominguez_2018_jcs: aggregate column(s) in the item set:
25 (JCS subscale mean (items 18-21), mis-headed `Item 17` -- #1965)
```

## Verified

```
dominguez_2018_jcs.csv:  rows=4040 ids=202 items=20 resp=1-5
dominguez_2018_uwes.csv: rows=3434 ids=202 items=17 resp=0-6
dominguez_2018_mbi.csv:  rows=4443 ids=202 items=22 resp=0-6
dominguez_2018_itl.csv:  rows=606  ids=202 items=3  resp=1-5
```

I checked the other three scales for the same defect: UWES (17), MBI (22) and ITL (3) each map to real item columns only, and all three pass both guards.

## Noted, not fixed

The workbook's own `Total JCS` (column 31) averages all 21 columns **including** the damaged one — verified, 202/202. So the paper's JCS totals inherit the defect. Nothing this script can repair; recording it here because a reuser comparing IRW against the published totals will find they disagree, and IRW will be the correct side.

## Item text

The batch_027 `__items.csv` ships `item_17` with blank `item_text` — the 4.8% blank rate `audit_batch` reports for this table. Once the response table is re-uploaded, that row should go and the blank rate drops to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjpFgj7bT9GJ8UeF5hMLdE