### PR TITLE
ENEM: stop scoring blanks and double marks as wrong answers (#1942)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,14 @@ jobs:
         working-directory: metadata
         run: Rscript tests/test_dict_union.R
 
+      # The ENEM post-scoring checks (#1942). Base R only -- no microdata, no
+      # network -- so the thresholds that decide whether a 45-million-row table
+      # is publishable are exercised on every PR rather than only when someone
+      # has 13 years of INEP files on disk.
+      - name: enem scoring checks
+        working-directory: data
+        run: Rscript tests/test_enem_checks.R
+
   # A PR to data/ contains a conversion SCRIPT, never a table --
   # automated_finding/irw_output/ is gitignored, so no output is ever in the
   # diff. This checks the script's contract; the data is checked by

--- a/data/enem_2013.R
+++ b/data/enem_2013.R
@@ -8,6 +8,25 @@ regular_prova_codes  <- c(167, 170, 171, 174, 176, 177, 178, 180, 181, 182, 189,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# "." and "*" are NON-RESPONSES, not wrong answers (#1942).
+#
+# This script validated the raw codes against ALPHABET and then scored both of
+# them 0, so a candidate who did not sit a section came out with a full block of
+# zeros. In a 3,000-candidate draw from the 2013 and 2014 tables, 44-45% of
+# candidates scored exactly zero with every item present -- on 45 answered
+# five-option items that has probability ~4e-5 each, so the block is coding, not
+# ability. Left in, it inflated SD(theta) to 2.2-2.9 and pinned every item's
+# guessing parameter to the no-guessing boundary.
+#
+# `.` is unambiguously a blank. `*` is a double mark -- a response that could
+# not be read -- which is not evidence of a wrong answer either, so both are
+# treated as missing and the row is dropped. Stated here rather than assumed:
+# if a later analysis wants double marks scored, they are recoverable from the
+# microdata, and this is the line to change.
+NONRESPONSE <- c(".", "*")
+
+source("enem_checks.R")   # post-scoring sanity checks (#1942, finding 3)
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -118,7 +137,10 @@ process_area <- function(area) {
       left_join(items |> select(subj, booklet, position, item, key),
                 by = c("subj","booklet","position"))
   }
-  out <- df |> mutate(resp = if_else(raw == key, 1, 0)) |>
+  out <- df |>
+    mutate(resp = case_when(raw %in% NONRESPONSE ~ NA_real_,
+                            raw == key           ~ 1,
+                            TRUE                 ~ 0)) |>
     filter(item %in% std_set(area)) |>
     select(id, item, resp, resp_raw = raw, position, booklet)
 
@@ -130,6 +152,15 @@ process_area <- function(area) {
                  paste(sprintf("%s(n=%d)", bad, tb[bad]), collapse = " ")))
   cat(sprintf("  %s raw: %s\n", area,
               paste(sprintf("%s=%.4f", names(tb), tb / sum(tb)), collapse = " ")))
+
+  # Dropped only AFTER the raw-code check above, which needs to see them: a
+  # non-response is not a response, and `resp_raw` is not published.
+  n_missing <- sum(is.na(out$resp))
+  cat(sprintf("  %s: dropped %d non-response(s) (%.2f%%) coded %s\n", area,
+              n_missing, 100 * n_missing / nrow(out),
+              paste(NONRESPONSE, collapse = "/")))
+  out <- out[!is.na(out$resp), ]
+  out$resp <- as.integer(out$resp)
   out
 }
 
@@ -138,6 +169,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2014.R
+++ b/data/enem_2014.R
@@ -8,6 +8,25 @@ regular_prova_codes  <- c(195, 198, 199, 202, 204, 205, 206, 208, 209, 210, 217,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# "." and "*" are NON-RESPONSES, not wrong answers (#1942).
+#
+# This script validated the raw codes against ALPHABET and then scored both of
+# them 0, so a candidate who did not sit a section came out with a full block of
+# zeros. In a 3,000-candidate draw from the 2013 and 2014 tables, 44-45% of
+# candidates scored exactly zero with every item present -- on 45 answered
+# five-option items that has probability ~4e-5 each, so the block is coding, not
+# ability. Left in, it inflated SD(theta) to 2.2-2.9 and pinned every item's
+# guessing parameter to the no-guessing boundary.
+#
+# `.` is unambiguously a blank. `*` is a double mark -- a response that could
+# not be read -- which is not evidence of a wrong answer either, so both are
+# treated as missing and the row is dropped. Stated here rather than assumed:
+# if a later analysis wants double marks scored, they are recoverable from the
+# microdata, and this is the line to change.
+NONRESPONSE <- c(".", "*")
+
+source("enem_checks.R")   # post-scoring sanity checks (#1942, finding 3)
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -118,7 +137,10 @@ process_area <- function(area) {
       left_join(items |> select(subj, booklet, position, item, key),
                 by = c("subj","booklet","position"))
   }
-  out <- df |> mutate(resp = if_else(raw == key, 1, 0)) |>
+  out <- df |>
+    mutate(resp = case_when(raw %in% NONRESPONSE ~ NA_real_,
+                            raw == key           ~ 1,
+                            TRUE                 ~ 0)) |>
     filter(item %in% std_set(area)) |>
     select(id, item, resp, resp_raw = raw, position, booklet)
 
@@ -130,6 +152,15 @@ process_area <- function(area) {
                  paste(sprintf("%s(n=%d)", bad, tb[bad]), collapse = " ")))
   cat(sprintf("  %s raw: %s\n", area,
               paste(sprintf("%s=%.4f", names(tb), tb / sum(tb)), collapse = " ")))
+
+  # Dropped only AFTER the raw-code check above, which needs to see them: a
+  # non-response is not a response, and `resp_raw` is not published.
+  n_missing <- sum(is.na(out$resp))
+  cat(sprintf("  %s: dropped %d non-response(s) (%.2f%%) coded %s\n", area,
+              n_missing, 100 * n_missing / nrow(out),
+              paste(NONRESPONSE, collapse = "/")))
+  out <- out[!is.na(out$resp), ]
+  out$resp <- as.integer(out$resp)
   out
 }
 
