### PR TITLE
Check that the three Redivis config files agree (#1733)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,47 @@ jobs:
         working-directory: metadata
         run: Rscript tests/test_dict_union.R
 
+      # Redivis config parity (#1733). The dataset list is declared once per
+      # language -- here, in Rpkg, and in Python-pkg -- and nothing compared
+      # the three. They had already drifted: Python-pkg carried no reference to
+      # irw_nominal, so that source was reachable from R and not from Python
+      # for months, and it was found by hand rather than by anything mechanical.
+      #
+      # The issue proposed hanging this off the weekly pipeline, because that
+      # was the only job with all the checkouts on disk. Both package repos are
+      # public, so any runner can have them -- which makes this a per-PR check
+      # that fails in the pull request that introduces the drift, rather than in
+      # the following Monday's metadata PR, which is about something else.
+      #
+      # Both are checked out at their default branch on purpose. A config change
+      # is only really landed once it is on main in all three repos, and that is
+      # the state this is asserting.
+      - name: Check out Rpkg
+        uses: actions/checkout@v4
+        with:
+          repository: itemresponsewarehouse/Rpkg
+          path: _deps/Rpkg
+
+      - name: Check out Python-pkg
+        uses: actions/checkout@v4
+        with:
+          repository: itemresponsewarehouse/Python-pkg
+          path: _deps/Python-pkg
+
+      # The unit tests first: they cover the parsers against synthetic files,
+      # including the floor that makes a config this can no longer read ERROR
+      # instead of comparing three empty sets and reporting green. Run as a
+      # script rather than through unittest discovery because metadata/ is not
+      # an importable package, unlike red_up/ and irw_validate/ above.
+      - name: config parity tests
+        run: python metadata/tests/test_config_parity.py -v
+
+      - name: Redivis config parity
+        run: |
+          python metadata/check_config_parity.py \
+            --rpkg  _deps/Rpkg/R/redivis-config.R \
+            --pypkg _deps/Python-pkg/src/irw/config.py
+
   # A PR to data/ contains a conversion SCRIPT, never a table --
   # automated_finding/irw_output/ is gitignored, so no output is ever in the
   # diff. This checks the script's contract; the data is checked by

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -77,16 +77,27 @@ Until August 2026 all of this lived under the personal Redivis account
 `bdomingu`. Redivis resolves references to a previous owner automatically, so
 older scripts still work.
 
-> **Known hazard.** The dataset identifiers are duplicated in three files:
-> `metadata/redivis_config.R` here, `R/redivis-config.R` in `Rpkg`, and
+> **Duplicated, and checked.** The dataset identifiers are declared in three
+> files: `metadata/redivis_config.R` here, `R/redivis-config.R` in `Rpkg`, and
 > `src/irw/config.py` in `Python-pkg`. All three describe themselves as a single
 > source of truth. They are reconcilable — this repo carries plain dataset
 > *names*, the two packages additionally carry version *hashes* — but a new shard
-> must be added in all three, and nothing currently checks that they agree. They
-> have already drifted once (#1733). Each file now carries *two* shard lists,
-> core and item text (`IRW_CORE_DATASETS`/`IRW_TEXT_DATASETS`,
+> must be added in all three, and each file carries *two* shard lists, core and
+> item text (`IRW_CORE_DATASETS`/`IRW_TEXT_DATASETS`,
 > `.irw_datasource_specs$core`/`.irw_itemtext_specs`,
 > `MAIN_REFS`/`ITEMTEXT_REFS`), so adding a shard means six edits, not three.
+>
+> They drifted once already, undetected for months: `Python-pkg` had no
+> reference to `irw_nominal`, so that source was reachable from R and not from
+> Python (#1733). The duplication is not going away — three languages, three
+> runtimes, no shared build — so what changed is that
+> [`metadata/check_config_parity.py`](metadata/check_config_parity.py) now
+> compares the three on every pull request, and it, not this paragraph, is what
+> tells you they disagree. Per rule 2 below: run it rather than trust this.
+
+```bash
+python metadata/check_config_parity.py   # with Rpkg and Python-pkg as siblings
+```
 
 ## 3. Google Sheets
 

--- a/metadata/check_config_parity.py
+++ b/metadata/check_config_parity.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Check that the three Redivis config files declare the same datasets (#1733).
+
+The set of Redivis datasets IRW reads is declared once per language:
+
+  | file                          | repo         | carries                |
+  |-------------------------------|--------------|------------------------|
+  | metadata/redivis_config.R     | irw          | dataset names only     |
+  | R/redivis-config.R            | Rpkg         | names + version hashes |
+  | src/irw/config.py             | Python-pkg   | names + version hashes |
+
+Each of the three describes itself as a single source of truth, and nothing
+compared them. They had already drifted: Python-pkg carried no reference to
+irw_nominal at all, so the nominal source was reachable from R and not from
+Python, and that went unnoticed until someone wrote ARCHITECTURE.md by hand.
+
+De-duplicating them is not on the table -- three languages, three runtimes, no
+shared build, and any scheme that "removes" the duplication just generates the
+copies, which can still go ungenerated. Publishing the registry as a Redivis
+table was considered and rejected: it puts a network round-trip and a bootstrap
+dependency in every client's cold start, so a client that cannot reach Redivis
+could no longer learn its own configuration. So: detect the drift instead.
+
+WHAT IS COMPARED, AND WHAT IS NOT
+Dataset *names*, with any `:refid` version hash stripped. The three files
+legitimately differ in content -- redivis_config.R carries no hashes by design
+-- so byte or line equality would false-alarm on every run. Whether the two
+packages pin the same version hash is a real but separate question, and not
+always a defect: one package may pin an older dataset version deliberately.
+
+Order is compared for the sharded sources (`core`, `text`). It is not
+decoration: all three files declare shards oldest-to-newest and every client
+searches them newest-first so a table resolves to its most recent copy. A file
+that listed them in a different order would resolve some tables to a stale copy
+while every name still matched.
+
+PARSE, DO NOT IMPORT
+Nothing here imports irw, sources R, or touches the network, so it runs on any
+runner in about a second. The R files are read with regexes and the Python file
+with `ast`; a config file is a literal declaration in all three, which is what
+makes that safe.
+
+Usage:
+    python metadata/check_config_parity.py                  # sibling checkouts
+    python metadata/check_config_parity.py --rpkg P --pypkg P
+
+Run it against checkouts that are up to date. It reads the working tree it is
+pointed at, so a sibling repo sitting behind its remote reports drift that is
+not actually on main -- which is exactly how the `nom` gap read as still open
+after it had been fixed and released. `git -C ../Python-pkg pull` first, or
+trust the CI run, which always checks out both packages fresh.
+
+Exits 0 when the three agree, 1 when they do not, 2 when a file could not be
+found or parsed (which is itself a failure -- see _require below).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Sequence, Tuple
+
+# Sources that are shards -- ordered lists, oldest to newest. Everything else
+# is a single dataset. Order is compared for these and only these.
+SHARDED = ("core", "text")
+
+# A floor on what a healthy parse returns, per source. The failure this guards
+# against is a parser that silently matches nothing -- if a file is reformatted
+# past our regexes and every extraction comes back empty, the sets all compare
+# equal and the check passes green while checking nothing at all. These are
+# deliberately floors, not exact counts: adding a seventh warehouse is a normal
+# Tuesday and must not have to edit this file.
+MIN_DATASETS = {"core": 6, "text": 2, "meta": 1, "sim": 1, "comp": 1, "nom": 1}
+
+
+class ParseError(RuntimeError):
+    """A config file could not be read or did not contain what we expected."""
+
+
+def _strip_hash(ref: str) -> str:
+    """`item_response_warehouse:as2e` -> `item_response_warehouse`."""
+    return ref.split(":", 1)[0].strip()
+
+
+def _require(name: str, source: str, values: Sequence[str]) -> List[str]:
+    """Fail loudly when an extraction comes back implausibly short."""
+    floor = MIN_DATASETS.get(source, 1)
+    if len(values) < floor:
+        raise ParseError(
+            f"{name}: extracted {len(values)} dataset(s) for source '{source}' "
+            f"but expected at least {floor}. The file's shape has probably "
+            f"changed; fix the parser in metadata/check_config_parity.py "
+            f"rather than lowering this floor."
+        )
+    return [_strip_hash(v) for v in values]
+
+
+# --------------------------------------------------------------------------
+# R parsing
+#
+# Both R files declare their datasets as literal c(...) / list(...) calls, so
+# the extraction is: find the assignment, take the balanced parenthetical that
+# follows it, and pull the quoted strings out of that. Balancing the parens
+# rather than reading to the next blank line is what makes the nested
+# list(list(...), list(...)) in Rpkg work.
+# --------------------------------------------------------------------------
+
+def _balanced_block(text: str, start: int) -> str:
+    """Return the parenthetical beginning at the first `(` at or after start."""
+    open_at = text.index("(", start)
+    depth = 0
+    for i in range(open_at, len(text)):
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return text[open_at : i + 1]
+    raise ParseError("unbalanced parentheses")
+
+
+def _r_assignment(text: str, var: str) -> str:
+    """The right-hand side of `var <- c(...)` or `var <- list(...)`."""
+    m = re.search(rf"^\s*{re.escape(var)}\s*<-\s*", text, re.MULTILINE)
+    if m is None:
+        raise ParseError(f"no assignment to `{var}`")
+    return _balanced_block(text, m.end())
+
+
+def _quoted(block: str) -> List[str]:
+    """Every double-quoted string in a block, in order."""
+    return re.findall(r'"([^"]*)"', block)
+
+
+def _r_datasets(block: str) -> List[str]:
+    """Dataset names from a block of Rpkg-style `dataset = "name:hash"` specs.
+
+    Reads the `dataset =` values only. The `user =` values in the same block
+    are the Redivis owner, not a dataset, and would otherwise be picked up as
+    six copies of "datapages".
+    """
+    return re.findall(r'dataset\s*=\s*"([^"]*)"', block)
+
+
+def parse_pipeline_config(path: Path) -> Dict[str, List[str]]:
+    """metadata/redivis_config.R -- bare names, no version hashes."""
+    text = path.read_text()
+    out: Dict[str, List[str]] = {}
+
+    out["core"] = _require(
+        path.name, "core", _quoted(_r_assignment(text, "IRW_CORE_DATASETS"))
+    )
+    out["text"] = _require(
+        path.name, "text", _quoted(_r_assignment(text, "IRW_TEXT_DATASETS"))
+    )
+
+    # IRW_AUX_DATASETS is a *named* vector -- c(meta = "irw_meta", ...) -- so
+    # the key is the source name the irw package uses and the value is the
+    # dataset. Item text is deliberately absent from it (it is a shard list,
+    # handled above); anything else that appears here must be matched.
+    aux_block = _r_assignment(text, "IRW_AUX_DATASETS")
+    for key, value in re.findall(r'(\w+)\s*=\s*"([^"]*)"', aux_block):
+        out[key] = _require(path.name, key, [value])
+
+    return out
+
+
+def parse_rpkg_config(path: Path) -> Dict[str, List[str]]:
+    """Rpkg/R/redivis-config.R -- names with version hashes."""
+    text = path.read_text()
+    out: Dict[str, List[str]] = {}
+
+    # .irw_datasource_specs is one nested list per source keyed by source name.
+    # Split the outer block on the `key = list(` headers so each source's
+    # datasets stay with their own key.
+    specs = _r_assignment(text, ".irw_datasource_specs")
+    keys = list(re.finditer(r"(\w+)\s*=\s*list\(", specs))
+    if not keys:
+        raise ParseError(f"{path.name}: no sources found in .irw_datasource_specs")
+    for i, m in enumerate(keys):
+        end = keys[i + 1].start() if i + 1 < len(keys) else len(specs)
+        key = m.group(1)
+        out[key] = _require(path.name, key, _r_datasets(specs[m.end() : end]))
+
+    out["meta"] = _require(
+        path.name, "meta", _r_datasets(_r_assignment(text, ".irw_meta_spec"))
+    )
+    out["text"] = _require(
+        path.name, "text", _r_datasets(_r_assignment(text, ".irw_itemtext_specs"))
+    )
+    return out
+
+
+# --------------------------------------------------------------------------
+# Python parsing
+#
+# config.py is literal module-level assignments, so `ast` reads it exactly and
+# without importing it -- importing would pull in the redivis client and its
+# dependencies, which a config check has no business requiring.
+# --------------------------------------------------------------------------
+
+# Module-level name in config.py -> the source key it stands for.
+PY_NAMES = {
+    "MAIN_REFS": "core",
+    "ITEMTEXT_REFS": "text",
+    "META_REF": "meta",
+    "SIM_REF": "sim",
+    "COMP_REF": "comp",
+    "NOM_REF": "nom",
+}
+
+
+def parse_python_config(path: Path) -> Dict[str, List[str]]:
+    """Python-pkg/src/irw/config.py -- names with version hashes.
+
+    Each value is either a (user, ref) pair or a tuple of them; both shapes
+    reduce to a list of refs the same way.
+    """
+    tree = ast.parse(path.read_text())
+
+    literals: Dict[str, object] = {}
+    for node in tree.body:
+        # Plain `X = ...` is Assign; the annotated `X: ClassVar[...] = ...`
+        # this file uses throughout is AnnAssign. Both appear here.
+        if isinstance(node, ast.AnnAssign):
+            targets, value = [node.target], node.value
+        elif isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        else:
+            continue
+        if value is None:
+            continue
+        for t in targets:
+            if isinstance(t, ast.Name) and t.id in PY_NAMES:
+                try:
+                    literals[t.id] = ast.literal_eval(value)
+                except ValueError as e:
+                    raise ParseError(f"{path.name}: {t.id} is not a literal ({e})")
+
+    out: Dict[str, List[str]] = {}
+    for name, source in PY_NAMES.items():
+        if name not in literals:
+            # A missing name is the exact defect this check exists to catch --
+            # NOM_REF was absent here for months -- so it is reported as a
+            # divergence below, not raised as a parse failure.
+            continue
+        value = literals[name]
+        if value and isinstance(value[0], (tuple, list)):
+            refs = [ref for _user, ref in value]   # tuple of (user, ref)
+        else:
+            refs = [value[1]]                      # a single (user, ref)
+        out[source] = _require(path.name, source, refs)
+    return out
+
+
+# --------------------------------------------------------------------------
+# Comparison
+# --------------------------------------------------------------------------
+
+def compare(configs: Dict[str, Dict[str, List[str]]]) -> List[str]:
+    """Return one problem line per divergence; empty when the three agree."""
+    problems: List[str] = []
+    files = list(configs)
+    all_sources = sorted({s for c in configs.values() for s in c})
+
+    for source in all_sources:
+        present = {f: configs[f].get(source) for f in files}
+
+        missing = [f for f, v in present.items() if v is None]
+        if missing:
+            has = [f for f, v in present.items() if v is not None]
+            names = ", ".join(sorted({n for f in has for n in present[f]}))
+            problems.append(
+                f"source '{source}' ({names}) is declared in "
+                f"{', '.join(has)} but MISSING from {', '.join(missing)}"
+            )
+            continue
+
+        if source in SHARDED:
+            # Ordered comparison: shard order decides which copy of a table wins.
+            if len({tuple(v) for v in present.values()}) > 1:
+                detail = "; ".join(f"{f}={present[f]}" for f in files)
+                problems.append(
+                    f"source '{source}' shards differ in membership or ORDER "
+                    f"(all three declare oldest-to-newest): {detail}"
+                )
+        else:
+            if len({tuple(sorted(v)) for v in present.values()}) > 1:
+                detail = "; ".join(f"{f}={present[f]}" for f in files)
+                problems.append(f"source '{source}' differs: {detail}")
+
+    return problems
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    here = Path(__file__).resolve().parent          # src/metadata
+    siblings = here.parent.parent                   # the projects/irw checkout
+    ap.add_argument(
+        "--pipeline", type=Path, default=here / "redivis_config.R",
+        help="path to metadata/redivis_config.R",
+    )
+    ap.add_argument(
+        "--rpkg", type=Path, default=siblings / "Rpkg" / "R" / "redivis-config.R",
+        help="path to Rpkg's R/redivis-config.R",
+    )
+    ap.add_argument(
+        "--pypkg", type=Path,
+        default=siblings / "Python-pkg" / "src" / "irw" / "config.py",
+        help="path to Python-pkg's src/irw/config.py",
+    )
+    args = ap.parse_args(argv)
+
+    wanted: List[Tuple[str, Path, object]] = [
+        ("irw/metadata/redivis_config.R", args.pipeline, parse_pipeline_config),
+        ("Rpkg/R/redivis-config.R", args.rpkg, parse_rpkg_config),
+        ("Python-pkg/src/irw/config.py", args.pypkg, parse_python_config),
+    ]
+
+    configs: Dict[str, Dict[str, List[str]]] = {}
+    for label, path, parser in wanted:
+        if not path.exists():
+            print(
+                f"ERROR: {label} not found at {path}\n"
+                f"       Pass --rpkg/--pypkg, or check the two package repos "
+                f"out as siblings of this one.",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            configs[label] = parser(path)
+        except ParseError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 2
+
+    problems = compare(configs)
+    if problems:
+        print("Redivis config files DISAGREE (see irw#1733):\n", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        print(
+            "\nAdding or moving a dataset means editing all three files:\n"
+            "  irw          metadata/redivis_config.R\n"
+            "  Rpkg         R/redivis-config.R\n"
+            "  Python-pkg   src/irw/config.py\n"
+            "See Rpkg/inst/developer/warehouses.md for the full checklist.",
+            file=sys.stderr,
+        )
+        return 1
+
+    for label, cfg in configs.items():
+        summary = ", ".join(f"{k}={len(v)}" for k, v in sorted(cfg.items()))
+        print(f"ok  {label}: {summary}")
+    print("\nAll three Redivis config files declare the same datasets.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/metadata/tests/test_config_parity.py
+++ b/metadata/tests/test_config_parity.py
@@ -1,0 +1,197 @@
+"""Unit tests for metadata/check_config_parity.py (#1733).
+
+The parity check has a failure mode worse than being wrong: being vacuous. If a
+config file is reformatted past its parser and every extraction comes back
+empty, the three empty sets compare equal and the check reports green while
+comparing nothing. `test_parser_floor_rejects_a_truncated_config` is the
+load-bearing test here -- the rest verify that real drift is reported.
+
+Fixtures are synthetic miniatures of the three files rather than copies of
+them, so these tests keep passing when a seventh warehouse is added. That the
+parsers handle the *real* files is checked by CI running the script itself
+against the real checkouts, which is the more important of the two checks.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import check_config_parity as ccp  # noqa: E402
+
+
+PIPELINE_R = """
+IRW_OWNER <- "datapages"
+IRW_CORE_DATASETS <- c(
+  "item_response_warehouse",
+  "item_response_warehouse_2",
+  "item_response_warehouse_3",
+  "item_response_warehouse_4",
+  "item_response_warehouse_5",
+  "item_response_warehouse_6"
+)
+IRW_TEXT_DATASETS <- c(
+  "irw_text",
+  "irw_text_2"
+)
+IRW_AUX_DATASETS <- c(
+  meta = "irw_meta",
+  sim  = "irw_simsyn",
+  comp = "irw_competitions",
+  nom  = "irw_nominal"
+)
+"""
+
+RPKG_R = """
+.irw_datasource_specs <- list(
+  core = list(
+    list(user = "datapages", dataset = "item_response_warehouse:as2e"),
+    list(user = "datapages", dataset = "item_response_warehouse_2:epbx"),
+    list(user = "datapages", dataset = "item_response_warehouse_3:5xaj"),
+    list(user = "datapages", dataset = "item_response_warehouse_4:980f"),
+    list(user = "datapages", dataset = "item_response_warehouse_5:3ykx"),
+    list(user = "datapages", dataset = "item_response_warehouse_6:fpe6")
+  ),
+  sim = list(
+    list(user = "datapages", dataset = "irw_simsyn:0btg")
+  ),
+  comp = list(
+    list(user = "datapages", dataset = "irw_competitions:cmd7")
+  ),
+  nom = list(
+    list(user = "datapages", dataset = "irw_nominal:614n")
+  )
+)
+.irw_meta_spec <- list(user = "datapages", dataset = "irw_meta:bdxt")
+.irw_itemtext_specs <- list(
+  list(user = "datapages", dataset = "irw_text:07b6"),
+  list(user = "datapages", dataset = "irw_text_2:ae47")
+)
+"""
+
+CONFIG_PY = '''
+from typing import Tuple, ClassVar
+
+MAIN_REFS: ClassVar[Tuple[Tuple[str, str], ...]] = (
+    ("datapages", "item_response_warehouse:as2e"),
+    ("datapages", "item_response_warehouse_2:epbx"),
+    ("datapages", "item_response_warehouse_3:5xaj"),
+    ("datapages", "item_response_warehouse_4:980f"),
+    ("datapages", "item_response_warehouse_5:3ykx"),
+    ("datapages", "item_response_warehouse_6:fpe6"),
+)
+SIM_REF: ClassVar[Tuple[str, str]] = ("datapages", "irw_simsyn:0btg")
+COMP_REF: ClassVar[Tuple[str, str]] = ("datapages", "irw_competitions:cmd7")
+NOM_REF: ClassVar[Tuple[str, str]] = ("datapages", "irw_nominal:614n")
+META_REF: ClassVar[Tuple[str, str]] = ("datapages", "irw_meta:bdxt")
+ITEMTEXT_REFS: ClassVar[Tuple[Tuple[str, str], ...]] = (
+    ("datapages", "irw_text:07b6"),
+    ("datapages", "irw_text_2:ae47"),
+)
+VERSION: str = "0.1.2"
+'''
+
+EXPECTED = {
+    "core": [
+        "item_response_warehouse",
+        "item_response_warehouse_2",
+        "item_response_warehouse_3",
+        "item_response_warehouse_4",
+        "item_response_warehouse_5",
+        "item_response_warehouse_6",
+    ],
+    "text": ["irw_text", "irw_text_2"],
+    "meta": ["irw_meta"],
+    "sim": ["irw_simsyn"],
+    "comp": ["irw_competitions"],
+    "nom": ["irw_nominal"],
+}
+
+
+class ParserTests(unittest.TestCase):
+    """Each parser reduces its file to the same bare, hash-free names."""
+
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def write(self, name, text):
+        p = self.tmp / name
+        p.write_text(text)
+        return p
+
+    def test_pipeline_config(self):
+        got = ccp.parse_pipeline_config(self.write("redivis_config.R", PIPELINE_R))
+        self.assertEqual(got, EXPECTED)
+
+    def test_rpkg_config_strips_version_hashes(self):
+        got = ccp.parse_rpkg_config(self.write("redivis-config.R", RPKG_R))
+        self.assertEqual(got, EXPECTED)
+
+    def test_python_config_strips_version_hashes(self):
+        got = ccp.parse_python_config(self.write("config.py", CONFIG_PY))
+        self.assertEqual(got, EXPECTED)
+
+    def test_rpkg_user_field_is_not_mistaken_for_a_dataset(self):
+        """`user = "datapages"` sits beside every `dataset =` in the same block."""
+        got = ccp.parse_rpkg_config(self.write("redivis-config.R", RPKG_R))
+        self.assertNotIn("datapages", got["core"])
+
+    def test_parser_floor_rejects_a_truncated_config(self):
+        """A file the parser can no longer read must ERROR, never pass green.
+
+        This is the test that keeps the whole check honest: without the floor,
+        a reformatted file yields empty sets that compare equal to each other.
+        """
+        truncated = "\n".join(
+            ln for ln in RPKG_R.splitlines()
+            if "item_response_warehouse_" not in ln
+        )
+        with self.assertRaises(ccp.ParseError):
+            ccp.parse_rpkg_config(self.write("redivis-config.R", truncated))
+
+
+class CompareTests(unittest.TestCase):
+    def configs(self, **overrides):
+        base = {name: dict(EXPECTED) for name in ("pipeline", "rpkg", "pypkg")}
+        for name, cfg in overrides.items():
+            base[name] = cfg
+        return base
+
+    def test_agreement_reports_nothing(self):
+        self.assertEqual(ccp.compare(self.configs()), [])
+
+    def test_missing_source_is_reported(self):
+        """The real #1733 defect: Python-pkg carried no irw_nominal for months."""
+        pypkg = {k: v for k, v in EXPECTED.items() if k != "nom"}
+        problems = ccp.compare(self.configs(pypkg=pypkg))
+        self.assertEqual(len(problems), 1)
+        self.assertIn("nom", problems[0])
+        self.assertIn("MISSING", problems[0])
+        self.assertIn("pypkg", problems[0])
+
+    def test_extra_shard_in_one_file_is_reported(self):
+        rpkg = dict(EXPECTED)
+        rpkg["core"] = EXPECTED["core"] + ["item_response_warehouse_7"]
+        problems = ccp.compare(self.configs(rpkg=rpkg))
+        self.assertEqual(len(problems), 1)
+        self.assertIn("core", problems[0])
+
+    def test_shard_order_is_compared(self):
+        """Same names, wrong order: clients would resolve tables to a stale shard."""
+        pypkg = dict(EXPECTED)
+        pypkg["text"] = list(reversed(EXPECTED["text"]))
+        problems = ccp.compare(self.configs(pypkg=pypkg))
+        self.assertEqual(len(problems), 1)
+        self.assertIn("ORDER", problems[0])
+
+    def test_unsharded_source_order_is_not_compared(self):
+        """Only `core` and `text` are shard lists; the rest are single datasets."""
+        self.assertEqual(ccp.SHARDED, ("core", "text"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1733.

The dataset list is declared once per language and nothing compared the three declarations:

| file | repo | carries |
|---|---|---|
| `metadata/redivis_config.R` | `irw` | dataset **names** only |
| `R/redivis-config.R` | `Rpkg` | names **+ version hashes** |
| `src/irw/config.py` | `Python-pkg` | names **+ version hashes** |

They drifted undetected for months — `Python-pkg` had no reference to `irw_nominal`, so that source was reachable from R and not from Python, and it was found by hand while writing ARCHITECTURE.md. **That gap is already fixed** (Python-pkg `1db679e`, released in 0.1.2); this is what would have caught it in the pull request that introduced it. All three agree today, so the check lands green.

### What it does

`metadata/check_config_parity.py` parses all three files — `ast` for `config.py`, regexes for the two `.R` files — and compares dataset **names**, with any `:refid` stripped. No imports, no Redivis, no credentials, no network; it runs in about a second.

Per the issue's scope note, this checks *presence*, not hash freshness: the three files legitimately differ in content, so byte equality would false-alarm every run, and whether the two packages pin the same hash is a separate and less clear-cut question.

Order **is** compared, but only for the sharded sources (`core`, `text`). All three files declare shards oldest-to-newest and every client searches them newest-first, so a file listing them in a different order would resolve some tables to a stale shard while every name still matched.

### Two departures from the issue as written

**It runs in `tests.yml`, not the weekly pipeline.** That proposal predates the cron being replaced by `metadata-pipeline.yml`, and its reasoning — the weekly job was the only thing with all four checkouts on disk — no longer binds: both package repos are public, so `actions/checkout` can pull them into any runner with no token. So this fails in the PR that introduces the drift rather than in the following Monday's metadata PR, which is about something else. The issue's "done when" asked for a week; this is minutes.

**`ARCHITECTURE.md`'s "Known hazard" callout now points at the check** instead of warning a human, which is what its own rule 2 asks for.

### The failure mode worth reviewing for

A vacuous pass. If a config file is reformatted past its parser and every extraction comes back empty, the three empty sets compare equal and the check reports green while comparing nothing. `MIN_DATASETS` is a per-source floor that turns that into a parse error (exit 2), and `test_parser_floor_rejects_a_truncated_config` is the test the rest of the check rests on.

### Verification

10 unit tests pass. Beyond those, I ran the checker against the real `origin/main` configs of all three repos (green) and against four injected divergences:

| injected | result |
|---|---|
| the real historical defect — Python-pkg before `1db679e`, no `NOM_REF` | exit 1, names `nom` and `Python-pkg` |
| a seventh warehouse added to `Rpkg` only | exit 1 |
| `text` shards reordered in Python only — identical names, wrong order | exit 1, flags ORDER |
| a config truncated past the regexes | exit **2**, not a green pass |

One local note: the script reads whichever working tree it is pointed at, so a stale sibling checkout reports drift that is not on main — that is how the `nom` gap read as still open here after it had been fixed and released. The docstring says so, and CI always checks both packages out fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVAQUN3mw1wCghnfSuxYds