### PR TITLE
itemtext: coerce item_text to character before strsplit (unblocks the scheduled pipeline)

### DIFF
--- a/metadata/08_itemtext.R
+++ b/metadata/08_itemtext.R
@@ -55,6 +55,10 @@ for (ii in seq_along(tables.new)) {
     cat(sprintf("[%d/%d] %s\n", ii, length(tables.new), tab))
     items <- irw::irw_itemtext(tab)
     z <- if ("item_text_translated" %in% names(items)) items$item_text_translated else items$item_text
+    # item_text arrives typed by its content: a table whose text is all bare
+    # digits (SART stimuli, say) comes back integer, and strsplit rejects a
+    # non-character argument. nchar() coerces silently; strsplit does not.
+    z         <- as.character(z)
     nw        <- lengths(strsplit(z, " "))
     nc        <- nchar(z)
     nc.option <- if ("option_text" %in% names(items)) nchar(items$option_text) else rep(NA_real_, length(z))

--- a/metadata/hotfixes/08_itemtext_recompute.R
+++ b/metadata/hotfixes/08_itemtext_recompute.R
@@ -36,6 +36,10 @@ for (ii in seq_along(lt)) {
     cat(sprintf("[%d/%d] %s\n", ii, length(lt), tab))
     items <- irw::irw_itemtext(tab)
     z <- if ("item_text_translated" %in% names(items)) items$item_text_translated else items$item_text
+    # item_text arrives typed by its content: a table whose text is all bare
+    # digits (SART stimuli, say) comes back integer, and strsplit rejects a
+    # non-character argument. nchar() coerces silently; strsplit does not.
+    z         <- as.character(z)
     nw        <- lengths(strsplit(z, " "))
     nc        <- nchar(z)
     nc.option <- if ("option_text" %in% names(items)) nchar(items$option_text) else rep(NA_real_, length(z))


### PR DESCRIPTION
The first *scheduled* run of the metadata pipeline ([34149989317](https://github.com/ben-domingue/irw/actions/runs/34149989317), 2026-09-07) failed at stage 08, table 48 of 198:

```
Error in strsplit(z, " ") : non-character argument
Calls: lengths -> strsplit
```

## Cause

`cogcontrol_gyurkovics_2019_sart` is a SART table whose item text *is* the stimulus — 18 bare digits:

| item | item_text | option_text |
|---|---|---|
| digit_5 | 5 | correct |
| digit_2 | 2 | correct |

Every value is numeric, so the column arrives typed `integer`, and `strsplit` rejects a non-character argument. The adjacent `nchar(z)` coerces silently — which is why this shows up as a hard crash rather than a quietly wrong word count.

This is a new failure, not a latent one. The loop processes `tables.new` only, and this table has no row in `itemtext_metadata.csv` yet, so the six manual runs on 2026-09-04 never reached it. It also needs item text that is *entirely* numeric; ordinary wording is unaffected. The `cogcontrol_*` family is where those stimuli live, so repeats are likely to come from there.

## Fix

`z <- as.character(z)` before the `strsplit`, in **both** copies of the loop — `metadata/08_itemtext.R:58` and `metadata/hotfixes/08_itemtext_recompute.R:39`. The hotfix script carries the identical line and would hit the identical crash the next time it runs over this table.

## Verification

Against both `cogcontrol` tables, fetched live:

```
sart    | before: ERROR | after: mean_word= 1 mean_char= 1
flanker | before: ok    | after: mean_word= 1 mean_char= 5
```

The failing table now computes; the neighbouring table, already character, is unchanged.

## Note on re-running

The workflow checks out `ref: main`, so a `workflow_dispatch` on this branch would still run main’s code. This needs to merge before a re-fire tests anything.

Separately worth a look, not addressed here: the run started at 18:01 UTC against a 13:00 slot — five hours late, well outside the ~3h lag the version-manifest job shows — and nothing distinguishes a very late scheduled run from a skipped one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUTDzTNn6wdPoNdWFNmjAz