@@ -138,6 +169,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2015.R
+++ b/data/enem_2015.R
@@ -8,6 +8,25 @@ regular_prova_codes  <- c(231, 234, 235, 238, 240, 241, 242, 244, 245, 246, 253,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# "." and "*" are NON-RESPONSES, not wrong answers (#1942).
+#
+# This script validated the raw codes against ALPHABET and then scored both of
+# them 0, so a candidate who did not sit a section came out with a full block of
+# zeros. In a 3,000-candidate draw from the 2013 and 2014 tables, 44-45% of
+# candidates scored exactly zero with every item present -- on 45 answered
+# five-option items that has probability ~4e-5 each, so the block is coding, not
+# ability. Left in, it inflated SD(theta) to 2.2-2.9 and pinned every item's
+# guessing parameter to the no-guessing boundary.
+#
+# `.` is unambiguously a blank. `*` is a double mark -- a response that could
+# not be read -- which is not evidence of a wrong answer either, so both are
+# treated as missing and the row is dropped. Stated here rather than assumed:
+# if a later analysis wants double marks scored, they are recoverable from the
+# microdata, and this is the line to change.
+NONRESPONSE <- c(".", "*")
+
+source("enem_checks.R")   # post-scoring sanity checks (#1942, finding 3)
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -118,7 +137,10 @@ process_area <- function(area) {
       left_join(items |> select(subj, booklet, position, item, key),
                 by = c("subj","booklet","position"))
   }
-  out <- df |> mutate(resp = if_else(raw == key, 1, 0)) |>
+  out <- df |>
+    mutate(resp = case_when(raw %in% NONRESPONSE ~ NA_real_,
+                            raw == key           ~ 1,
+                            TRUE                 ~ 0)) |>
     filter(item %in% std_set(area)) |>
     select(id, item, resp, resp_raw = raw, position, booklet)
 
@@ -130,6 +152,15 @@ process_area <- function(area) {
                  paste(sprintf("%s(n=%d)", bad, tb[bad]), collapse = " ")))
   cat(sprintf("  %s raw: %s\n", area,
               paste(sprintf("%s=%.4f", names(tb), tb / sum(tb)), collapse = " ")))
+
+  # Dropped only AFTER the raw-code check above, which needs to see them: a
+  # non-response is not a response, and `resp_raw` is not published.
+  n_missing <- sum(is.na(out$resp))
+  cat(sprintf("  %s: dropped %d non-response(s) (%.2f%%) coded %s\n", area,
+              n_missing, 100 * n_missing / nrow(out),
+              paste(NONRESPONSE, collapse = "/")))
+  out <- out[!is.na(out$resp), ]
+  out$resp <- as.integer(out$resp)
   out
 }
 
@@ -138,6 +169,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2016.R
+++ b/data/enem_2016.R
@@ -8,6 +8,25 @@ regular_prova_codes  <- c(291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# "." and "*" are NON-RESPONSES, not wrong answers (#1942).
+#
+# This script validated the raw codes against ALPHABET and then scored both of
+# them 0, so a candidate who did not sit a section came out with a full block of
+# zeros. In a 3,000-candidate draw from the 2013 and 2014 tables, 44-45% of
+# candidates scored exactly zero with every item present -- on 45 answered
+# five-option items that has probability ~4e-5 each, so the block is coding, not
+# ability. Left in, it inflated SD(theta) to 2.2-2.9 and pinned every item's
+# guessing parameter to the no-guessing boundary.
+#
+# `.` is unambiguously a blank. `*` is a double mark -- a response that could
+# not be read -- which is not evidence of a wrong answer either, so both are
+# treated as missing and the row is dropped. Stated here rather than assumed:
+# if a later analysis wants double marks scored, they are recoverable from the
+# microdata, and this is the line to change.
+NONRESPONSE <- c(".", "*")
+
+source("enem_checks.R")   # post-scoring sanity checks (#1942, finding 3)
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -118,7 +137,10 @@ process_area <- function(area) {
       left_join(items |> select(subj, booklet, position, item, key),
                 by = c("subj","booklet","position"))
   }
-  out <- df |> mutate(resp = if_else(raw == key, 1, 0)) |>
+  out <- df |>
+    mutate(resp = case_when(raw %in% NONRESPONSE ~ NA_real_,
+                            raw == key           ~ 1,
+                            TRUE                 ~ 0)) |>
     filter(item %in% std_set(area)) |>
     select(id, item, resp, resp_raw = raw, position, booklet)
 
@@ -130,6 +152,15 @@ process_area <- function(area) {
                  paste(sprintf("%s(n=%d)", bad, tb[bad]), collapse = " ")))
   cat(sprintf("  %s raw: %s\n", area,
               paste(sprintf("%s=%.4f", names(tb), tb / sum(tb)), collapse = " ")))
+
+  # Dropped only AFTER the raw-code check above, which needs to see them: a
+  # non-response is not a response, and `resp_raw` is not published.
+  n_missing <- sum(is.na(out$resp))
+  cat(sprintf("  %s: dropped %d non-response(s) (%.2f%%) coded %s\n", area,
+              n_missing, 100 * n_missing / nrow(out),
+              paste(NONRESPONSE, collapse = "/")))
+  out <- out[!is.na(out$resp), ]
+  out$resp <- as.integer(out$resp)
   out
 }
 
@@ -138,6 +169,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2017.R
+++ b/data/enem_2017.R
@@ -8,6 +8,25 @@ regular_prova_codes  <- c(391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# "." and "*" are NON-RESPONSES, not wrong answers (#1942).
+#
+# This script validated the raw codes against ALPHABET and then scored both of
+# them 0, so a candidate who did not sit a section came out with a full block of
+# zeros. In a 3,000-candidate draw from the 2013 and 2014 tables, 44-45% of
+# candidates scored exactly zero with every item present -- on 45 answered
+# five-option items that has probability ~4e-5 each, so the block is coding, not
+# ability. Left in, it inflated SD(theta) to 2.2-2.9 and pinned every item's
+# guessing parameter to the no-guessing boundary.
+#
+# `.` is unambiguously a blank. `*` is a double mark -- a response that could
+# not be read -- which is not evidence of a wrong answer either, so both are
+# treated as missing and the row is dropped. Stated here rather than assumed:
+# if a later analysis wants double marks scored, they are recoverable from the
+# microdata, and this is the line to change.
+NONRESPONSE <- c(".", "*")
+
+source("enem_checks.R")   # post-scoring sanity checks (#1942, finding 3)
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -118,7 +137,10 @@ process_area <- function(area) {
       left_join(items |> select(subj, booklet, position, item, key),
                 by = c("subj","booklet","position"))
   }
-  out <- df |> mutate(resp = if_else(raw == key, 1, 0)) |>
+  out <- df |>
+    mutate(resp = case_when(raw %in% NONRESPONSE ~ NA_real_,
+                            raw == key           ~ 1,
+                            TRUE                 ~ 0)) |>
     filter(item %in% std_set(area)) |>
     select(id, item, resp, resp_raw = raw, position, booklet)
 
@@ -130,6 +152,15 @@ process_area <- function(area) {
                  paste(sprintf("%s(n=%d)", bad, tb[bad]), collapse = " ")))
   cat(sprintf("  %s raw: %s\n", area,
               paste(sprintf("%s=%.4f", names(tb), tb / sum(tb)), collapse = " ")))
