### PR TITLE
debacker_2018_*: drop resp=0, outside the paper's 1-5 scale (#1952)

### DIFF
--- a/data/debacker_2018_coaching_justice.py
+++ b/data/debacker_2018_coaching_justice.py
@@ -16,8 +16,8 @@ OUT_DIR = REPO_ROOT / "automated_finding" / "irw_output"
 # study in elite handball and volleyball teams". S2 File. CC BY 4.0.
 # N=96 athletes, repeated across matches (wave = match_number, up to 11
 # matches per athlete). Two tables: `decisionjustification` (4 items,
-# 0-5) and `justice_appraisal` (12 items: distributive/procedural
-# justice x group/personal referent, 3 items each, 0-5).
+# 1-5) and `justice_appraisal` (12 items: distributive/procedural
+# justice x group/personal referent, 3 items each, 1-5).
 URL = ("https://journals.plos.org/plosone/article/file"
        "?type=supplementary&id=10.1371/journal.pone.0205559.s003")
 UA = {"User-Agent": "IRW-Finder/1.0 (ben.domingue@gmail.com)"}
@@ -34,10 +34,44 @@ def fetch() -> pd.DataFrame:
     return df.rename(columns={"ID": "id", "match_number": "wave"})
 
 
+# The response scale, from the paper: "Items were answered on a 5-point Likert
+# scale ranging from 1 (strongly disagree) to 5 (strongly agree)." Both blocks
+# are the same game-specific questionnaire, so both are 1-5.
+#
+# The deposit nonetheless carries 98 zeros -- 74 across the justice block, 24
+# across decisionjustification -- and 0 is not a point on that scale (#1952).
+# Three things about the .sav say they are re-encoded missing rather than a
+# sixth category the paper failed to describe:
+#
+#   * all 16 item variables DECLARE 99 as their SPSS user-missing value, and
+#     99 never occurs in the file;
+#   * there is not one NaN cell in the whole file. A six-week per-match diary
+#     that no athlete ever left a single item blank is not credible;
+#   * the zeros sit singly inside otherwise-normal response vectors -- 19 of
+#     the 21 rows carrying any zero in the justice block are only partly zero
+#     -- which is a per-item skip, not a person who stopped responding.
+#
+# The earlier reading that 0 marks athletes who did not play (playing_match
+# = 3, "niet spelen") is disproved: rows carrying a zero split 9/4/8 across
+# playing_match, close to the 387/161/113 overall distribution.
+#
+# So 0 is dropped rather than shipped as a response. If it is ever established
+# to mean something, the fix is to map it here rather than to restore it: the
+# one thing that is certain is that it is not a point on a 1-5 scale.
+RESP_MIN, RESP_MAX = 1, 5
+
+
 def _ship(df, out_name, item_cols):
     long = df.melt(id_vars=["id", "wave"], value_vars=item_cols, var_name="item", value_name="resp")
     long["resp"] = pd.to_numeric(long["resp"], errors="coerce")
     long = long.dropna(subset=["resp"]).reset_index(drop=True)
+    out_of_range = ~long["resp"].between(RESP_MIN, RESP_MAX)
+    if out_of_range.any():
+        gone = long.loc[out_of_range, "resp"].value_counts().sort_index()
+        print(f"  {out_name}: dropped {int(out_of_range.sum())} response(s) outside "
+              f"{RESP_MIN}-{RESP_MAX}: "
+              + ", ".join(f"{v:.0f} x{n}" for v, n in gone.items()))
+        long = long.loc[~out_of_range].reset_index(drop=True)
     long = long[["id", "item", "resp", "wave"]]
     long.to_csv(OUT_DIR / f"{out_name}.csv", index=False)
     print(f"{out_name}: rows={len(long)} ids={long['id'].nunique()} "


### PR DESCRIPTION
Proposes a resolution for #1952. **This is the decision the issue asks for, so treat the PR as the question** — declining it is a valid answer and costs nothing but a revert. Corrected tables are staged in `/tmp/here/`.

## What the evidence now says

The issue filed this as *"out-of-range 0 of unknown meaning"* and asked for a ruling between missing-code and undescribed scale point. Two things I could add push it firmly toward missing-code.

**The paper is explicit about the scale.** "Items were answered on a 5-point Likert scale ranging from **1 (strongly disagree) to 5 (strongly agree)**." That is the game-specific questionnaire, which is both blocks.

**The `.sav`'s own metadata contradicts itself in a telling way.** Reading it with `pyreadstat`:

- All 16 item variables **declare 99 as their SPSS user-missing value** — and `99` occurs **zero times** in the file.
- There is **not one `NaN` cell** in the whole file. Every athlete has a value for every item at every match.

A six-week per-match diary study in which no athlete ever skipped a single item is not credible, and a declared missing code that is never used is the signature of missingness having been re-encoded to something else. The 98 zeros are where it went.

That sits on top of the pattern you already established: the zeros are scattered singly inside otherwise-normal response vectors (19 of the 21 zero-carrying rows in the justice block are only partly zero), which is a per-item skip rather than a person who stopped. And your disproof of the `playing_match = 3` reading holds — I re-derived it.

## What it does

`RESP_MIN, RESP_MAX = 1, 5`, applied in `_ship()` for both tables, with the reasoning written into the file so it does not get re-litigated from the data alone.

```
debacker_2018_decisionjustification: dropped 24 response(s) outside 1-5: 0 x24
debacker_2018_decisionjustification: rows=2648 ids=96 items=4 resp=1-5
debacker_2018_justice_appraisal: dropped 74 response(s) outside 1-5: 0 x74
debacker_2018_justice_appraisal: rows=7942 ids=96 items=12 resp=1-5
```

Verified against live Redivis (both in `item_response_warehouse_3`): 2,672 → 2,648 and 8,016 → 7,942, deltas of exactly 24 and 74. No ids lost. `irw-validate` reports no errors; its warnings are pre-existing shape.

## If you'd rather not

The alternative reading is that 0 is a real category the paper failed to describe — in which case the right move is not to restore it silently but to give it an explicit meaning. Either way the current state is the one option that is definitely wrong: shipping an out-of-scale value as though it were a response.

## Item text

Unaffected. `decisionjustification` ships `option_text` blank on every row, which is correct under either reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjpFgj7bT9GJ8UeF5hMLdE