### PR TITLE
SAS_Deters_2022 and PTCI_Chinese_Zhan_2024 are id collisions (#1842)

### DIFF
--- a/data/PTCI_Chinese_Zhan_2024.R
+++ b/data/PTCI_Chinese_Zhan_2024.R
@@ -6,17 +6,63 @@ library(tidyr)
 library(foreign)
 
 # ------ Process Dataset 1 ------
+#
+# `ID` IS NOT A PERSON. `PTCI_data.sav` holds 2,375 respondents under 1,206
+# distinct `ID` values -- 1,866 rows share a number with another row (#1842).
+# It is a collision, not repeated measurement, and three things in the source
+# say so together:
+#
+#   * `sex` differs within an ID for 461 numbers and `age` for 687;
+#   * `T_ptci` equals that row's own item sum on all 2,375 rows, so every row is
+#     a complete, self-consistent respondent record;
+#   * not one whole row is byte-identical to another.
+#
+# The published table used `ID` alone and so merged up to four respondents into
+# one. The block H prescription -- dedupe 17,394 rows, chase 21,183 -- would
+# have deleted roughly 1,169 people.
+#
+# `C2` is the sample stratum (senior / high / adult; `C1` is its adolescent-adult
+# collapse, and nests inside it), and numbering restarts within each. Namespacing
+# by it, per the rule agreed 2026-09-02, resolves most of the collision; 125
+# numbers still carry two sexes within one stratum, so a finer unit the file does
+# not carry -- school or class -- is also in play, and those take an occurrence
+# suffix. Every row ends up its own respondent, which is what the T_ptci identity
+# says it is.
+PTCI_SAMPLE <- c("1" = "senior", "2" = "high", "3" = "adult")
+
 df <- read_sav("PTCI_data.sav")
+
+stopifnot(all(c("ID", "C2") %in% names(df)))
+stopifnot(anyDuplicated(df$ID) > 0)   # the collision this file exists to fix
+
+df$cov_sample <- unname(PTCI_SAMPLE[as.character(as.integer(df$C2))])
+stopifnot(!any(is.na(df$cov_sample)))
+df$id <- paste0(df$cov_sample, "_", as.integer(df$ID))
+rep_id <- df$id %in% df$id[duplicated(df$id)]
+if (any(rep_id)) {
+  df$id[rep_id] <- paste0(df$id[rep_id], ".",
+                          ave(seq_len(sum(rep_id)), df$id[rep_id], FUN = seq_along))
+  message(sprintf("PTCI: %d number(s) repeated within a stratum; suffixed %d row(s)",
+                  length(unique(sub("\\..$", "", df$id[rep_id]))), sum(rep_id)))
+}
+stopifnot(!anyDuplicated(df$id))
+
 df <- df |>
-  select(ID, starts_with("PTCI")) |>
-  rename(id = ID)
+  select(id, cov_sample, starts_with("PTCI"))
 df[] <- lapply(df, function(col) { # Remove column labels for each column
   attr(col, "label") <- NULL
   return(col)
 })
-df <- pivot_longer(df, cols=-id, names_to = "item", values_to = "resp")
+df <- pivot_longer(df, cols=c(-id, -cov_sample), names_to = "item", values_to = "resp")
 
 # ------ Process Dataset 2 ------
+# A separate retest sample, numbered 3001-3117, with no overlap against dataset
+# 1's numbers and no repeats of its own. Labelled so the two are distinguishable
+# once they are stacked.
+#
+# Note for later: this file also carries the ptci*_retest columns -- a real
+# second occasion, 61 respondents -- which this script drops. Adding them needs
+# a `wave` column and is a change of shape, so it is not done here.
 df_retest <- read.spss("./PTCI_retest.sav", to.data.frame = TRUE, use.value.labels = FALSE)
 df_retest <- df_retest |>
   rename(id=ID_retest) |>
@@ -32,8 +78,17 @@ ptci_df <- df_retest |>
 ptci_test_df <- ptci_df |>
   select(id, ends_with("_test"))
 colnames(ptci_test_df) <- gsub('_test$', '', colnames(ptci_test_df))
-ptci_test_df <- pivot_longer(ptci_test_df, cols=-id, names_to = "item", values_to = "resp")
+ptci_test_df$cov_sample <- "retest"
+ptci_test_df$id <- paste0("retest_", as.integer(ptci_test_df$id))
+stopifnot(!anyDuplicated(ptci_test_df$id))
+ptci_test_df <- pivot_longer(ptci_test_df, cols=c(-id, -cov_sample),
+                             names_to = "item", values_to = "resp")
 
 df <- rbind(df, ptci_test_df)
+df <- df[!is.na(df$resp), c("id", "item", "resp", "cov_sample")]
+
+## No id+item pair may repeat once the strata are namespaced. This is the
+## measure #1842 is closed on.
+stopifnot(!anyDuplicated(df[, c("id", "item")]))
 save(df, file="PTCI_Chinese_Zhan_2024.Rdata")
 write.csv(df, "PTCI_Chinese_Zhan_2024.csv", row.names=FALSE)

--- a/data/SAS_Deters_2022.R
+++ b/data/SAS_Deters_2022.R
@@ -1,13 +1,72 @@
 # Paper: https://osf.io/ztycp/
 # Data: https://osf.io/ztycp/
+#
+# `id` IS NOT A PERSON. `SAmb_R.csv` pools twenty semesters of a university
+# subject pool, and the participant number restarts within each: 1,526 numbers
+# across 7,096 rows, one number used up to 14 times (#1842).
+#
+# This is a collision, not repeated measurement, and the source proves it.
+# Keyed on `id` alone, 456 numbers carry more than one `gender`, 1,095 more than
+# one `age` and 1,003 more than one `ethnic`. Keyed on `id` + `semester`:
+#
+#            key            groups   ids w/ 2 genders   2 ages   2 ethnicities
+#   id                       1,526              456      1,095          1,003
+#   id + semester            7,088                0          1              2
+#
+# Zero. So the number identifies a person only within its semester, and the
+# published table -- which used `id` alone -- merged up to fourteen students
+# into one respondent. The block H prescription to dedupe it would have deleted
+# them outright.
+#
+# Namespaced per the rule agreed 2026-09-02: prefix `id` with the sample label
+# and keep the label as its own `cov_` column.
+#
+# Seven (id, semester) groups still hold more than one row, and those are
+# collisions too rather than duplicates -- every one has distinct responses, and
+# two are unambiguous (id 2319 in semester 59 is aged 18.28 and 24.86 with two
+# different ethnicities; id 2553 likewise differs on ethnicity). They take an
+# occurrence suffix, as PEPABAS2C's did.
+#
+# Not shipped, but available in the source if wanted later: gender, age and
+# ethnic, which are what identify these as separate people.
 library(dplyr)
 library(tidyr)
 library(haven)
 
 df <- read.csv("SAmb_R.csv")
+
+stopifnot(all(c("id", "semester") %in% names(df)))
+stopifnot(anyDuplicated(df$id) > 0)   # the collision this file exists to fix
+
 df <- df |>
-  select(id, starts_with("samb"), -SAmb_tot)
-df <- pivot_longer(df, cols=-id, names_to="item", values_to="resp")
+  mutate(cov_semester = as.integer(semester),
+         .person      = paste0("s", cov_semester, "_", as.integer(id)))
+
+## Within-semester repeats: distinct people sharing a number. Suffix by
+## occurrence -- the order is arbitrary and they are anonymous; the point is
+## only that they stop being one person. "." cannot occur in the source id,
+## which is an integer.
+rep_person <- df$.person %in% df$.person[duplicated(df$.person)]
+if (any(rep_person)) {
+  df$.person[rep_person] <- paste0(df$.person[rep_person], ".",
+                                   ave(seq_len(sum(rep_person)),
+                                       df$.person[rep_person], FUN = seq_along))
+  message(sprintf("SAS_Deters_2022: %d number(s) repeated within a semester; suffixed %d row(s)",
+                  length(unique(sub("\\..$", "", df$.person[rep_person]))),
+                  sum(rep_person)))
+}
+df$id <- df$.person
+stopifnot(!anyDuplicated(df$id))
+
+df <- df |>
+  select(id, cov_semester, starts_with("samb"), -SAmb_tot) |>
+  pivot_longer(cols = c(-id, -cov_semester), names_to = "item", values_to = "resp") |>
+  filter(!is.na(resp)) |>
+  select(id, item, resp, cov_semester)
+
+## No id+item pair may repeat once the semesters are namespaced. This is the
+## measure #1842 is closed on.
+stopifnot(!anyDuplicated(df[, c("id", "item")]))
 
 save(df, file="SAS_Deters_2022.Rdata")
 write.csv(df, "SAS_Deters_2022.csv", row.names=FALSE)

--- a/irw_validate/results/dup_id_item_worklist.md
+++ b/irw_validate/results/dup_id_item_worklist.md
@@ -277,6 +277,30 @@ safe now that group is a function of item.
 > published seven 99s as responses. The script now recodes explicitly, which is
 > correct against either file. 4,846 -> 4,841 rows.
 
+> **`SAS_Deters_2022` and `PTCI_Chinese_Zhan_2024` too, 2026-09-06 — also id
+> collisions.** Both sources are public OSF nodes (`ztycp`, `tj8rh`).
+>
+> - **`SAS_Deters_2022`** — `SAmb_R.csv` pools twenty semesters of a subject
+>   pool and the participant number restarts in each: 1,526 numbers over 7,096
+>   rows, one used 14 times. Keyed on `id` alone, 456 numbers carry two genders,
+>   1,095 two ages, 1,003 two ethnicities; keyed on `id`+`semester`, **0 / 1 /
+>   2**. The published table merged up to fourteen students into one respondent.
+>   ids 1,526 -> 7,096.
+> - **`PTCI_Chinese_Zhan_2024`** — 2,375 respondents under 1,206 `ID` values.
+>   `sex` differs within an ID for 461 numbers and `age` for 687; `T_ptci`
+>   equals its own row's item sum on all 2,375 rows, so every row is a complete
+>   respondent record; and no whole row is byte-identical to another. Namespaced
+>   by `C2` (the senior/high/adult strata). ids 1,206 -> 2,436. Row count
+>   unchanged at 80,388.
+>
+> Block H prescribed deduping both. That would have deleted roughly 1,169 people
+> from `PTCI` and merged fourteen-to-one in `SAS`.
+>
+> **Two more published NULL/`"NA"` resp values found while there**, the same
+> class as `PEPABAS2C`'s five: `SAS_Deters_2022` publishes **189 rows whose
+> `resp` is the literal string `"NA"`**, which is what types its `resp` column as
+> a string. Both scripts now drop missing responses rather than writing them.
+
 Two halves; the first is mechanical, the second is research. Do the first and
 record the second, rather than blocking on it.
 


### PR DESCRIPTION
Two more of block H, same finding as #2021. Corrected tables staged in `/tmp/here/`. Sources are the public OSF nodes `ztycp` and `tj8rh`.

## `SAS_Deters_2022` — up to fourteen students published as one respondent

`SAmb_R.csv` pools **twenty semesters** of a university subject pool, and the participant number restarts in each: 1,526 numbers over 7,096 rows, one used 14 times.

| key | groups | ids with 2 genders | 2 ages | 2 ethnicities |
|---|---|---|---|---|
| `id` | 1,526 | **456** | 1,095 | 1,003 |
| `id` + `semester` | 7,088 | **0** | 1 | 2 |

Zero. The number identifies a person only within its semester. Namespaced with `cov_semester`; **ids 1,526 → 7,096**.

The seven remaining within-semester repeats are collisions too, not duplicates — every one has distinct responses, and two are unambiguous (id 2319 in semester 59 is aged **18.28 and 24.86** with two different ethnicities). They take an occurrence suffix, as `PEPABAS2C`'s did.

## `PTCI_Chinese_Zhan_2024` — ~1,169 people would have been deleted

2,375 respondents published under 1,206 `ID` values. Three things in the source agree:

- `sex` differs within an ID for **461** numbers, `age` for **687**;
- `T_ptci` equals that row's own item sum on **all 2,375 rows**, so every row is a complete, self-consistent respondent record;
- **not one whole row is byte-identical to another.**

`C2` is the sample stratum (senior / high / adult) and numbering restarts within each. Namespacing by it resolves most of it; 125 numbers still carry two sexes inside one stratum, so a finer unit the file does not carry — school or class — is also in play, and those take an occurrence suffix. **ids 1,206 → 2,436, row count unchanged at 80,388.**

Block H prescribed "dedupe 17,394, then chase 21,183" here. That would have deleted roughly 1,169 people.

## A second defect, same class as last time

**`SAS_Deters_2022` publishes 189 rows whose `resp` is the literal string `"NA"`**:

```
resp      n
   0  87535
   1  47100
  NA    189
```

That single fact is what types the whole `resp` column as a string rather than an integer — the same shape as `PEPABAS2C`'s five NULLs and as the `na = "NA"` defect fixed in `project_kids` under #416. Both scripts now drop missing responses. 134,824 → 134,635.

## Verification

Both scripts `stopifnot(!anyDuplicated(df[, c("id","item")]))` before writing. Against live: `PTCI` delta **0** (nothing added or removed, only ids made honest), `SAS` **−189**, exactly the `"NA"` rows. `irw-validate` reports no errors on either.

## Noted, not done

`PTCI_retest.sav` also carries the `ptci*_retest` columns — **a real second occasion for 61 respondents** — which this script drops and keeps only the `_test` half. Adding them needs a `wave` column and changes the table's shape, so it is not done here. Worth its own issue if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjpFgj7bT9GJ8UeF5hMLdE