+
+  # Dropped only AFTER the raw-code check above, which needs to see them: a
+  # non-response is not a response, and `resp_raw` is not published.
+  n_missing <- sum(is.na(out$resp))
+  cat(sprintf("  %s: dropped %d non-response(s) (%.2f%%) coded %s\n", area,
+              n_missing, 100 * n_missing / nrow(out),
+              paste(NONRESPONSE, collapse = "/")))
+  out <- out[!is.na(out$resp), ]
+  out$resp <- as.integer(out$resp)
   out
 }
 
@@ -138,6 +169,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2018.R
+++ b/data/enem_2018.R
@@ -8,6 +8,25 @@ regular_prova_codes  <- c(447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# "." and "*" are NON-RESPONSES, not wrong answers (#1942).
+#
+# This script validated the raw codes against ALPHABET and then scored both of
+# them 0, so a candidate who did not sit a section came out with a full block of
+# zeros. In a 3,000-candidate draw from the 2013 and 2014 tables, 44-45% of
+# candidates scored exactly zero with every item present -- on 45 answered
+# five-option items that has probability ~4e-5 each, so the block is coding, not
+# ability. Left in, it inflated SD(theta) to 2.2-2.9 and pinned every item's
+# guessing parameter to the no-guessing boundary.
+#
+# `.` is unambiguously a blank. `*` is a double mark -- a response that could
+# not be read -- which is not evidence of a wrong answer either, so both are
+# treated as missing and the row is dropped. Stated here rather than assumed:
+# if a later analysis wants double marks scored, they are recoverable from the
+# microdata, and this is the line to change.
+NONRESPONSE <- c(".", "*")
+
+source("enem_checks.R")   # post-scoring sanity checks (#1942, finding 3)
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -118,7 +137,10 @@ process_area <- function(area) {
       left_join(items |> select(subj, booklet, position, item, key),
                 by = c("subj","booklet","position"))
   }
-  out <- df |> mutate(resp = if_else(raw == key, 1, 0)) |>
+  out <- df |>
+    mutate(resp = case_when(raw %in% NONRESPONSE ~ NA_real_,
+                            raw == key           ~ 1,
+                            TRUE                 ~ 0)) |>
     filter(item %in% std_set(area)) |>
     select(id, item, resp, resp_raw = raw, position, booklet)
 
@@ -130,6 +152,15 @@ process_area <- function(area) {
                  paste(sprintf("%s(n=%d)", bad, tb[bad]), collapse = " ")))
   cat(sprintf("  %s raw: %s\n", area,
               paste(sprintf("%s=%.4f", names(tb), tb / sum(tb)), collapse = " ")))
+
+  # Dropped only AFTER the raw-code check above, which needs to see them: a
+  # non-response is not a response, and `resp_raw` is not published.
+  n_missing <- sum(is.na(out$resp))
+  cat(sprintf("  %s: dropped %d non-response(s) (%.2f%%) coded %s\n", area,
+              n_missing, 100 * n_missing / nrow(out),
+              paste(NONRESPONSE, collapse = "/")))
+  out <- out[!is.na(out$resp), ]
+  out$resp <- as.integer(out$resp)
   out
 }
 
@@ -138,6 +169,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2019.R
+++ b/data/enem_2019.R
@@ -8,6 +8,25 @@ regular_prova_codes  <- c(503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# "." and "*" are NON-RESPONSES, not wrong answers (#1942).
+#
+# This script validated the raw codes against ALPHABET and then scored both of
+# them 0, so a candidate who did not sit a section came out with a full block of
+# zeros. In a 3,000-candidate draw from the 2013 and 2014 tables, 44-45% of
+# candidates scored exactly zero with every item present -- on 45 answered
+# five-option items that has probability ~4e-5 each, so the block is coding, not
+# ability. Left in, it inflated SD(theta) to 2.2-2.9 and pinned every item's
+# guessing parameter to the no-guessing boundary.
+#
+# `.` is unambiguously a blank. `*` is a double mark -- a response that could
+# not be read -- which is not evidence of a wrong answer either, so both are
+# treated as missing and the row is dropped. Stated here rather than assumed:
+# if a later analysis wants double marks scored, they are recoverable from the
+# microdata, and this is the line to change.
+NONRESPONSE <- c(".", "*")
+
+source("enem_checks.R")   # post-scoring sanity checks (#1942, finding 3)
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -118,7 +137,10 @@ process_area <- function(area) {
       left_join(items |> select(subj, booklet, position, item, key),
                 by = c("subj","booklet","position"))
   }
-  out <- df |> mutate(resp = if_else(raw == key, 1, 0)) |>
+  out <- df |>
+    mutate(resp = case_when(raw %in% NONRESPONSE ~ NA_real_,
+                            raw == key           ~ 1,
+                            TRUE                 ~ 0)) |>
     filter(item %in% std_set(area)) |>
     select(id, item, resp, resp_raw = raw, position, booklet)
 
@@ -130,6 +152,15 @@ process_area <- function(area) {
                  paste(sprintf("%s(n=%d)", bad, tb[bad]), collapse = " ")))
   cat(sprintf("  %s raw: %s\n", area,
               paste(sprintf("%s=%.4f", names(tb), tb / sum(tb)), collapse = " ")))
+
+  # Dropped only AFTER the raw-code check above, which needs to see them: a
+  # non-response is not a response, and `resp_raw` is not published.
+  n_missing <- sum(is.na(out$resp))
+  cat(sprintf("  %s: dropped %d non-response(s) (%.2f%%) coded %s\n", area,
+              n_missing, 100 * n_missing / nrow(out),
+              paste(NONRESPONSE, collapse = "/")))
+  out <- out[!is.na(out$resp), ]
+  out$resp <- as.integer(out$resp)
   out
 }
 
