### PR TITLE
Record emailed permission for the 115 OSF tables with no licence

### DIFF
--- a/metadata/02_biblio.R
+++ b/metadata/02_biblio.R
@@ -268,6 +268,9 @@ getrows<-function(l) {
     ## biblio carries only one licence and one reference (#1694). Fills a
     ## blank Custom_License_Terms only, so the sheet still wins the cell.
     biblio <- apply_license_attribution(biblio, name)
+    ## Blank-only fill for the OSF deposits that set no licence; the sheet
+    ## always wins, so a real licence recorded later supersedes it.
+    biblio <- apply_osf_permission(biblio, name)
     ## Same carry-through, for the paper/deposit DOI split (#1690).
     biblio <- apply_data_doi(biblio, irw_dict, name)
     ## Correct the Descriptions that name an instrument the table does not

--- a/metadata/dict_union.R
+++ b/metadata/dict_union.R
@@ -815,3 +815,71 @@ apply_license_attribution <- function(biblio, label = "core",
     message(label, ": attached second-source attribution to ", n, " row(s)")
     biblio
 }
+
+##---------------------------------------------------------------------------
+##Licence of record for the OSF deposits that state none.
+##
+##115 published tables across 23 OSF projects carry a blank `Derived_License`.
+##OSF makes setting a licence optional and defaults to none, so a blank here
+##means the DEPOSIT is silent rather than that nobody checked -- confirmed
+##directly for osf.io/3xvys, which the OSF API reports as `license: NONE SET`.
+##
+##RULING (Ben, 2026-09-07): these reached IRW under emailed permission from the
+##depositors; record them as such. That is HIS ruling written down, not
+##something this repo established -- no correspondence is cited or held here.
+##The value belongs in the Data Dictionary sheet, and this is a stopgap so that
+##users stop seeing a blank licence in the meantime.
+##
+##KEYED ON THE OSF PROJECT, not the 115 table names. A table added later from
+##the same deposit arrived under the same permission, so it should inherit it;
+##115 names would also go stale the moment one is renamed.
+##
+##BLANK-ONLY. A licence recorded in the sheet always wins, so this can never
+##overwrite a real one -- which matters for osf.io/3xvys specifically, where
+###2058 asks the depositor to set a public licence. If that lands, the sheet
+##supersedes this automatically and the entry can be deleted.
+OSF_PERMISSION_PROJECTS <- c(
+    "qtqpb",  # 19  eammi_grahe_2018_*
+    "75crd",  # 15  parentalempathy_gonzalez_2021_*
+    "4fdw9",  # 10  darkfactorfrench_pischel_2026_*
+    "rjbx2",  #  9  hachenberger_2025_*
+    "3w6ap",  #  7  kazarovytska_2026_*
+    "t3a9r",  #  7  transyouth_leshin_2026_*
+    "zevcs",  #  7  personalitychange_kramer_2025_*
+    "3xvys",  #  6  parenting_anunciacao_2025_*  -- see #2058
+    "6nm2s",  #  6  thirdpartypunishmentunfairsharing_mcauliffe_*
+    "rf9k8",  #  5  talaifar_2025_*
+    "69nwe",  #  4  smpi_lorenzoluaces_2020_*
+    "g8dvj",  #  4  morgan_2026_music_personality_*
+    "c6rqy",  #  2  christensen_2018_*
+    "gvx7s",  #  2  itemrandom_buchanan
+    "kqxd5",  #  2  west_2021_aggnet_*
+    "snmqt",  #  2  mclaughlin_samuel_2025_*
+    "umdg3",  #  2  haehner_2026_personality_subsaharan_*
+    "9cm75",  #  1  steinberg_2023_mentalizing_momentary
+    "frwq4",  #  1  kay_2025_antonyms
+    "mbywd",  #  1  west_2022_psychnet_pclsv
+    "thdf5",  #  1  vollbracht_et_al_2026_ambulatory_assessment
+    "twgcu",  #  1  schoen_2019_to_2022_mkt
+    "zajk6"   #  1  kalimahnorms_alzahrani
+)
+OSF_PERMISSION_VALUE <- "Permission via Email"
+
+apply_osf_permission <- function(biblio, label = "core",
+                                 projects = OSF_PERMISSION_PROJECTS,
+                                 value = OSF_PERMISSION_VALUE) {
+    if (!length(projects) ||
+        !all(c("URL__for_data_", "Derived_License") %in% names(biblio))) {
+        return(biblio)
+    }
+    ##`\\b` would not anchor here: OSF ids are alphanumeric, so "qtqpb" could
+    ##match a longer id starting with it. Require the id to end the path
+    ##segment instead.
+    pat <- paste0("osf\\.io/(", paste(projects, collapse = "|"), ")(/|$|[?#])")
+    hit <- grepl(pat, biblio$URL__for_data_) & dict_blank(biblio$Derived_License)
+    hit[is.na(hit)] <- FALSE
+    biblio$Derived_License[hit] <- value
+    message(label, ": set `", value, "` on ", sum(hit),
+            " OSF row(s) that had no licence")
+    biblio
+}

--- a/metadata/tests/test_dict_union.R
+++ b/metadata/tests/test_dict_union.R
@@ -651,6 +651,55 @@ local({
           "no table carries two Description overrides")
 })
 
