### PR TITLE
itemtext_standard.md: field order is not significant (#1812)

### DIFF
--- a/itemtext/.claude/skills/irw-auto-itemtext/references/itemtext_standard.md
+++ b/itemtext/.claude/skills/irw-auto-itemtext/references/itemtext_standard.md
@@ -6,6 +6,10 @@ skill doesn't need to re-fetch the page every run. This is the
 schema of the **merged** `{table}__items.csv` — the output of joining the four
 per-table tabs (instrument, sections, items, responses) on `table` / `section_id` / `item`.
 
+**Field order is not significant.** The table below defines which fields exist, not the
+order they must appear in: Redivis matches columns by name, and nothing validates order.
+Batches that emit these columns in different orders are both correct.
+
 | Field | Definition |
 |---|---|
 | `table` | Identifier used to link to the IRW response data. |


### PR DESCRIPTION
Closes #1812.

Column order does not matter — Redivis matches fields by name and nothing validates order. The only real problem in #1812 was that the field table in `itemtext_standard.md` reads like an order without saying it is one, which is why two batches in the same week emitted different orders. One added note says it isn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LaZ4f6UXaMFjV1CFr12ZF9