@@ -138,6 +169,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2020.R
+++ b/data/enem_2020.R
@@ -8,6 +8,25 @@ regular_prova_codes  <- c(567, 568, 569, 570, 571, 572, 574, 575, 577, 578, 579,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# "." and "*" are NON-RESPONSES, not wrong answers (#1942).
+#
+# This script validated the raw codes against ALPHABET and then scored both of
+# them 0, so a candidate who did not sit a section came out with a full block of
+# zeros. In a 3,000-candidate draw from the 2013 and 2014 tables, 44-45% of
+# candidates scored exactly zero with every item present -- on 45 answered
+# five-option items that has probability ~4e-5 each, so the block is coding, not
+# ability. Left in, it inflated SD(theta) to 2.2-2.9 and pinned every item's
+# guessing parameter to the no-guessing boundary.
+#
+# `.` is unambiguously a blank. `*` is a double mark -- a response that could
+# not be read -- which is not evidence of a wrong answer either, so both are
+# treated as missing and the row is dropped. Stated here rather than assumed:
+# if a later analysis wants double marks scored, they are recoverable from the
+# microdata, and this is the line to change.
+NONRESPONSE <- c(".", "*")
+
+source("enem_checks.R")   # post-scoring sanity checks (#1942, finding 3)
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -118,7 +137,10 @@ process_area <- function(area) {
       left_join(items |> select(subj, booklet, position, item, key),
                 by = c("subj","booklet","position"))
   }
-  out <- df |> mutate(resp = if_else(raw == key, 1, 0)) |>
+  out <- df |>
+    mutate(resp = case_when(raw %in% NONRESPONSE ~ NA_real_,
+                            raw == key           ~ 1,
+                            TRUE                 ~ 0)) |>
     filter(item %in% std_set(area)) |>
     select(id, item, resp, resp_raw = raw, position, booklet)
 
@@ -130,6 +152,15 @@ process_area <- function(area) {
                  paste(sprintf("%s(n=%d)", bad, tb[bad]), collapse = " ")))
   cat(sprintf("  %s raw: %s\n", area,
               paste(sprintf("%s=%.4f", names(tb), tb / sum(tb)), collapse = " ")))
+
+  # Dropped only AFTER the raw-code check above, which needs to see them: a
+  # non-response is not a response, and `resp_raw` is not published.
+  n_missing <- sum(is.na(out$resp))
+  cat(sprintf("  %s: dropped %d non-response(s) (%.2f%%) coded %s\n", area,
+              n_missing, 100 * n_missing / nrow(out),
+              paste(NONRESPONSE, collapse = "/")))
+  out <- out[!is.na(out$resp), ]
+  out$resp <- as.integer(out$resp)
   out
 }
 
@@ -138,6 +169,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2021.R
+++ b/data/enem_2021.R
@@ -8,6 +8,25 @@ regular_prova_codes  <- c(879, 880, 881, 882, 885, 886, 887, 889, 890, 891, 892,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# "." and "*" are NON-RESPONSES, not wrong answers (#1942).
+#
+# This script validated the raw codes against ALPHABET and then scored both of
+# them 0, so a candidate who did not sit a section came out with a full block of
+# zeros. In a 3,000-candidate draw from the 2013 and 2014 tables, 44-45% of
+# candidates scored exactly zero with every item present -- on 45 answered
+# five-option items that has probability ~4e-5 each, so the block is coding, not
+# ability. Left in, it inflated SD(theta) to 2.2-2.9 and pinned every item's
+# guessing parameter to the no-guessing boundary.
+#
+# `.` is unambiguously a blank. `*` is a double mark -- a response that could
+# not be read -- which is not evidence of a wrong answer either, so both are
+# treated as missing and the row is dropped. Stated here rather than assumed:
+# if a later analysis wants double marks scored, they are recoverable from the
+# microdata, and this is the line to change.
+NONRESPONSE <- c(".", "*")
+
+source("enem_checks.R")   # post-scoring sanity checks (#1942, finding 3)
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -118,7 +137,10 @@ process_area <- function(area) {
       left_join(items |> select(subj, booklet, position, item, key),
                 by = c("subj","booklet","position"))
   }
-  out <- df |> mutate(resp = if_else(raw == key, 1, 0)) |>
+  out <- df |>
+    mutate(resp = case_when(raw %in% NONRESPONSE ~ NA_real_,
+                            raw == key           ~ 1,
+                            TRUE                 ~ 0)) |>
     filter(item %in% std_set(area)) |>
     select(id, item, resp, resp_raw = raw, position, booklet)
 
@@ -130,6 +152,15 @@ process_area <- function(area) {
                  paste(sprintf("%s(n=%d)", bad, tb[bad]), collapse = " ")))
   cat(sprintf("  %s raw: %s\n", area,
               paste(sprintf("%s=%.4f", names(tb), tb / sum(tb)), collapse = " ")))
+
+  # Dropped only AFTER the raw-code check above, which needs to see them: a
+  # non-response is not a response, and `resp_raw` is not published.
+  n_missing <- sum(is.na(out$resp))
+  cat(sprintf("  %s: dropped %d non-response(s) (%.2f%%) coded %s\n", area,
+              n_missing, 100 * n_missing / nrow(out),
+              paste(NONRESPONSE, collapse = "/")))
+  out <- out[!is.na(out$resp), ]
+  out$resp <- as.integer(out$resp)
   out
 }
 
@@ -138,6 +169,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2022.R
+++ b/data/enem_2022.R
@@ -8,6 +8,25 @@ regular_prova_codes  <- c(1055, 1056, 1057, 1058, 1062, 1063, 1065, 1066, 1067, 
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# "." and "*" are NON-RESPONSES, not wrong answers (#1942).
+#
+# This script validated the raw codes against ALPHABET and then scored both of
+# them 0, so a candidate who did not sit a section came out with a full block of
+# zeros. In a 3,000-candidate draw from the 2013 and 2014 tables, 44-45% of
+# candidates scored exactly zero with every item present -- on 45 answered
+# five-option items that has probability ~4e-5 each, so the block is coding, not
+# ability. Left in, it inflated SD(theta) to 2.2-2.9 and pinned every item's
+# guessing parameter to the no-guessing boundary.
+#
+# `.` is unambiguously a blank. `*` is a double mark -- a response that could
+# not be read -- which is not evidence of a wrong answer either, so both are
+# treated as missing and the row is dropped. Stated here rather than assumed:
+# if a later analysis wants double marks scored, they are recoverable from the
+# microdata, and this is the line to change.
+NONRESPONSE <- c(".", "*")
+
+source("enem_checks.R")   # post-scoring sanity checks (#1942, finding 3)
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -118,7 +137,10 @@ process_area <- function(area) {
       left_join(items |> select(subj, booklet, position, item, key),
                 by = c("subj","booklet","position"))
   }
-  out <- df |> mutate(resp = if_else(raw == key, 1, 0)) |>
+  out <- df |>
+    mutate(resp = case_when(raw %in% NONRESPONSE ~ NA_real_,
+                            raw == key           ~ 1,
+                            TRUE                 ~ 0)) |>
     filter(item %in% std_set(area)) |>
     select(id, item, resp, resp_raw = raw, position, booklet)
 
@@ -130,6 +152,15 @@ process_area <- function(area) {
                  paste(sprintf("%s(n=%d)", bad, tb[bad]), collapse = " ")))
   cat(sprintf("  %s raw: %s\n", area,
               paste(sprintf("%s=%.4f", names(tb), tb / sum(tb)), collapse = " ")))
