### PR TITLE
check_config_parity: point at a runbook that has the cross-repo steps

### DIFF
--- a/metadata/check_config_parity.py
+++ b/metadata/check_config_parity.py
@@ -346,7 +346,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             "  irw          metadata/redivis_config.R\n"
             "  Rpkg         R/redivis-config.R\n"
             "  Python-pkg   src/irw/config.py\n"
-            "See Rpkg/inst/developer/warehouses.md for the full checklist.",
+            "\n"
+            "Land the two package pull requests BEFORE the irw one: this reads\n"
+            "Rpkg and Python-pkg at their default branch, so an irw change that\n"
+            "arrives first is a real disagreement and stays red until they land.\n"
+            "\n"
+            'Runbook: Rpkg/inst/developer/warehouses.md, "Adding a warehouse\n'
+            'everywhere else". Overview: ARCHITECTURE.md section 2.',
             file=sys.stderr,
         )
         return 1


### PR DESCRIPTION
Follow-up to #2027 (#1733), and a defect in it.

The parity check's failure message ended with *"See `Rpkg/inst/developer/warehouses.md` for the full checklist"* — and that checklist was the one telling maintainers to edit a single file and stop. Anyone hitting the check for the first time was sent to instructions that contradicted it.

Two companion PRs fix the guides themselves:

- `itemresponsewarehouse/Rpkg#157`
- `itemresponsewarehouse/Python-pkg#47`

This one updates the pointer to name the new section, and states the ordering the check imposes — the first question anyone seeing it red will have. The message now reads:

```
Adding or moving a dataset means editing all three files:
  irw          metadata/redivis_config.R
  Rpkg         R/redivis-config.R
  Python-pkg   src/irw/config.py

Land the two package pull requests BEFORE the irw one: this reads
Rpkg and Python-pkg at their default branch, so an irw change that
arrives first is a real disagreement and stays red until they land.

Runbook: Rpkg/inst/developer/warehouses.md, "Adding a warehouse
everywhere else". Overview: ARCHITECTURE.md section 2.
```

String change only — no logic touched. The 10 unit tests still pass, and the check is still green against the real configs.

Merge order does not matter here: this PR names a section that the two package PRs create, so merging it first leaves the pointer briefly ahead of the docs, which is strictly better than the current state of pointing at contradicting instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVAQUN3mw1wCghnfSuxYds