### PR TITLE
gsheet: read every dictionary column as character — restores the empty Custom_License_Terms (#1732)

### DIFF
--- a/metadata/gsheet_retry.R
+++ b/metadata/gsheet_retry.R
@@ -25,9 +25,36 @@
 ## This file deliberately defines a function called `gsheet2tbl`, masking the
 ## package's, so that existing call sites get retries without being edited --
 ## there are ten across seven scripts. Source it AFTER library(gsheet).
+##
+## It also reads EVERY column as character rather than letting readr guess.
+##
+## gsheet::gsheet2tbl hardcodes its own read_csv call and accepts no col_types,
+## so guessing was not overridable at the call sites. readr infers a column's
+## type from the first rows only, and a column that is blank there is guessed
+## `logical` -- after which every real value further down fails to parse and is
+## silently replaced with NA. The whole column arrives empty, with nothing in
+## the pipeline output to say so.
+##
+## That is not hypothetical: the dictionary sheet's second `Custom License`
+## column is blank until row 801, so all four tables carrying custom licence
+## terms (ml_harper_2015, roar_gijbels2024, nit_must_2014 and
+## bicb-j_ishiguro_2025) parsed as NA, and biblio.csv shipped
+## `Custom_License_Terms` populated on 0 rows in pipeline run 34152997615 --
+## the column #1732 exists to deliver. A `curl` of the same sheet showed all
+## four present, which is what made this a parse bug rather than a sheet one.
+##
+## Every dictionary column is text as far as this pipeline is concerned, so
+## forcing character costs nothing and closes the whole class: any sparse
+## column in any of the seven sheets was one blank prefix away from the same
+## silent emptying.
 gsheet2tbl <- function(url, ..., .attempts = 4L, .waits = c(5, 15, 45)) {
+  read_all_character <- function(url, ...) {
+    readr::read_csv(I(gsheet::gsheet2text(url, format = "csv")),
+                    col_types = readr::cols(.default = readr::col_character()),
+                    ...)
+  }
   for (i in seq_len(.attempts)) {
-    result <- try(gsheet::gsheet2tbl(url, ...), silent = TRUE)
+    result <- try(suppressMessages(read_all_character(url, ...)), silent = TRUE)
     if (!inherits(result, "try-error")) {
       if (i > 1L) message("  gsheet: succeeded on attempt ", i)
       return(result)


### PR DESCRIPTION
Pipeline run [34152997615](https://github.com/ben-domingue/irw/actions/runs/34152997615) shipped `biblio.csv` with `Custom_License_Terms` populated on **0 rows** — the column #1732 exists to deliver. All four shards agreed:

```
core: 0 row(s) carry custom licence terms
comps: 0    nom: 0    sim: 0
```

## The sheet is fine; the parse is not

A `curl` of the same gid shows all four terms present. readr guesses a column type from the leading rows, and the dictionary sheet’s second `Custom License` column is blank until row 801 — so it is guessed `logical`, and every real value below it fails to parse and is silently replaced with NA:

```
row   col  expected              actual
801   11   1/0/T/F/TRUE/FALSE    License text: Neither the University of Minnesota...
1091  11   1/0/T/F/TRUE/FALSE    https://github.com/yeatmanlab/roar-pa-manuscript/...
1164  11   1/0/T/F/TRUE/FALSE    All data uploaded to this Dataverse are licensed...
1508  11   1/0/T/F/TRUE/FALSE    CC BY-NC-ND 4.0
```

`dict_terms_column` was never at fault — it resolves to index 11 correctly. It was handed an all-NA logical vector.

## Fix

`gsheet::gsheet2tbl` hardcodes its `read_csv` call and accepts no `col_types`, so this was not overridable at the ten call sites. The retry wrapper in `gsheet_retry.R` already masks that function, so it now parses the same text itself with `cols(.default = col_character())`.

## Why this is safe across all ten call sites

Audited every sheet the pipeline reads before touching this — **not one has a numeric column**:

| sheet | ncol | parse problems | non-character columns |
|---|---|---|---|
| core | 14 | **4** | `Custom License...11` (logical) |
| comps | 14 | 0 | `Custom License` (logical), `Notes` (logical), `...14` (Date) |
| nominal | 13 | 0 | `Custom License` (logical) |
| simsyn | 13 | 0 | `Custom License` (logical) |
| tags ×2 | 13 | 0 | none |

Every non-character column is either `logical` (i.e. entirely empty) or the one unnamed comps `Date`, which nothing references — `Date` appears only in `DICT_NEVER_FILL`. No arithmetic or comparison changes behaviour. The readr `...N` name mangling that `dict_base_names` depends on is preserved.

## Verification

- `apply_custom_license_terms` goes **0 → 4** against the live sheet, naming `ml_harper_2015`, `roar_gijbels2024`, `nit_must_2014`, `bicb-j_ishiguro_2025` — the four in the #1732 baseline.
- Parse problems on the core sheet: **4 → 0**.
- `tests/test_dict_union.R` passes.

## Note

`bicb-j_ishiguro_2025` is the ND table in #2002 — the licence terms that make it a hard stop were exactly what was being dropped. And this closes a class, not one case: any sparse column in any of the seven sheets was one blank prefix away from the same silent emptying, with nothing in the pipeline output to signal it.

Once merged, the pipeline needs a re-run for `biblio.csv` to actually carry the terms; #2066 as it stands has the column empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUTDzTNn6wdPoNdWFNmjAz