+
+  # Dropped only AFTER the raw-code check above, which needs to see them: a
+  # non-response is not a response, and `resp_raw` is not published.
+  n_missing <- sum(is.na(out$resp))
+  cat(sprintf("  %s: dropped %d non-response(s) (%.2f%%) coded %s\n", area,
+              n_missing, 100 * n_missing / nrow(out),
+              paste(NONRESPONSE, collapse = "/")))
+  out <- out[!is.na(out$resp), ]
+  out$resp <- as.integer(out$resp)
   out
 }
 
@@ -138,6 +169,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2023.R
+++ b/data/enem_2023.R
@@ -8,6 +8,25 @@ regular_prova_codes  <- c(1191, 1192, 1193, 1194, 1195, 1196, 1197, 1198, 1199, 
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# "." and "*" are NON-RESPONSES, not wrong answers (#1942).
+#
+# This script validated the raw codes against ALPHABET and then scored both of
+# them 0, so a candidate who did not sit a section came out with a full block of
+# zeros. In a 3,000-candidate draw from the 2013 and 2014 tables, 44-45% of
+# candidates scored exactly zero with every item present -- on 45 answered
+# five-option items that has probability ~4e-5 each, so the block is coding, not
+# ability. Left in, it inflated SD(theta) to 2.2-2.9 and pinned every item's
+# guessing parameter to the no-guessing boundary.
+#
+# `.` is unambiguously a blank. `*` is a double mark -- a response that could
+# not be read -- which is not evidence of a wrong answer either, so both are
+# treated as missing and the row is dropped. Stated here rather than assumed:
+# if a later analysis wants double marks scored, they are recoverable from the
+# microdata, and this is the line to change.
+NONRESPONSE <- c(".", "*")
+
+source("enem_checks.R")   # post-scoring sanity checks (#1942, finding 3)
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -118,7 +137,10 @@ process_area <- function(area) {
       left_join(items |> select(subj, booklet, position, item, key),
                 by = c("subj","booklet","position"))
   }
-  out <- df |> mutate(resp = if_else(raw == key, 1, 0)) |>
+  out <- df |>
+    mutate(resp = case_when(raw %in% NONRESPONSE ~ NA_real_,
+                            raw == key           ~ 1,
+                            TRUE                 ~ 0)) |>
     filter(item %in% std_set(area)) |>
     select(id, item, resp, resp_raw = raw, position, booklet)
 
@@ -130,6 +152,15 @@ process_area <- function(area) {
                  paste(sprintf("%s(n=%d)", bad, tb[bad]), collapse = " ")))
   cat(sprintf("  %s raw: %s\n", area,
               paste(sprintf("%s=%.4f", names(tb), tb / sum(tb)), collapse = " ")))
+
+  # Dropped only AFTER the raw-code check above, which needs to see them: a
+  # non-response is not a response, and `resp_raw` is not published.
+  n_missing <- sum(is.na(out$resp))
+  cat(sprintf("  %s: dropped %d non-response(s) (%.2f%%) coded %s\n", area,
+              n_missing, 100 * n_missing / nrow(out),
+              paste(NONRESPONSE, collapse = "/")))
+  out <- out[!is.na(out$resp), ]
+  out$resp <- as.integer(out$resp)
   out
 }
 
@@ -138,6 +169,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2024.R
+++ b/data/enem_2024.R
@@ -8,6 +8,25 @@ regular_prova_codes  <- c(1383, 1384, 1385, 1386, 1387, 1388, 1390, 1395, 1396, 
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# "." and "*" are NON-RESPONSES, not wrong answers (#1942).
+#
+# This script validated the raw codes against ALPHABET and then scored both of
+# them 0, so a candidate who did not sit a section came out with a full block of
+# zeros. In a 3,000-candidate draw from the 2013 and 2014 tables, 44-45% of
+# candidates scored exactly zero with every item present -- on 45 answered
+# five-option items that has probability ~4e-5 each, so the block is coding, not
+# ability. Left in, it inflated SD(theta) to 2.2-2.9 and pinned every item's
+# guessing parameter to the no-guessing boundary.
+#
+# `.` is unambiguously a blank. `*` is a double mark -- a response that could
+# not be read -- which is not evidence of a wrong answer either, so both are
+# treated as missing and the row is dropped. Stated here rather than assumed:
+# if a later analysis wants double marks scored, they are recoverable from the
+# microdata, and this is the line to change.
+NONRESPONSE <- c(".", "*")
+
+source("enem_checks.R")   # post-scoring sanity checks (#1942, finding 3)
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -118,7 +137,10 @@ process_area <- function(area) {
       left_join(items |> select(subj, booklet, position, item, key),
                 by = c("subj","booklet","position"))
   }
-  out <- df |> mutate(resp = if_else(raw == key, 1, 0)) |>
+  out <- df |>
+    mutate(resp = case_when(raw %in% NONRESPONSE ~ NA_real_,
+                            raw == key           ~ 1,
+                            TRUE                 ~ 0)) |>
     filter(item %in% std_set(area)) |>
     select(id, item, resp, resp_raw = raw, position, booklet)
 
@@ -130,6 +152,15 @@ process_area <- function(area) {
                  paste(sprintf("%s(n=%d)", bad, tb[bad]), collapse = " ")))
   cat(sprintf("  %s raw: %s\n", area,
               paste(sprintf("%s=%.4f", names(tb), tb / sum(tb)), collapse = " ")))
+
+  # Dropped only AFTER the raw-code check above, which needs to see them: a
+  # non-response is not a response, and `resp_raw` is not published.
+  n_missing <- sum(is.na(out$resp))
+  cat(sprintf("  %s: dropped %d non-response(s) (%.2f%%) coded %s\n", area,
+              n_missing, 100 * n_missing / nrow(out),
+              paste(NONRESPONSE, collapse = "/")))
+  out <- out[!is.na(out$resp), ]
+  out$resp <- as.integer(out$resp)
   out
 }
 
