### PR TITLE
CLAUDE.md: flag the automated_finding .RData exception (#1731)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,8 @@ Additional rules:
 - Each measurement scale is saved as a **separate file**
 - Response times in **seconds**
 - Longitudinal timestamps in **Unix time**
-- Output saved as both `.csv` and `.RData`
+- Output saved as both `.csv` and `.RData` — except the `automated_finding`
+  pipeline, where `datastandard.md` overrides this
 
 ## Typical Processing Script Pattern
 


### PR DESCRIPTION
Closes #1731.

`CLAUDE.md` said output is saved as both `.csv` and `.RData`; `datastandard.md` overrides that for the `automated_finding` pipeline (CSV only). The override was documented only on the winning side, so a reader starting from `CLAUDE.md` — the file agents load automatically — had no signal an exception existed.

One clause added at the `.RData` bullet, pointing at `datastandard.md`. The rule itself is not restated, per rule 1 (a fact lives in exactly one place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvDCXmBEhCTNT4XJpdTwSv