### PR TITLE
DART study 1: repair the three item codes a ja->1 find/replace corrupted (#1950)

### DIFF
--- a/data/DART_Brysbaert_2020.R
+++ b/data/DART_Brysbaert_2020.R
@@ -4,8 +4,54 @@ library(readxl)
 library(tidyr)
 library(dplyr)
 
-# -------- Process Dataset 1 -------- 
+# The deposited study-1 workbook was damaged by a global find/replace of "ja"
+# -> "1" before it was uploaded to OSF (#1950). Four of its 138 headers carry
+# the artifact, three of which become IRW item codes:
+#
+#   "... auteur- [1ne Austen]"      -> Jane Austen
+#   "... auteur- [1mes Patterson]"  -> James Patterson
+#   "... auteur- [1ne Jessup]"      -> Jane Jessup
+#   "Aantal boeken gelezen in het afgelopen 1ar-"  -> "jaar"; dropped below, so
+#                                                    it never reaches IRW
+#
+# Repaired as FIXED STRINGS rather than by reversing the find/replace. A blanket
+# "1" -> "ja" would rewrite any legitimate digit, and the point of the repair is
+# that we know these three names, not that we can invert the damage.
+#
+# The names are not reconstructed -- they are copied from
+# DART_Brysbaert_2020_3_4_5, which carries the same three people uncorrupted
+# ("Jane Austen", "James Patterson", "Jane Jessup") because studies 3-5 were
+# deposited as separate workbooks that the find/replace never touched.
+#
+# `Jane Jessup` is the one that matters most: it is one of the test's foils, a
+# non-existent author, correctly rejected by 94% of respondents. Its exact
+# string is what a reuser matches on to identify the false-alarm items, and
+# "1ne Jessup" matches nothing.
+DART1_HEADER_REPAIRS <- c(
+  "Is de volgende persoon een auteur- [1ne Austen]"     = "Is de volgende persoon een auteur- [Jane Austen]",
+  "Is de volgende persoon een auteur- [1mes Patterson]" = "Is de volgende persoon een auteur- [James Patterson]",
+  "Is de volgende persoon een auteur- [1ne Jessup]"     = "Is de volgende persoon een auteur- [Jane Jessup]"
+)
+
+repair_dart1_headers <- function(df) {
+  hit <- match(names(df), names(DART1_HEADER_REPAIRS))
+  found <- sum(!is.na(hit))
+  # Stop rather than warn if the deposit no longer needs repairing. Silently
+  # doing nothing would leave no signal that the source had changed under us,
+  # and this script is only ever run by hand against a freshly downloaded
+  # workbook -- the moment to notice is now, not after upload.
+  if (found != length(DART1_HEADER_REPAIRS)) {
+    stop("DART study 1: expected ", length(DART1_HEADER_REPAIRS),
+         " corrupted headers to repair, found ", found,
+         ". If OSF has fixed the deposit, delete DART1_HEADER_REPAIRS (#1950).")
+  }
+  names(df)[!is.na(hit)] <- DART1_HEADER_REPAIRS[hit[!is.na(hit)]]
+  df
+}
+
+# -------- Process Dataset 1 --------
 df1 <- read_excel("raw_data_study1.xlsx")
+df1 <- repair_dart1_headers(df1)
 df1 <- df1 |>
   rename(id=Toegangscode, mother_language=`Moedertaal-`, gender=`Geslacht-`, age=`Leeftijd-`)
 df1$mother_language <- ifelse(!is.na(df1$`Moedertaal- [Andere]`), df1$`Moedertaal- [Andere]`, df1$mother_language)


### PR DESCRIPTION
Closes #1950.

The deposited study-1 workbook was damaged by a global find/replace of `ja` → `1` before it reached OSF, and the ingest carried it through unchanged. `DART_Brysbaert_2020_1` serves three corrupted item identifiers today, 199 responses each:

| live item code | should be | live `p` |
|---|---|---:|
| `Is de volgende persoon een auteur- [1ne Austen]` | Jane Austen | 0.61 |
| `Is de volgende persoon een auteur- [1mes Patterson]` | James Patterson | 0.32 |
| `Is de volgende persoon een auteur- [1ne Jessup]` | Jane Jessup | **0.06** |

The fourth damaged header, `Aantal boeken gelezen in het afgelopen 1ar-` (*jaar*), is already dropped by the existing `select()`, so it never reached IRW.

### The names are copied, not reconstructed

`DART_Brysbaert_2020_3_4_5` carries **the same three people uncorrupted** — studies 3–5 were deposited as separate workbooks the find/replace never touched. Verified live: that table holds `Jane Austen`, `James Patterson` and `Jane Jessup`, and none of the three artifacts appears in it. So this is a copy from a known-good sibling rather than a guess at what the string used to be.

`Jane Jessup` is the one that matters. It is one of the test's **foils** — a non-existent author — and the live `p` of 0.06 confirms it, correctly rejected by 94% of respondents. Its exact string is what a reuser matches on to identify the false-alarm items, and `1ne Jessup` matches nothing.

### Two judgement calls

**Fixed strings, not an inverted find/replace.** A blanket `1` → `ja` would rewrite any legitimate digit. What we actually know is these three names, not how to undo the damage in general.

**It stops the run rather than warning** if the headers are ever repaired upstream. This script is only ever run by hand against a freshly downloaded workbook, so the moment to notice the source changed is before an upload, not after. Exercised both paths.

### Scope

**One table, not two.** The issue's `DART_Brysbaert_2020_*` implied the family; `_3_4_5` is clean. The "changes join keys" concern in the issue is also thinner than it looks — **zero item codes are shared between the two DART tables** today, because `_1` uses full Dutch question strings and `_3_4_5` uses bare names. Nothing joins across them to break.

### Found while verifying, filed separately

`DART_Brysbaert_2020_3_4_5` has 264 item codes that normalise to **174 names** — 90 authors appear twice, once spaced and once underscored (`Agatha Christie` / `Agatha_Christie`), split exactly on `group` (Study 5 underscored, Studies 3 and 4 spaced). Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qqi2JuwjHKusdGgrp9QMRT