@@ -138,6 +169,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2025.R
+++ b/data/enem_2025.R
@@ -8,6 +8,25 @@ regular_prova_codes  <- c(1447, 1448, 1449, 1450, 1451, 1452, 1454, 1459, 1460, 
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# "." and "*" are NON-RESPONSES, not wrong answers (#1942).
+#
+# This script validated the raw codes against ALPHABET and then scored both of
+# them 0, so a candidate who did not sit a section came out with a full block of
+# zeros. In a 3,000-candidate draw from the 2013 and 2014 tables, 44-45% of
+# candidates scored exactly zero with every item present -- on 45 answered
+# five-option items that has probability ~4e-5 each, so the block is coding, not
+# ability. Left in, it inflated SD(theta) to 2.2-2.9 and pinned every item's
+# guessing parameter to the no-guessing boundary.
+#
+# `.` is unambiguously a blank. `*` is a double mark -- a response that could
+# not be read -- which is not evidence of a wrong answer either, so both are
+# treated as missing and the row is dropped. Stated here rather than assumed:
+# if a later analysis wants double marks scored, they are recoverable from the
+# microdata, and this is the line to change.
+NONRESPONSE <- c(".", "*")
+
+source("enem_checks.R")   # post-scoring sanity checks (#1942, finding 3)
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -118,7 +137,10 @@ process_area <- function(area) {
       left_join(items |> select(subj, booklet, position, item, key),
                 by = c("subj","booklet","position"))
   }
-  out <- df |> mutate(resp = if_else(raw == key, 1, 0)) |>
+  out <- df |>
+    mutate(resp = case_when(raw %in% NONRESPONSE ~ NA_real_,
+                            raw == key           ~ 1,
+                            TRUE                 ~ 0)) |>
     filter(item %in% std_set(area)) |>
     select(id, item, resp, resp_raw = raw, position, booklet)
 
@@ -130,6 +152,15 @@ process_area <- function(area) {
                  paste(sprintf("%s(n=%d)", bad, tb[bad]), collapse = " ")))
   cat(sprintf("  %s raw: %s\n", area,
               paste(sprintf("%s=%.4f", names(tb), tb / sum(tb)), collapse = " ")))
+
+  # Dropped only AFTER the raw-code check above, which needs to see them: a
+  # non-response is not a response, and `resp_raw` is not published.
+  n_missing <- sum(is.na(out$resp))
+  cat(sprintf("  %s: dropped %d non-response(s) (%.2f%%) coded %s\n", area,
+              n_missing, 100 * n_missing / nrow(out),
+              paste(NONRESPONSE, collapse = "/")))
+  out <- out[!is.na(out$resp), ]
+  out$resp <- as.integer(out$resp)
   out
 }
 
@@ -138,6 +169,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_checks.R
+++ b/data/enem_checks.R
@@ -1,0 +1,132 @@
+## Post-scoring sanity checks for the ENEM ingest (#1942, finding 3).
+##
+## Everything the year scripts guarded before this file was a guard on the
+## INPUTS and the JOINS: off-length response strings, raw codes outside the
+## expected alphabet, `9` padding surviving the language mapping, duplicate
+## id+item rows after the booklet/position join. Both defects #1942 reports get
+## past all of them, because both produce structurally valid output that is
+## psychometrically impossible:
+##
+##   * blanks and double marks scored as wrong answers -- 45% of candidates in
+##     the 2013/2014 tables score exactly zero on 45 answered five-option
+##     items, which has probability ~4e-5 each;
+##   * enem_2019_1mil_lc, where five items are scored 0 for all 1,504
+##     candidates who answered them and 73% of items correlate below .05 with
+##     the rest of the form.
+##
+## Both are one-line summaries of the SCORED output. This file computes them.
+##
+## Sourced by each enem_<year>.R. Self-tested offline against synthetic data:
+##
+##     Rscript tests/test_enem_checks.R
+
+## ENEM is five-option multiple choice throughout, so a candidate who knows
+## nothing still scores 1/5 by guessing. Everything below is calibrated to that.
+ENEM_N_OPTIONS <- 5
+ENEM_CHANCE    <- 1 / ENEM_N_OPTIONS
+
+## Thresholds. Deliberately far from the healthy tables rather than tight: the
+## point is to catch a form that is mis-keyed, not to police difficulty. Across
+## the ten healthy tables measured in #1942 the median item-rest correlation
+## runs .09-.49 and no table has more than 27% of items below .05.
+ENEM_MAX_SHARE_BELOW_CHANCE <- 0.50   # items with p < 1/5
+ENEM_MIN_MEDIAN_ITEM_REST   <- 0.05
+ENEM_MAX_SHARE_LOW_ITEM_REST<- 0.60
+ENEM_MAX_SHARE_ALL_WRONG    <- 0.05   # candidates at exactly zero, all answered
+
+## Item-rest correlations on 45,000,000 rows are not free. A sample of
+## candidates is enough for a statistic used as a floor, and the seed makes the
+## build reproducible.
+ENEM_CHECK_SAMPLE_IDS <- 5000
+ENEM_CHECK_SEED       <- 1942
+
+## Returns a named list of statistics; `enem_check_scored()` decides what to do
+## about them. Split so the thresholds can be tested without a build.
+enem_scored_stats <- function(df, sample_ids = ENEM_CHECK_SAMPLE_IDS,
+                              seed = ENEM_CHECK_SEED) {
+  stopifnot(all(c("id", "item", "resp") %in% names(df)))
+  scored <- df[!is.na(df$resp), c("id", "item", "resp")]
+  if (nrow(scored) == 0) stop("no scored responses")
+
+  p <- tapply(scored$resp, scored$item, mean)
+  n <- tapply(scored$resp, scored$item, length)
+
+  ids <- unique(scored$id)
+  if (length(ids) > sample_ids) {
+    set.seed(seed)
+    ids <- sample(ids, sample_ids)
+  }
+  s <- scored[scored$id %in% ids, ]
+  w <- tapply(s$resp, list(as.character(s$id), as.character(s$item)), sum)
+
+  ## Item-rest: correlate each item with the total of the OTHER items, so a
+  ## mis-keyed item cannot prop up its own correlation.
+  tot <- rowSums(w, na.rm = TRUE)
+  rest <- vapply(colnames(w), function(j) {
+    x <- w[, j]
+    ok <- !is.na(x)
+    r <- tot[ok] - x[ok]
+    if (length(unique(x[ok])) < 2 || length(unique(r)) < 2) return(NA_real_)
+    stats::cor(x[ok], r)
+  }, numeric(1))
+
+  ## "All wrong" counts only candidates with NO missing item on the form --
+  ## a candidate who answered three items and got them wrong is not evidence.
+  answered <- rowSums(!is.na(w))
+  complete <- answered == ncol(w)
+  all_wrong <- if (any(complete)) mean(tot[complete] == 0) else 0
+
+  list(n_items          = length(p),
+       median_p         = stats::median(p),
+       share_below_chance = mean(p < ENEM_CHANCE),
+       zero_variance    = names(p)[p == 0 | p == 1],
+       median_item_rest = stats::median(rest, na.rm = TRUE),
+       share_low_item_rest = mean(rest < ENEM_MIN_MEDIAN_ITEM_REST, na.rm = TRUE),
+       share_all_wrong  = all_wrong,
+       n_complete       = sum(complete),
+       min_n_per_item   = min(n))
+}
+
+## `label` is used in every message so a failing build says which table.
+## Stops on the two conditions that cannot be produced by difficulty; warns on
+## the rest, because a warning that fires on a legitimately hard form is worse
+## than useless.
+enem_check_scored <- function(df, label, stats = NULL) {
+  st <- if (is.null(stats)) enem_scored_stats(df) else stats
+  cat(sprintf("  %s scored: %d items, median p=%.3f, %.0f%% below chance, ",
+              label, st$n_items, st$median_p, 100 * st$share_below_chance))
+  cat(sprintf("median item-rest=%.3f, %.1f%% of candidates all-wrong\n",
+              st$median_item_rest, 100 * st$share_all_wrong))
+
+  if (length(st$zero_variance) > 0) {
+    stop(sprintf("%s: %d item(s) scored identically for every candidate (%s). ",
+                 label, length(st$zero_variance),
+                 paste(utils::head(st$zero_variance, 8), collapse = ", ")),
+         "An item nobody gets right is a keying failure, not a hard item.")
+  }
+  if (!is.na(st$median_item_rest) &&
+      st$median_item_rest < ENEM_MIN_MEDIAN_ITEM_REST &&
+      st$share_low_item_rest > ENEM_MAX_SHARE_LOW_ITEM_REST) {
+    stop(sprintf(paste0("%s: median item-rest correlation %.3f with %.0f%% of ",
+                        "items below %.2f. A correctly keyed item correlates ",
+                        "positively with the rest of the form regardless of ",
+                        "difficulty."),
+                 label, st$median_item_rest, 100 * st$share_low_item_rest,
+                 ENEM_MIN_MEDIAN_ITEM_REST))
+  }
+  if (st$share_below_chance > ENEM_MAX_SHARE_BELOW_CHANCE) {
+    warning(sprintf("%s: %.0f%% of items sit below the 1/%d chance floor.",
+                    label, 100 * st$share_below_chance, ENEM_N_OPTIONS),
+            call. = FALSE)
+  }
+  if (st$share_all_wrong > ENEM_MAX_SHARE_ALL_WRONG) {
+    warning(sprintf(paste0("%s: %.1f%% of candidates who answered every item ",
+                           "scored exactly zero. On %d five-option items that ",
+                           "has probability ~%.0e each -- suspect non-responses ",
+                           "being scored as wrong (#1942)."),
+                    label, 100 * st$share_all_wrong, st$n_items,
+                    (1 - ENEM_CHANCE)^st$n_items),
+            call. = FALSE)
+  }
+  invisible(st)
+}

--- a/data/tests/test_enem_checks.R
+++ b/data/tests/test_enem_checks.R
@@ -1,0 +1,133 @@
+## Tests for data/enem_checks.R (#1942, finding 3).
+##
+## Offline and deterministic: the checks touch no INEP microdata, so the
+## thresholds are exercised on synthetic forms built to look like the two
+## defects the issue reports and like a healthy table. Run from `data/`:
+##
+##     Rscript tests/test_enem_checks.R
+
+source("enem_checks.R")
+
+failures <- 0L
+ok    <- function(what) cat("  ok   -", what, "\n")
+check <- function(cond, what) {
+  if (isTRUE(cond)) ok(what)
+  else { cat("  FAIL -", what, "\n"); failures <<- failures + 1L }
+}
+expect_stop <- function(expr, pattern, what) {
+  e <- tryCatch({ suppressWarnings(force(expr)); NULL }, error = conditionMessage)
+  if (is.null(e)) { cat("  FAIL -", what, "(no error)\n"); failures <<- failures + 1L }
+  else check(grepl(pattern, e, fixed = TRUE), what)
+}
+expect_warn <- function(expr, pattern, what) {
+  w <- character(0)
+  withCallingHandlers(suppressMessages(capture.output(force(expr))),
+                      warning = function(x) { w <<- c(w, conditionMessage(x));
+                                              invokeRestart("muffleWarning") })
+  check(any(grepl(pattern, w, fixed = TRUE)), what)
+}
+quiet <- function(expr) suppressWarnings(capture.output(force(expr)))
+
+## ------------------------------------------------------------- fixtures ---
+## A healthy five-option form: one latent ability, items of varying difficulty,
+## and a chance floor -- what every ENEM table should look like.
+make_form <- function(n_ids = 400, n_items = 45, seed = 1) {
+  set.seed(seed)
+  theta <- stats::rnorm(n_ids)
+  b     <- seq(-1.5, 1.5, length.out = n_items)
+  g     <- 1 / 5
+  out <- expand.grid(id = seq_len(n_ids), item = seq_len(n_items))
+  pr   <- g + (1 - g) * stats::plogis(theta[out$id] - b[out$item])
+  out$resp <- stats::rbinom(nrow(out), 1, pr)
+  out
+}
+
+healthy <- make_form()
+
+cat("a healthy form passes\n")
+local({
+  st <- enem_scored_stats(healthy)
+  check(st$median_p > ENEM_CHANCE, "median p is above the chance floor")
+  check(st$median_item_rest > ENEM_MIN_MEDIAN_ITEM_REST,
+        "median item-rest clears the floor")
+  check(st$share_all_wrong <= ENEM_MAX_SHARE_ALL_WRONG,
+        "almost nobody scores exactly zero")
+  quiet(enem_check_scored(healthy, "healthy"))
+  ok("enem_check_scored() does not stop on it")
+})
+
+cat("finding 1 -- non-responses scored as wrong answers\n")
+local({
+  ## 40% of candidates sat the form but left it blank; scoring blanks as 0
+  ## puts them at exactly zero with every item present.
+  d <- healthy
+  absent <- 1:160
+  d$resp[d$id %in% absent] <- 0
+  st <- enem_scored_stats(d)
+  check(st$share_all_wrong > 0.3,
+        "the all-wrong share detects the block (this is the 45% in the issue)")
+  expect_warn(enem_check_scored(d, "blank-scored"),
+              "scored exactly zero",
+              "and enem_check_scored() warns, naming #1942")
+})
+
+local({
+  ## Once the blanks are NA rather than 0, the same candidates are simply
+  ## absent from the form and the statistic returns to normal.
+  d <- healthy
+  d$resp[d$id %in% 1:160] <- NA
+  st <- enem_scored_stats(d)
+  check(st$share_all_wrong <= ENEM_MAX_SHARE_ALL_WRONG,
+        "dropping them clears it -- the check tracks the fix, not the sample")
+})
+
+cat("finding 2 -- a mis-keyed form\n")
+local({
+  ## enem_2019_1mil_lc: five items scored 0 for everyone who answered them.
+  d <- healthy
+  d$resp[d$item %in% 1:5] <- 0
+  expect_stop(enem_check_scored(d, "dead-items"),
+              "scored identically for every candidate",
+              "an item nobody gets right stops the build")
+})
+
+local({
+  ## The wider defect: responses joined to the wrong keys, so scoring is
+  ## near-random and item-rest correlations collapse toward zero.
+  set.seed(9)
+  d <- healthy
+  d$resp <- stats::rbinom(nrow(d), 1, 0.16)   # median p .16, as observed
+  expect_stop(enem_check_scored(d, "mis-keyed"),
+              "median item-rest correlation",
+              "a form with no item-total structure stops the build")
+})
+
+local({
+  ## The check must not fire on a merely HARD form. Same latent structure,
+  ## every item shifted well above the sample's ability.
+  d <- make_form(seed = 3)
+  set.seed(4)
+  theta <- stats::rnorm(400); b <- seq(1.5, 4.0, length.out = 45)
+  pr <- 1/5 + (1 - 1/5) * stats::plogis(theta[d$id] - b[d$item])
+  d$resp <- stats::rbinom(nrow(d), 1, pr)
+  st <- enem_scored_stats(d)
+  check(st$median_p < 0.35, "the fixture really is a hard form")
+  check(st$median_item_rest > ENEM_MIN_MEDIAN_ITEM_REST,
+        "a hard form still has item-total structure")
+  quiet(enem_check_scored(d, "hard"))
+  ok("and is not stopped -- difficulty alone never fails the build")
+})
+
+cat("shape\n")
+local({
+  d <- healthy
+  set.seed(11)
+  d$resp[sample(nrow(d), 500)] <- NA   # scattered, so no item empties out
+  st <- enem_scored_stats(d)
+  check(st$n_items == 45, "NA responses are excluded, not counted as items")
+  check(st$min_n_per_item > 0, "every item keeps respondents")
+})
+
+cat("\n")
+if (failures > 0L) { cat(failures, "FAILURE(S)\n"); quit(status = 1L) }
+cat("all tests passed\n")


