### PR TITLE
COACH_Chen_2022_IADL: filter each item to its codebook range (#1924)

### DIFF
--- a/data/COACH_Chen_2022.R
+++ b/data/COACH_Chen_2022.R
@@ -3,7 +3,24 @@ library(dplyr)
 library(tidyr)
 library(stringr)
 
-df <- read.xlsx("Copy of COACH_raw_data_22_5_16.xlsx")
+## The deposited workbook (Harvard Dataverse doi:10.7910/DVN/6RWH41) has a
+## TWO-ROW header. Row 2 carries the real column name for every column except
+## the first five: the 15 Charlson comorbidity flags sit under a merged
+## `Comorbidity` band, so their names are on row 2 while `Cohort`, `Group`,
+## `Number`, `Village` are on row 1.
+##
+## read.xlsx() reads a single header row, so against the file AS DEPOSITED the
+## comorbidity columns come back as X6..X20 and the select() below fails on
+## names that do not exist -- this script could only ever run against a local
+## copy whose top row had been removed by hand. Build the header from both rows
+## instead: row 2 wins, row 1 fills the blanks. Verified to produce exactly the
+## names this script goes on to reference.
+XLSX <- "Copy of COACH_raw_data_22_5_16.xlsx"
+hdr <- read.xlsx(XLSX, colNames = FALSE, rows = 1:2)
+df  <- read.xlsx(XLSX, colNames = FALSE, startRow = 3)
+.nm <- ifelse(is.na(hdr[2, ]) | trimws(as.character(hdr[2, ])) == "",
+              as.character(hdr[1, ]), as.character(hdr[2, ]))
+names(df) <- make.names(trimws(.nm), unique = TRUE)
 
 df$id <- seq(1, nrow(df))
 
@@ -66,8 +83,36 @@ df_csq <- df %>% filter(grepl("customer", item)) %>%
           select (id, resp, item)
 df_adl <- df %>% filter(grepl("_adl", item)) %>%
   filter(resp != 0)
-df_iadl <- df %>% filter(grepl("iadl", item)) %>%
-  filter(resp != 5)
+## The Lawton IADL prints a different number of options per item, and the
+## deposit ships them: COACH_Code Book_Final_version.xlsx, sheet 2, one row per
+## IADL item with its value labels. Transcribed here rather than inferred from
+## observed maxima.
+##
+##   q1 Shopping 0-3   q2 Transportation 0-4   q3 Food preparation 0-3
+##   q4 Housekeeping 0-4   q5 Laundry 0-2   q6 Telephone 0-3
+##   q7 Own medication 0-3   q8 Finances 0-2
+##
+## 65 stored responses sit above their own item's ceiling (#1924), and they are
+## only at the 6- and 12-month waves: at baseline every item's observed maximum
+## equals its codebook ceiling exactly. A uniform 0-4 administration would show
+## the extra levels at baseline too, so this is 0.12% data entry, not a wrong
+## option mapping -- q8 alone carries 35 of them (3 x26, 4 x9) on a two-option
+## item.
+##
+## Replaces `filter(resp != 5)`, which caught one of the 66 by coincidence: 5 is
+## out of range for every IADL item, but so are 3 and 4 on q5/q8, and 12 on q3.
+IADL_MAX <- c(ra_iadl_q1 = 3, ra_iadl_q2 = 4, ra_iadl_q3 = 3, ra_iadl_q4 = 4,
+              ra_iadl_q5 = 2, ra_iadl_q6 = 3, ra_iadl_q7 = 3, ra_iadl_q8 = 2)
+
+df_iadl <- df %>% filter(grepl("iadl", item))
+## A renamed item must fail loudly: an unmatched name would give NA and drop
+## every row of that item silently.
+stopifnot(all(unique(df_iadl$item) %in% names(IADL_MAX)))
+iadl_resp <- as.numeric(df_iadl$resp)
+iadl_keep <- !is.na(iadl_resp) & iadl_resp >= 0 & iadl_resp <= IADL_MAX[df_iadl$item]
+message(sprintf("IADL: dropped %d of %d response(s) outside the codebook range",
+                sum(!iadl_keep), nrow(df_iadl)))
+df_iadl <- df_iadl[iadl_keep, ]
 df_mos <- df %>% filter(grepl("mos", item))
 df_sns <- df %>% filter(grepl("social", item))
 df_phq <- df %>% filter(grepl("phq", item)) %>%


### PR DESCRIPTION
Fixes the script for #1924. Corrected table is in `/tmp/here/COACH_Chen_2022_IADL.csv` (54,588 rows); the published one still carries the 65.

## Confirmed, from the deposit's own codebook

`COACH_Code Book_Final_version.xlsx` sheet 2 carries one row per IADL item with its value labels. Transcribed, not inferred from observed maxima:

| item | | range |
|---|---|---|
| q1 | Shopping | 0–3 |
| q2 | Mode of Transportation | 0–4 |
| q3 | Food Preparation | 0–3 |
| q4 | Housekeeping | 0–4 |
| q5 | Laundry | **0–2** |
| q6 | Ability to Use Telephone | 0–3 |
| q7 | Responsibility for Own Medication | 0–3 |
| q8 | Ability to Handle Finances | **0–2** |

Exactly the ranges the issue reports. Replaying the script's IADL path against the deposit removes **65 of 54,653**, matching the issue item for item: q8 35 (3×26, 4×9), q5 19 (3×15, 4×4), q1 5, q3 3, q7 2, q6 1. After the filter every item's observed maximum equals its ceiling at **all three waves**; before, that held only at baseline — which is what settles it as data entry rather than a wrong option mapping, exactly as the issue argued.

`filter(resp != 5)` is replaced. It caught one stray by coincidence: 5 is out of range for every IADL item, but so are 3 and 4 on the two-option items and 12 on q3.

## The loader, without which none of this is reproducible

The script could not run against the file as deposited. The workbook has a **two-row header** — the 15 Charlson comorbidity flags sit under a merged `Comorbidity` band, so their names are on row 2 while `Cohort`/`Group`/`Number`/`Village` are on row 1. `read.xlsx()` reads one header row, so those columns come back as `X6`..`X20` and the `select(-c(...))` on line 12 fails on names that do not exist:

```
Error: Can't subset columns that don't exist. ✖ Column `AIDS` doesn't exist.
```

So this only ever ran against a local copy whose top row had been deleted by hand. The header is now built from both rows (row 2 wins, row 1 fills blanks), which reproduces every name the script goes on to reference.

## Verified output-neutral

Rebuilt all nine tables and compared against the **live Redivis row counts**:

| table | rebuilt | live |
|---|---|---|
| ADL | 95,653 | 95,653 ✓ |
| CSQ | 18,891 | 18,891 ✓ |
| HDRS | 232,006 | 232,006 ✓ |
| MOS_SSS_C | 129,644 | 129,644 ✓ |
| PHQ9 | 122,645 | 122,645 ✓ |
| SNS | 50,272 | 50,272 ✓ |
| treatmentStigma | 13,722 | 13,722 ✓ |
| WHOQOL_BREF | 176,081 | 176,081 ✓ |
| **IADL** | **54,588** | 54,653 → **−65, the intended change** |

Eight of nine reproduce exactly, so the loader repair changes nothing but reachability. Only `IADL` needs re-uploading.

`irw-validate`: no errors. Its warnings are pre-existing table shape (column order, capitalised name, and the genuinely unequal option counts that are correct Lawton IADL).

## Noted, not changed

Line 58 applies `filter(!resp %in% c(6, 7, 11, 12, 21, 22, 32, 33, 55))` **globally**, across all nine instruments, with no comment saying where the list came from. It is doing real work here — it removes the `12` on q3 and the `7` on q4 before the IADL filter ever sees them — but a shared magic list that silently deletes legitimate responses from an unrelated scale is the kind of thing worth its own look. Out of scope for this fix; happy to open an issue.

## Item text

The 65 responses carried no `option_text`, which is what `audit_batch.R` flagged. The item table itself is right and the resp set does not change, so it does not need re-uploading — the audit line just stops firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjpFgj7bT9GJ8UeF5hMLdE