### PR TITLE
5personalityfactors: 18 participant numbers are held by two students (#1842)

### DIFF
--- a/data/5personalityfactors.R
+++ b/data/5personalityfactors.R
@@ -1,9 +1,56 @@
+# Smits, Dolan, Vorst, Wicherts & Timmerman (2011), "Cohort differences in Big
+# Five personality factors over a period of 25 years", JPSP 100(6):1124-1138.
+# doi:10.1037/a0022874
+#
+# Source: DANS, doi:10.17026/DANS-Z5P-ZEDJ (CC0), file `data5pft19822007.tab`.
+# The dictionary still records the retired EASY URL (easy-dataset:51655), which
+# now answers with an anti-bot challenge rather than the data; the Data Station
+# DOI above is the live copy of the same deposit -- 8,954 rows, matching the
+# published table's id count. (The dictionary also records CC BY 4.0; DANS
+# states CC0-1.0.)
+#
+# `TWNO` IS NOT UNIQUE. 18 participant numbers appear twice, and all 18 are two
+# different students rather than one student recorded twice (#1842):
+#
+#   * not one of the 18 pairs is byte-identical on the whole row;
+#   * they agree on 5 to 52 of the 70 items, mostly 8-18 -- about what two
+#     unrelated people score on a 7-point scale by chance;
+#   * `cohort` and `testweek` are identical within every pair, so no occasion
+#     column explains them;
+#   * twno 16167 is explicit: sex 2 vs 1, age 18 vs 24.
+#
+# The published table used `twno` alone, so 18 pairs of students are merged into
+# one respondent each. Block H prescribed "dedupe 264, chase 996"; deduping
+# would delete 18 people. They take an occurrence suffix, as PEPABAS2C's and
+# SAS_Deters_2022's did.
+#
+# `age` also becomes `cov_age` -- a person-level covariate must carry the prefix.
+#
+# Not shipped, though the source has them and this study is *about* them:
+# `cohort` (13 values) and `testweek` (25). Adding them changes the table's
+# shape, so it is left for its own pass -- but a table built from the Smits
+# cohort study without its cohort column is missing the study's own variable.
 library(tidyverse)
 library(readr)
 
-df <- read_csv('data.csv')
+df <- read_tsv('data5pft19822007.tab', show_col_types = FALSE)
 
 names(df) <- tolower(names(df))
+
+stopifnot(anyDuplicated(df$twno) > 0)   # the collision this file exists to fix
+rep_twno <- df$twno %in% df$twno[duplicated(df$twno)]
+if (any(rep_twno)) {
+  df$twno <- as.character(df$twno)
+  ## A LETTER suffix, not ".1": `twno` is purely numeric, so "16167.1" parses
+  ## straight back to a double and reads as a decimal rather than as two people.
+  ## "16167a"/"16167b" cannot.
+  df$twno[rep_twno] <- paste0(df$twno[rep_twno],
+                              letters[ave(seq_len(sum(rep_twno)),
+                                          df$twno[rep_twno], FUN = seq_along)])
+  message(sprintf("5personalityfactors: %d participant number(s) held by two students; suffixed %d row(s)",
+                  sum(rep_twno) / 2L, sum(rep_twno)))
+}
+stopifnot(!anyDuplicated(df$twno))
 
 df <- df |>
   # rename "twono" (participant ID) variable to id
@@ -104,5 +151,19 @@ df<-as.data.frame(df)
 table(df$resp)
 df$resp<-ifelse(df$resp<1 | df$resp>7,NA,df$resp)
 table(df$resp)
+
+# A missing response is not a response. These were written out as NA and land in
+# the warehouse as the literal string "NA", which is what types `resp` as a
+# string rather than an integer (#1842).
+df <- df[!is.na(df$resp), ]
+
+# `age` is a person-level covariate and must carry the prefix; 99 is the
+# codebook's missing code for it, already mapped to -9 above.
+names(df)[names(df) == "age"] <- "cov_age"
+df$cov_age[df$cov_age == -9] <- NA
+
+stopifnot(!anyDuplicated(df[, c("id", "item")]))
+
 # save df to Rdata file
 save(df, file="5personalityfactors.Rdata")
+write.csv(df, "5personalityfactors.csv", row.names = FALSE)


### PR DESCRIPTION
Fifth block-H table, same finding as #2021 and #2023. Corrected table staged at `/tmp/here/5personalityfactors.csv`.

## Not duplication

18 of the 8,936 `twno` values appear twice, and every one of the 18 pairs is **two different students**:

- not one pair is byte-identical on the whole row;
- they agree on **5 to 52 of the 70 items**, mostly 8–18 — about what two unrelated people score on a 7-point scale by chance;
- `cohort` and `testweek` are identical within every pair, so no occasion column explains them;
- `twno` 16167 is explicit: **sex 2 vs 1, age 18 vs 24**.

Block H said "dedupe 264, chase 996". Deduping deletes 18 people.

Suffixed with a **letter** rather than `.1` — `twno` is purely numeric, so `16167.1` parses straight back to a double and reads as a decimal rather than as two people. `16167a` / `16167b` cannot.

## The source had moved

The dictionary records `easy-dataset:51655`. That URL now answers with an **anti-bot challenge**, not data — which is presumably why this was filed as needing a source nobody had. The same deposit is live at DANS Data Station, **doi:10.17026/DANS-Z5P-ZEDJ**, 8,954 rows, matching the published id count exactly. The script now names it.

Worth a dictionary fix separately: it records **CC BY 4.0**; DANS states **CC0-1.0**.

## Two more the worklist asked for

- **`age` → `cov_age`.** It was published as a bare `age` column.
- **3,675 missing responses dropped** rather than written out as `NA`. They reach the warehouse as the literal string `"NA"`, which is what types this table's `resp` as a string.

## Verified

```
5personalityfactors: 18 participant number(s) held by two students; suffixed 36 row(s)
rows 623105  ids 8954  items 70  dup id+item 0  resp 1-7  cov_age NA 0
```

Against live: 626,780 → 623,105 (**−3,675, exactly the `"NA"` rows**), ids 8,936 → 8,954 (**+18, exactly the split students**). `irw-validate`: **no errors and no warnings**.

## Not done

`cohort` (13 values) and `testweek` (25) are still dropped. This is the Smits *cohort* study — the paper is "Cohort differences in Big Five personality factors over a period of 25 years" — so a table built from it without its cohort column is missing the study's own variable. Adding them changes the table's shape, so it wants its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjpFgj7bT9GJ8UeF5hMLdE