### PR DESCRIPTION
Fixes findings **1** and **3** of #1942. Finding 2 (`enem_2019_1mil_lc`) is not fixed here — see below.

**Nothing is rebuilt.** The INEP microdata is not on this machine, and the blast radius is large: **52 live tables, 2.34 billion rows**. So this is the code change, verified as far as it can be without the source files, and the rebuild is its own operation.

## Finding 1 — the one-line bug

```r
resp = case_when(raw %in% NONRESPONSE ~ NA_real_,   # "." blank, "*" double mark
                 raw == key           ~ 1,
                 TRUE                 ~ 0)
```

Dropped **after** the raw-code validation, which still needs to see them, and with a count printed per area.

Worth stating because it changes who can work around this: **`resp_raw` is not published.** The live tables carry only `id / item / resp / position / booklet`, so a consumer cannot screen the non-responses out themselves. Everyone pulling these tables gets the 45%.

`*` is a judgement call and is written down as one, per the issue: a double mark is a response that could not be read, which is not evidence of a wrong answer either. `NONRESPONSE` is the single line to change if a later analysis wants them scored.

## Finding 3 — the guard, and it is tested

`data/enem_checks.R`. Every existing guard in these scripts is on the *inputs and the joins*; both defects produce structurally valid output that is psychometrically impossible, so none of them fires. The new checks run on the **scored output**:

| condition | action |
|---|---|
| an item scored identically for every candidate | **stop** — `enem_2019_1mil_lc` has five, 0 correct out of 7,520 |
| median item-rest < .05 *and* >60% of items below it | **stop** — a correctly keyed item correlates positively with the rest regardless of difficulty |
| >50% of items below the 1/5 chance floor | warn |
| >5% of candidates who answered every item scoring exactly zero | warn — this is finding 1 |

Item-rest on 45M rows is not free, so it runs on a seeded 5,000-candidate sample; p-values use everything.

`data/tests/test_enem_checks.R` exercises it offline on synthetic forms built to look like each defect, and — the test that matters — on a **legitimately hard form**, which passes. Difficulty alone must never fail a build. Added to `.github/workflows/tests.yml` (base R only, no microdata, no network), so the thresholds that decide whether a 45-million-row table is publishable are checked on every PR rather than only when someone has 13 years of INEP files on disk.

```
a healthy form passes                        4 ok
finding 1 -- non-responses scored as wrong   3 ok
finding 2 -- a mis-keyed form                5 ok
shape                                        2 ok
all tests passed
```

## What I could and could not verify

- **Could:** the 13 scripts still differ only in their two prova-code lines, exactly as before — the same patch applied 13 times, mechanically, with no drift. All 14 files parse. The guard is tested against both defect shapes and against a false positive.
- **Could not:** run any year script. That needs the INEP microdata. So the scoring change is verified by inspection and by the identical-diff property, not by execution against real data.

## Not in this PR

**Finding 2, `enem_2019_1mil_lc`.** Still needs `ITENS_PROVA_2019.csv` and the 2019 microdata to confirm whether the LC language items sit where the `width == npos + 5` branch assumes. The new guard would have *failed* that build — five zero-variance items stop it outright — but diagnosing it is a separate job. Note that this table stays wrong-now until then; the finding-1 fix does not touch it.

**The docs line.** There is no ENEM markdown to put it in; the reasoning now lives in the script header, which is where a reader of these scripts would look. The user-facing statement belongs in the dictionary `Description` for the 52 tables, which is a sheet edit rather than a code change.

## Note on the refactor

The issue suggests factoring the 13 near-identical scripts into one helper. I did not, deliberately: I cannot execute them, and collapsing 13 files I cannot run is a bigger change than the bug warrants. The patch being provably identical across all 13 is the next best thing. Happy to do the refactor as its own PR once there is a machine that can run one year end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjpFgj7bT9GJ8UeF5hMLdE