### PR TITLE
itemtext: name identical-vs-differing name collisions (#1962)

### DIFF
--- a/itemtext/BATCH_PROCESS.md
+++ b/itemtext/BATCH_PROCESS.md
@@ -13,7 +13,7 @@ extraction) — this file covers the batching layer. The round's own prompt is
 | `extraction_batches/queue_state.csv` | `table,status,batch,timestamp`; status is `pending`/`in_progress`/`done`/`failed`/`blocked`/`excluded`. `failed` and `blocked` are BOTH "no CSV" but mean different things and are counted differently by the circuit breaker (Step 5, ruled 2026-09-03): `failed` is a fault or an unresolved access failure that an unchanged retry might get past, and it counts; `blocked` is a determinate verdict that an unchanged retry cannot change, and it does not count. `blocked` is not permanent the way `excluded` is -- it says a HUMAN action or a data change is needed first, so these are the pool to revisit when one happens. Seeded from the AVAILABLE rows of `availability_audit_full.csv`. **The only state that must persist between rounds.** `excluded` means do not extract, ever — see the standing exclusions below. |
 | `extraction_batches/round_log.md` | One entry per round: counts, notable findings, open items. |
 | `extraction_batches/circuit_breaker.flag` | Present = a round failed >30% and the loop stopped for human review. Delete it to resume. |
-| `itemtables/batch_NNN/` | `{table}__items.csv` (validated output), `notes.csv`, `provenance.csv`, `verification_merged.csv`, `audit_report.csv`. |
+| `itemtables/batch_NNN/` | `{table}__items.csv` (validated output), `notes.csv`, `provenance.csv`, `verification_merged.csv`, `audit_report.csv`. **Batch history, not a staging area** — see the note below on why the same table appears in two of these. |
 | `mapping_verification.csv` | Permanent, cross-batch record of how each table's item↔text mapping was verified (`route`, `status`, `evidence`). One row per table, ever. Fed by each batch's `verification_merged.csv`. |
 | `itemtables/pending_index_notes.csv` | Standing cumulative log of tables that could not be automated, for the index workbook. Columns `table,note,status`; `status` is one of `pending`/`blocked`/`excluded`/`note_only`/`resolved` (see SKILL.md Step 6b). Append across batches; never reset. |
 | `itemtables/clean/` | Vetted tables staged for upload. **Only `*__items.csv` may live here** — an uploader walks recursively, and this directory exists because stray `.csv` files were once uploaded as tables. `red_up` now excludes non-`__items` files when the target is an item-text shard and names what it excluded, but keep the directory clean anyway. Ben clears it after uploading. |
@@ -22,6 +22,25 @@ Everything except `queue_state.csv` is rederived from disk each round, so a roun
 that dies partway (API limit, crash) is safely resumable — the next firing sees
 what's missing and continues. Tables left `in_progress` by a dead round need
 manual reconciliation back to `pending`.
