### PR TITLE
red_up: refuse an upload root that is batch history (#2055)

### DIFF
--- a/itemtext/BATCH_PROCESS.md
+++ b/itemtext/BATCH_PROCESS.md
@@ -33,8 +33,12 @@ original extraction, uploaded 2026-08-16) and `batch_012` (the #1643 hold releas
 provenance updated only), byte-identical in both.
 
 The consequence for uploading: **run `red_up` against `itemtables/clean/`, never
-across `itemtables/*/`.** A run over the batch directories walks extraction history
-and hits these duplicates, which `red_up` correctly refuses — a Redivis upload
+across `itemtables/*/`.** Since #2055 `red_up` refuses the wrong argument outright:
+a directory holding a `provenance.csv` is batch history, and it stops before reading
+a single table. Do not reach for `--allow-history-dirs` to get past that here — the
+answer is always to stage into `clean/` first. The older, weaker backstop still
+applies when something slips through with the override: a run over the batch
+directories hits these duplicates, which `red_up` correctly refuses — a Redivis upload
 appends, so uploading two identical files doubles the table. The refusal names
 whether the colliding files have the same bytes; identical means you are pointed at
 the wrong directory, differing means two versions are genuinely in flight.

--- a/red_up/README.md
+++ b/red_up/README.md
@@ -36,6 +36,16 @@ Both response data and item text are **shard lists**, because Redivis caps a
 dataset at 1000 tables (`ARCHITECTURE.md` §2). A second item-text shard is a
 one-line edit to `IRW_TEXT_DATASETS`; nothing in this package changes.
 