+
+##--------------------------------------------------- OSF permission fill ---
+##A licence is the one field where a wrong value is worse than a blank, so the
+##load-bearing property is that this can only ever fill, never overwrite.
+local({
+    mk <- function(url, lic) {
+        d <- fake_biblio(biblio_row("a_2020"))
+        d$URL__for_data_ <- url; d$Derived_License <- lic; d
+    }
+    ap <- function(d) suppressMessages(apply_osf_permission(d, "core", c("qtqpb")))
+
+    check(identical(ap(mk("https://osf.io/qtqpb/", NA_character_))$Derived_License[1],
+                    "Permission via Email"),
+          "a listed OSF project with a blank licence is filled")
+
+    ##The one that matters. #2058 asks a depositor to set a public licence; when
+    ##one is recorded in the sheet it must beat this, or we would publish
+    ##"Permission via Email" over a real CC BY.
+    check(identical(ap(mk("https://osf.io/qtqpb/", "CC BY 4.0"))$Derived_License[1],
+                    "CC BY 4.0"),
+          "a recorded licence is never overwritten by the permission fill")
+
+    for (empty in list(NA_character_, "", "NA")) {
+        check(identical(ap(mk("https://osf.io/qtqpb/", empty))$Derived_License[1],
+                        "Permission via Email"),
+              paste0("the sheet's blank spelling ", dQuote(as.character(empty)),
+                     " counts as blank"))
+    }
+
+    check(identical(ap(mk("https://osf.io/zzzzz/", NA_character_))$Derived_License[1],
+                    NA_character_),
+          "an OSF project not on the list is left blank")
+    check(identical(ap(mk("https://example.org/qtqpb/", NA_character_))$Derived_License[1],
+                    NA_character_),
+          "a non-OSF url carrying the same string is not matched")
+
+    ##Ids are alphanumeric, so a prefix match would sweep in a longer id.
+    check(identical(ap(mk("https://osf.io/qtqpbXY/", NA_character_))$Derived_License[1],
+                    NA_character_),
+          "a longer id starting with a listed id is not matched")
+})
+
+local({
+    check(!anyDuplicated(OSF_PERMISSION_PROJECTS),
+          "no OSF project is listed twice")
+    check(all(grepl("^[a-z0-9]{5}$", OSF_PERMISSION_PROJECTS)),
+          "every listed OSF project id is well formed")
+})
+
 ##------------------------------------------------------------------ result ---
 cat("\n")
 if (failures > 0L) { cat(failures, "FAILURE(S)\n"); quit(status = 1L) }


### PR DESCRIPTION
Your ruling of 2026-09-07, written down.

**115 published tables across 23 OSF projects** carry a blank `Derived_License`. OSF makes setting a licence optional and defaults to none, so a blank here means the *deposit* is silent rather than that nobody checked — confirmed directly for `osf.io/3xvys`, which the OSF API reports as `license: NONE SET`.

### Three choices worth reviewing

**It says whose ruling it is.** The comment states plainly that this is your call written down rather than something the repo established, and cites no correspondence, because none is held here. I didn't want a rights field asserting an email exists that the repo can't produce.

**Keyed on the OSF project, not the 115 table names.** A table added later from the same deposit arrived under the same permission and should inherit it; a list of 115 names also goes stale the first time one is renamed. 23 entries instead of 115.

**Blank-only — this is the property that matters for a licence.** A value recorded in the sheet always wins, so this can never publish `Permission via Email` over a real licence. That is live right now for `osf.io/3xvys`, where #2058 asks the depositor to set a public one: if that lands, the sheet supersedes this automatically and the entry can just be deleted.

### Verified against the real `metadata/biblio.csv`

```
blank Derived_License : 229 -> 114   (115 filled)
all filled rows are OSF        : TRUE
no non-blank cell altered      : TRUE
rows in / out                  : 4261 / 4261
```

Ten assertions added to `tests/test_dict_union.R`. The load-bearing one is that a recorded licence is never overwritten; there's also a guard that a longer OSF id starting with a listed one isn't swept in, since OSF ids are alphanumeric and a prefix match would be wrong.

### What this does not do

**It does not reach the Data Dictionary sheet**, so `lookup_dictionary.py` and `run_audit.py` still see 115 blanks. That gap is now three mechanisms deep and is filed as **#2067** rather than left implicit.

### What remains of the 229

114 rows still have no licence: **86** national-statistics tables (Chile/Mexico/Uruguay, asked of @SamuelEnrique in #2064) and **28** others across Zenodo, openICPSR, figshare, Dataverse, SciDB, PLOS, GitHub and CRAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qqi2JuwjHKusdGgrp9QMRT