+
+### The same table can appear in two batch directories
+
+That is expected and is **not** a bug to clean up. When a held table is released
+(a paywall resolved, an author's confirmation arriving), the releasing batch keeps
+an unchanged copy of the CSV next to its new `provenance.csv` row, so that batch
+reads on its own. `ALSECYPIAMH_WU_2022_PHQ__items.csv` is in both `batch_004` (the
+original extraction, uploaded 2026-08-16) and `batch_012` (the #1643 hold release,
+provenance updated only), byte-identical in both.
+
+The consequence for uploading: **run `red_up` against `itemtables/clean/`, never
+across `itemtables/*/`.** A run over the batch directories walks extraction history
+and hits these duplicates, which `red_up` correctly refuses — a Redivis upload
+appends, so uploading two identical files doubles the table. The refusal names
+whether the colliding files have the same bytes; identical means you are pointed at
+the wrong directory, differing means two versions are genuinely in flight.
+
+Deleting one copy to silence it is the wrong fix. irw#1962 proposed exactly that,
+and the copy it called stale was the record of the hold release.
 
 ## Standing exclusions — do NOT extract these
 

--- a/red_up/checks.py
+++ b/red_up/checks.py
@@ -13,6 +13,7 @@ header.
 from __future__ import annotations
 
 import csv
+import hashlib
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -155,8 +156,23 @@ def check_all(pairs: list[tuple[Path, str]]) -> list[FileReport]:
     where the file is going belongs in check_schema or validate_for_target.
 
     Two files with the same stem in different subdirectories would upload one
-    after the other into the same table name, and the second would silently
-    win. That is a batch-assembly mistake, so it is an error, not a warning.
+    after the other into the same table name. Because a Redivis upload APPENDS,
+    that is not "the second one wins" -- it is a doubled table. So it stays an
+    error even when the files are byte-identical, and especially then.
+
+    The message says whether the colliding files have the same content, because
+    that is the first thing anyone asks and the answer decides what to do:
+
+      - IDENTICAL content is usually not a batch-assembly mistake at all. A
+        re-issued batch keeps an unchanged copy of the CSV alongside its new
+        provenance row (see itemtext/BATCH_PROCESS.md), so the same table
+        legitimately appears in two batch directories. The fix is to point the
+        uploader at the staging directory instead of walking batch history --
+        NOT to delete either copy. irw#1962 spent its whole life on the other
+        reading, and deleting the "stale" copy there would have destroyed the
+        record of a hold release.
+      - DIFFERING content is the real batch-assembly mistake: two versions of a
+        table are in flight and someone has to say which one is right.
     """
     reports = [scan(path, table) for path, table in pairs]
 
@@ -166,8 +182,40 @@ def check_all(pairs: list[tuple[Path, str]]) -> list[FileReport]:
     for table, group in seen.items():
         if len(group) > 1:
             others = ", ".join(str(r.path) for r in group)
+            if _all_identical(r.path for r in group):
+                detail = (
+                    "byte-identical content, so this is probably batch history "
+                    "rather than two competing versions -- upload from the "
+                    "staging directory rather than deleting a copy"
+                )
+            else:
+                detail = "DIFFERING content -- decide which version is right"
             for report in group:
                 report.errors.append(
-                    f"table name '{table}' is claimed by {len(group)} files: {others}"
+                    f"table name '{table}' is claimed by {len(group)} files "
+                    f"({detail}): {others}"
                 )
     return reports
+
+
+def _all_identical(paths) -> bool:
+    """True when every path has the same bytes.
+
+    Hashes rather than compares pairwise: a collision group can be larger than
+    two, and these files run to hundreds of MB, so read each one once and in
+    chunks. An unreadable file returns False -- "cannot prove identical" is the
+    safe answer, and it keeps the caller on the louder message.
+    """
+    digests = set()
+    for path in paths:
+        digest = hashlib.sha256()
+        try:
+            with open(path, "rb") as handle:
+                for chunk in iter(lambda: handle.read(1 << 20), b""):
+                    digest.update(chunk)
+        except OSError:
+            return False
+        digests.add(digest.hexdigest())
+        if len(digests) > 1:
+            return False
+    return True

--- a/red_up/tests/test_red_up.py
+++ b/red_up/tests/test_red_up.py
@@ -325,15 +325,38 @@ class Checks(unittest.TestCase):
             path = write(Path(tmp), "Foo.csv", RESPONSE)
             self.assertTrue(any("lowercase" in w for w in scan(path, "Foo").warnings))
 
+    def _collision(self, tmp, content_a, content_b):
+        root = Path(tmp)
+        (root / "x").mkdir()
+        (root / "y").mkdir()
+        a = write(root / "x", "dup.csv", content_a)
+        b = write(root / "y", "dup.csv", content_b)
+        return check_all([(a, "dup"), (b, "dup")])
+
     def test_two_files_claiming_one_table_name_is_an_error(self):
         with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            (root / "x").mkdir()
-            (root / "y").mkdir()
-            a = write(root / "x", "dup.csv", RESPONSE)
-            b = write(root / "y", "dup.csv", RESPONSE)
-            reports = check_all([(a, "dup"), (b, "dup")])
+            reports = self._collision(tmp, RESPONSE, RESPONSE)
             self.assertTrue(all(not r.ok for r in reports))
+
+    def test_identical_collision_is_still_an_error_but_says_so(self):
+        """A Redivis upload appends, so two identical files double the table.
+
+        The message has to distinguish this case: identical content means batch
+        history, and the fix is to upload from the staging directory, never to
+        delete a copy (irw#1962).
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            reports = self._collision(tmp, RESPONSE, RESPONSE)
+            self.assertTrue(all(not r.ok for r in reports))
+            for report in reports:
+                self.assertTrue(any("byte-identical" in e for e in report.errors))
+
+    def test_differing_collision_says_the_versions_differ(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            reports = self._collision(tmp, RESPONSE, RESPONSE + "9,9,9\n")
+            self.assertTrue(all(not r.ok for r in reports))
+            for report in reports:
+                self.assertTrue(any("DIFFERING" in e for e in report.errors))
 
 
 class Planning(unittest.TestCase):


### PR DESCRIPTION
Closes #1962 — but not the way the issue proposed.

## The issue was wrong twice

**"one 8-row table has silently never shipped"** — it shipped.
`extraction_batches/queue_state.csv:38` records it `done,batch_004,2026-08-16`, and
`itemtext/language_backfill/round2/published/ALSECYPIAMH_WU_2022_PHQ__published.csv`
is an 8-row pull of the live table made by `fetch_published_itemtext.R` (which calls
`irw_itemtext()`) on 2026-09-02. You cannot read back a table that was never uploaded.

**"batch_004's copy is presumably the stale one"** — batch_012's copy is not a stray
re-extraction at all. Its `provenance.csv` row is the #1643 hold release: *"Hold
released 2026-08-26 per issue #1643 … File content unchanged from batch_004; only the
provenance and mapping_verification rows were updated."* Deleting either copy would
have destroyed a record — the original extraction, or the hold release.

The collision exists only because the accidental 2026-09-04 run walked
`itemtables/*/` — extraction history — instead of `itemtables/clean/`, the staging
directory `BATCH_PROCESS.md` says uploads run from.

## What this changes

No file is deleted. The real defect is that `red_up`'s refusal could not be told apart
from the genuine article: it said only `claimed by 2 files`, leaving a reader to md5
them by hand and, here, to guess wrong.

`check_all` now hashes the colliding group and says which case it is:

```
table name 'X' is claimed by 2 files (byte-identical content, so this is probably
batch history rather than two competing versions -- upload from the staging
directory rather than deleting a copy): …
```
```
table name 'X' is claimed by 2 files (DIFFERING content -- decide which version is
right): …
```

It stays an **error** in both cases. The old docstring said the second file would
"silently win"; a Redivis upload appends, so two identical files double the table —
which makes the identical case worse than the differing one, not benign.

`BATCH_PROCESS.md` gains the convention, which was written down nowhere: a re-issued
batch keeps an unchanged copy of the CSV, so cross-batch duplicates are expected, and
uploads run from `clean/`, never across the batch directories.

Tests: 65 pass, two new ones covering the identical and differing messages.

Leaves open the question #1962 raised in passing — nothing stops someone pointing
`red_up` at the batch tree in the first place. That is a guard on the invocation, not
on the check, and worth its own issue if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9VZXXf6xC2qaQPQFya2on