+**Refuses a history tree.** A directory holding a `provenance.csv` is a record
+of a past batch, not a place uploads are staged from, and red_up stops rather
+than walking one (#2055). This is a guard on the *argument*, which the checks
+below are not: they see the files, so they only speak up when two batches
+happen to claim one table name. Point at thirty-six batches with distinct
+names and every already-shipped table uploads again — and because uploads
+append, each one **doubles**. The rule is written about the marker file, not
+about `itemtext/itemtables/`, so red_up stays general-purpose;
+`--allow-history-dirs` is there for a tree that really does stage that way.
+
 **Excludes what does not belong.** Once a dataset is chosen, files of the wrong
 kind are listed and skipped rather than uploaded. This is the guard against the
 failure `itemtext/itemtables/clean/` exists to undo: item-text batch

--- a/red_up/checks.py
+++ b/red_up/checks.py
@@ -148,6 +148,32 @@ def validate_for_target(report: FileReport, target: Target,
     report.warnings.extend(warnings)
 
 
+#: A directory holding this file is a record of an extraction, not a place
+#: uploads are staged from. Item text is where this bit us (see
+#: itemtext/BATCH_PROCESS.md: batches are history, `clean/` is staging), but
+#: the rule is stated about the marker file rather than about that path, so
+#: red_up stays general-purpose and any tree with the same convention is
+#: covered.
+HISTORY_MARKER = "provenance.csv"
+
+
+def history_dirs(csvs: list[Path]) -> list[Path]:
+    """Directories among `csvs` that are batch history rather than staging.
+
+    The collision check in `check_all` is NOT a backstop for this. It only
+    fires when two batches happen to hold the same table name; a walk over a
+    tree whose names are all distinct uploads the entire extraction history
+    without a word -- and because a Redivis upload appends, re-uploading an
+    already-shipped table doubles it rather than doing nothing (#2055).
+
+    Reported per directory rather than as a boolean: a run over `itemtables/`
+    picks up thirty-odd of them at once, and the useful message names the tree,
+    not the first file in it.
+    """
+    dirs = {p.parent for p in csvs if p.name != HISTORY_MARKER}
+    return sorted(d for d in dirs if (d / HISTORY_MARKER).is_file())
+
+
 def check_all(pairs: list[tuple[Path, str]]) -> list[FileReport]:
     """Scan every file, and flag names that collide within the batch itself.
 

--- a/red_up/cli.py
+++ b/red_up/cli.py
@@ -22,7 +22,8 @@ from pathlib import Path
 
 from . import plan as planning
 from .auth import authenticate
-from .checks import check_all, check_schema, validate_for_target
+from .checks import (HISTORY_MARKER, check_all, check_schema, history_dirs,
+                     validate_for_target)
 from .discover import Discovery, discover, table_name
 from .push import open_draft, push_one
 from .targets import (ConfigError, Target, eligible, guess_target,
@@ -184,6 +185,10 @@ def main(argv: list[str] | None = None) -> int:
                         help="skip the IRW format validator (the one check that "
                              "needs pandas). checks.py has pointed at this flag "
                              "since 2026-09-02; it did not exist until 2026-09-03")
+    parser.add_argument("--allow-history-dirs", action="store_true",
+                        help=f"upload from directories containing a "
+                             f"{HISTORY_MARKER}, which normally marks a record "
+                             f"of a past batch rather than a staging area")
     parser.add_argument("--strict", action="store_true",
                         help="treat warnings as errors and upload nothing")
     args = parser.parse_args(argv)
@@ -208,6 +213,25 @@ def main(argv: list[str] | None = None) -> int:
         where = ", ".join(str(p) for p in paths)
         die(f"no .csv files under {where}"
             + (f" ({len(found.skipped)} non-CSV files ignored)" if found.skipped else ""))
+
+    # Before anything else about the files themselves: is this tree one that
+    # uploads are staged from at all? #2055 -- a run pointed at
+    # `itemtext/itemtables/*/` instead of `itemtables/clean/` would have
+    # uploaded thirty-six batches of extraction history, most of it already
+    # shipped, and every one of those a doubled table.
+    if not args.allow_history_dirs:
+        history = history_dirs(found.csvs)
+        if history:
+            listed = "\n  ".join(str(d) for d in history[:10])
+            more = (f"\n  ... and {len(history) - 10} more"
+                    if len(history) > 10 else "")
+            die(f"{len(history)} of the directories here contain a "
+                f"{HISTORY_MARKER}, which marks a record of a past batch "
+                f"rather than a staging area:\n  {listed}{more}\n"
+                f"Upload from the staging directory instead (item text stages "
+                f"in itemtext/itemtables/clean/ -- see BATCH_PROCESS.md). "
+                f"Use --allow-history-dirs if this really is where the tables "
+                f"to upload live.")
 
     reports = check_all([(p, table_name(p)) for p in found.csvs])
 

--- a/red_up/tests/test_red_up.py
+++ b/red_up/tests/test_red_up.py
@@ -16,7 +16,8 @@ from pathlib import Path
 
 from red_up import cli
 from red_up import plan as planning
-from red_up.checks import check_all, check_schema, scan, validate_for_target
+from red_up.checks import (check_all, check_schema, history_dirs, scan,
+                          validate_for_target)
 from red_up.discover import discover, table_name
 from red_up.targets import (
     ConfigError,
@@ -357,6 +358,59 @@ class Checks(unittest.TestCase):
             self.assertTrue(all(not r.ok for r in reports))
             for report in reports:
                 self.assertTrue(any("DIFFERING" in e for e in report.errors))
+
+
+class BatchHistoryGuard(unittest.TestCase):
+    """A directory with a provenance.csv is a record, not a staging area (#2055).
+
+    The collision check is not a backstop here: it only fires when two batches
+    hold the same table name, and a walk over batches with distinct names
+    uploads the whole extraction history without a word.
+    """
+
+    def _tree(self, root: Path) -> Path:
+        """Two batch directories and one staging directory, as item text has."""
+        for batch in ("batch_001", "batch_002"):
+            (root / batch).mkdir()
+            write(root / batch, "provenance.csv", "table,batch\nt,1\n")
+            write(root / batch, f"{batch}_t__items.csv", ITEMS)
+        (root / "clean").mkdir()
+        write(root / "clean", "staged__items.csv", ITEMS)
+        return root
+
+    def test_both_batch_directories_are_named(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._tree(Path(tmp))
+            csvs = sorted(discover(root).csvs)
+            self.assertEqual(history_dirs(csvs),
+                             [root / "batch_001", root / "batch_002"])
+
+    def test_the_staging_directory_alone_is_clean(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._tree(Path(tmp))
+            self.assertEqual(history_dirs(discover(root / "clean").csvs), [])
+
+    def test_the_marker_does_not_flag_its_own_directory_by_itself(self):
+        """A lone provenance.csv is just a file the target will exclude."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            marker = write(root, "provenance.csv", "table,batch\nt,1\n")
+            self.assertEqual(history_dirs([marker]), [])
+
+    def test_the_run_stops_before_anything_is_uploaded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._tree(Path(tmp))
+            with mock.patch("sys.stderr"), self.assertRaises(SystemExit) as caught:
+                cli.main([str(root)])
+            self.assertEqual(caught.exception.code, 2)
+
+    def test_the_override_lets_a_deliberate_run_through(self):
+        sentinel = RuntimeError("reached the checks")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._tree(Path(tmp))
+            with mock.patch.object(cli, "check_all", side_effect=sentinel):
+                with self.assertRaises(RuntimeError):
+                    cli.main([str(root), "--allow-history-dirs"])
 
 
 class Planning(unittest.TestCase):


### PR DESCRIPTION
Closes #2055.

`red_up` had no guard on its *argument*. Pointed at `itemtext/itemtables/`
instead of `itemtables/clean/`, it walks thirty-six batches of extraction
history; because a Redivis upload appends, every already-shipped table it
finds there is uploaded again and **doubles**. The collision check added in
#2037 is not a backstop for this — it only fires when two batches happen to
claim the same table name, so a walk over batches with distinct names goes
through in silence.

## The guard

A directory containing a `provenance.csv` is a record of a past batch, not a
place uploads are staged from. If any discovered CSV lives in one, the run
stops before a single table is read.

Stated about the marker file rather than about `itemtext/itemtables/`, as the
issue suggested, so `red_up` stays general-purpose — no item-text path is
hard-coded and no wrapper is needed. `--allow-history-dirs` exists for a tree
that genuinely stages that way; BATCH_PROCESS.md says plainly that item text
is never that tree.

## Verification

Against the real tree, it names all 37 directories (36 batches plus `pilot/`,
the other suspected sweep) and exits 2:

    red_up: 37 of the directories here contain a provenance.csv, which marks a
    record of a past batch rather than a staging area: ...
    Upload from the staging directory instead (item text stages in
    itemtext/itemtables/clean/ -- see BATCH_PROCESS.md).

A staging-shaped directory is unaffected — a `__items.csv` dry-run still plans
normally (`ELSEWHERE -> irw_text`). Five new tests cover both batch directories
being named, staging staying clean, a lone `provenance.csv` not flagging its
own directory, exit code 2, and the override getting through. 65 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182XB7rNyU8GLLnr5QSr5in