### PR TITLE
README: install the Python package from PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ irw_fetch("agn_kay_2025")
 
 **Python:**
 ```bash
-python -m pip install "git+https://github.com/itemresponsewarehouse/Python-pkg.git"
+python -m pip install irw
 ```
 ```python
 import irw


### PR DESCRIPTION
`Python-pkg` has been on PyPI as [`irw`](https://pypi.org/project/irw/) since 2026-09-07 (v0.1.3). The quickstart in this README was still handing out a `git+` URL, which installs but does not upgrade — pip resolves the version from the clone, sees it installed and skips even under `--upgrade`.

One line. The R line beside it is unchanged: `Rpkg` is still GitHub-only, because `redivis` is on neither CRAN nor r-universe (re-verified 2026-09-07, `Rpkg#147`).

Y3 item 5, sub-action 5.4 — see #1707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnAPVTEVkceNBvWsyymrUf