### PR TITLE
Aspirations_Sonmez_2022 and PEPABAS2C_Kubicka_2024 are id collisions, not duplication (#1842)

### DIFF
--- a/data/Aspirations_Sonmez_2022.R
+++ b/data/Aspirations_Sonmez_2022.R
@@ -1,14 +1,50 @@
 # Paper: https://www.inderscienceonline.com/doi/abs/10.1504/IJHD.2023.131527
 # Data: https://osf.io/psgk8/
+#
+# `Aspirations_CFA.sav` is TWO INDEPENDENT SAMPLES STACKED: Study 1 (265
+# respondents) on top of Study 2 (208), with `StudyNo` separating them and
+# `ParticipantNo` restarting at 1 in each. So participant 1 of Study 1 and
+# participant 1 of Study 2 are different people, and every one of Study 2's 208
+# numbers collides with a Study 1 number.
+#
+# This script used `ParticipantNo` as `id` unchanged, which is why the published
+# table carries 208 x 35 = 7,280 id+item pairs appearing twice and 57 x 35 =
+# 1,995 appearing once (#1842, block H). Those were read as two waves or as
+# duplication; they are neither, and deduping them would have deleted 208
+# people. The source settles it: for the 208 colliding numbers, `Age` agrees on
+# 22 and `Gender` on 106 -- chance, for a binary variable -- and only 31.9% of
+# item responses match.
+#
+# Fixed the way the other id collisions in #1842 were (agreed 2026-09-02):
+# namespace `id` with the sample label, and keep the label as its own `cov_`
+# column. The separator "_" cannot occur in a source id, which is an integer.
 library(haven)
 library(dplyr)
 library(tidyr)
 
 df <- read_sav('Aspirations_CFA.sav')
-df <- df |>
-  rename(id=ParticipantNo) |>
-  select(id, starts_with("Asp"))
-df <- pivot_longer(df, cols=-id, values_to = "resp", names_to="item")
 
-save(df, file="Aspirations_Sonmez_2022.Rdata")
-write.csv(df, "Aspirations_Sonmez_2022.csv", row.names=FALSE)
+stopifnot(all(c("StudyNo", "ParticipantNo") %in% names(df)))
+## The collision this file exists to fix must actually be there: if a future
+## revision of the source numbers participants uniquely, namespacing would be
+## wrong rather than merely unnecessary.
+stopifnot(anyDuplicated(df$ParticipantNo) > 0)
+
+df <- df |>
+  mutate(cov_study = paste0("s", as.integer(StudyNo)),
+         id        = paste0(cov_study, "_", as.integer(ParticipantNo))) |>
+  select(id, cov_study, starts_with("Asp"))
+
+stopifnot(!anyDuplicated(df$id))
+
+df <- pivot_longer(df, cols = c(-id, -cov_study),
+                   values_to = "resp", names_to = "item") |>
+  filter(!is.na(resp)) |>
+  select(id, item, resp, cov_study)
+
+## No id+item pair may repeat once the samples are namespaced. This is the
+## measure #1842 is closed on.
+stopifnot(!anyDuplicated(df[, c("id", "item")]))
+
+save(df, file = "Aspirations_Sonmez_2022.Rdata")
+write.csv(df, "Aspirations_Sonmez_2022.csv", row.names = FALSE)

--- a/data/PEPABAS2C_Kubicka_2024.r
+++ b/data/PEPABAS2C_Kubicka_2024.r
@@ -19,6 +19,36 @@ data_df <- read_sav("BAS2_Children_dataset.sav")
 data_df <- data_df %>%
   rename(id = CODE)
 
+# Two CODEs are held by two DIFFERENT CHILDREN each (#1842). `2_2BIMA` and
+# `2_2BISE` appear twice in the source, and the pairs are not re-tests:
+#
+#   2_2BIMA   gender 2 vs 1, 30.0 kg / 1.30 m vs 27.5 kg / 1.33 m
+#   2_2BISE   age 9 vs 8,    33.0 kg / 1.40 m vs 21.0 kg / 1.20 m
+#
+# 12 kg and 20 cm apart. That is the whole of this table's dup_id_item flag --
+# 2 codes x 24 items = 48 rows -- and the block H prescription to dedupe it
+# would have deleted two real children.
+#
+# There is no sample label to namespace with, as there was for the other #1842
+# collisions, so the repeated code gets an occurrence suffix. The order within a
+# code is arbitrary and it does not matter: they are anonymous, and the point is
+# only that they stop being one person. "." is used because "_" occurs in the
+# source codes.
+#
+# The source also carries Gender/Age/Weight/Height/BMI per row, which is what
+# distinguishes them; none of it is currently shipped. Worth adding as cov_
+# columns, but that is a separate change from making the ids honest.
+dup_code <- data_df$id %in% data_df$id[duplicated(data_df$id)]
+if (any(dup_code)) {
+  n_dup <- length(unique(data_df$id[dup_code]))
+  data_df$id[dup_code] <- paste0(data_df$id[dup_code], ".",
+                                 ave(seq_len(sum(dup_code)),
+                                     data_df$id[dup_code], FUN = seq_along))
+  message(sprintf("PEPABAS2C: %d code(s) held by more than one child; suffixed %d row(s)",
+                  n_dup, sum(dup_code)))
+}
+stopifnot(!anyDuplicated(data_df$id))
+
 data_df[] <- lapply(data_df, function(col) { # Remove column labels for each column
   attr(col, "label") <- NULL
   return(col)
@@ -47,6 +77,31 @@ Body_df <- pivot_longer(Body_df, cols=-c(id), names_to="item", values_to="resp")
 Body_df$resp <- as.numeric(Body_df$resp)
 df <- rbind(Body_df, BAS_df)
 df <- rbind(df, SPP_df)
+
+# 99 is the study's missing code, and it must be removed explicitly rather than
+# left to whichever file this is run against (#1842).
+#
+# The published table carries 5 rows with a NULL `resp` and no 99s, so the .sav
+# the original build read had these cells stored as SPSS user-missing. Harvard
+# Dataverse does not serve that .sav -- it ingested it to `.tab`, where the user
+# missing values are materialised as the literal 99. So a rebuild from the
+# archive would publish seven 99s as responses, and the current table publishes
+# five NULLs; recoding here is correct against both files.
+#
+# Seven cells: SPP6, SPP16, SPP18, SPP22, Body_satisfaction1 and
+# Body_satisfaction2 (x2). Two of them are the same respondent's only two Body
+# items, which is why remove_na() drops that row entirely and the live table is
+# 4,846 rather than 4,848.
+MISSING_CODE <- 99
+df$resp <- as.numeric(df$resp)
+n_missing <- sum(df$resp == MISSING_CODE, na.rm = TRUE)
+df <- df[!is.na(df$resp) & df$resp != MISSING_CODE, ]
+message(sprintf("PEPABAS2C: dropped %d response(s) coded %d and any NA",
+                n_missing, MISSING_CODE))
+
+## No id+item pair may repeat once the collided codes are separated.
+stopifnot(!anyDuplicated(df[, c("id", "item")]))
+stopifnot(!any(is.na(df$resp)))
 
 save(df, file="PEPABAS2C_Kubicka_2024.Rdata")
 write.csv(df, "PEPABAS2C_Kubicka_2024.csv", row.names=FALSE)

--- a/irw_validate/results/dup_id_item_worklist.md
+++ b/irw_validate/results/dup_id_item_worklist.md
@@ -249,6 +249,34 @@ safe now that group is a function of item.
 > second" produces a file no uploader will take. Block H is all-or-nothing: it
 > needs the source before any of it reaches the corpus.
 
+> **Two more re-diagnosed, 2026-09-06, and both are ID COLLISIONS.** The
+> sources were public all along -- OSF `psgk8` and Harvard Dataverse `LGXP5A`
+> both download without an account.
+>
+> - **`Aspirations_Sonmez_2022`** — `Aspirations_CFA.sav` is Study 1 (265) and
+>   Study 2 (208) stacked, with `StudyNo` separating them and `ParticipantNo`
+>   restarting at 1 in each. 208 x 35 items = **7,280** pairs twice and
+>   57 x 35 = **1,995** once, which is exactly the copies-per-pair shape recorded
+>   above. Not two waves: across the 208 colliding numbers `Age` agrees on 22
+>   and `Gender` on 106, and only 31.9% of responses match. Fixed by namespacing
+>   `id` with the sample and keeping `cov_study`; row count unchanged at 16,555,
+>   ids 265 -> 473.
+> - **`PEPABAS2C_Kubicka_2024`** — two CODEs are held by two different children
+>   each (`2_2BIMA`, `2_2BISE`; 12 kg and 20 cm apart). That is the whole flag:
+>   2 codes x 24 items = 48 rows. Fixed with an occurrence suffix, since there
+>   is no sample label to namespace with.
+>
+> Both were listed here as "dedupe, then chase". Deduping either would have
+> deleted real people — 208 of them in `Aspirations`. That is the same error
+> the block-H note above already names, found twice more.
+>
+> **A separate defect found in `PEPABAS2C` while there:** the live table
+> publishes **5 rows with a NULL `resp`**, and the source's missing code, 99,
+> was never recoded. Dataverse ingested the `.sav` to `.tab`, which materialises
+> user-missing as the literal 99, so a rebuild from the archive would have
+> published seven 99s as responses. The script now recodes explicitly, which is
+> correct against either file. 4,846 -> 4,841 rows.
+
 Two halves; the first is mechanical, the second is research. Do the first and
 record the second, rather than blocking on it.
 


### PR DESCRIPTION
Two of block H, re-diagnosed and fixed. Corrected tables staged in `/tmp/here/`.

**The sources were public all along.** The worklist says what remains "needs a source file somebody has to fetch" — OSF `psgk8` and Harvard Dataverse `LGXP5A` both download without an account. That is what settled both of these.

## `Aspirations_Sonmez_2022` — 208 people would have been deleted

`Aspirations_CFA.sav` is **two independent samples stacked**: Study 1 (265) on Study 2 (208), with `StudyNo` separating them and `ParticipantNo` restarting at 1 in each.

That reproduces the recorded copies-per-pair exactly:

| | predicted from the source | recorded in `copies_per_pair` |
|---|---|---|
| pairs appearing twice | 208 shared numbers × 35 items = **7,280** | 7,280 |
| pairs appearing once | 57 × 35 = **1,995** | 1,995 |

The block read this as two waves. It is not — the colliding numbers are **different people**:

```
Age agrees on     22 of 208
Gender agrees on 106 of 208     (chance, for a binary variable)
item responses identical: 31.9%
```

Fixed by namespacing `id` with the sample and keeping `cov_study`, per the rule agreed 2026-09-02. **Row count unchanged at 16,555** — nothing removed, nothing added, ids 265 → 473. Verified against live.

## `PEPABAS2C_Kubicka_2024` — two codes, four children

`2_2BIMA` and `2_2BISE` each appear twice in the source, and the pairs are not re-tests:

```
2_2BIMA   gender 2 vs 1,  30.0 kg / 1.30 m  vs  27.5 kg / 1.33 m
2_2BISE   age    9 vs 8,  33.0 kg / 1.40 m  vs  21.0 kg / 1.20 m
```

12 kg and 20 cm apart. That is the whole of this table's flag — 2 codes × 24 items = 48 rows, matching the recorded 4,750 once / 48 twice. There is no sample label to namespace with, so the repeated code takes an occurrence suffix, using `.` because `_` occurs in the source codes.

### A second defect found while there

**The live table publishes 5 rows with a NULL `resp`**, and the study's missing code — 99 — was never recoded. Dataverse ingested the `.sav` to `.tab`, and that materialises SPSS user-missing as the literal **99**, so a rebuild from the archive would have shipped seven 99s as responses. The recode is now explicit, which is correct against either file:

```
PEPABAS2C: 2 code(s) held by more than one child; suffixed 4 row(s)
PEPABAS2C: dropped 7 response(s) coded 99 and any NA
rows 4841  ids 202  items 24  resp 1-7  dup id+item 0  NA resp 0
```

4,846 → 4,841, the difference being exactly the five NULLs.

## Verification

Both scripts now `stopifnot(!anyDuplicated(df[, c("id","item")]))` before writing, which is this issue's own "done when". `irw-validate` reports no errors on either; the warnings are pre-existing shape (capitalised names, mixed subscales).

One caveat on `PEPABAS2C`: Dataverse serves only the ingested `.tab`, not the depositor's `.sav`, so I rebuilt through a `.tab` → `.sav` round trip. The 99 recode makes the output identical either way, but if you have the original `.sav` it is worth a re-run to confirm.

## For the worklist

`irw_validate/results/dup_id_item_worklist.md` records both re-diagnoses in the block H note. That note already warns that reading `excess_exact > 0` as duplication destroys data in a repeated-measures design — this is the same error found twice more, in the other direction: two stacked samples look like repeated measurement and are neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjpFgj7bT9GJ8UeF5hMLdE