### PR TITLE
Surface partial source failures; make Step 2b required, not suggested

### DIFF
--- a/automated_finding/.claude/skills/irw-automated-finding/SKILL.md
+++ b/automated_finding/.claude/skills/irw-automated-finding/SKILL.md
@@ -190,9 +190,14 @@ python irw_discover_updated.py "search term 1" "search term 2" --out runs/candid
 
 ```bash
 python irw_batch_updated.py runs/candidates.csv --limit 10 --out runs/triage_test.csv   # sanity check first
-python irw_batch_updated.py runs/candidates.csv --out runs/irw_triage.csv     # full run
-python irw_batch_updated.py runs/candidates.csv --out runs/irw_triage.csv --resume   # if interrupted
+python irw_batch_updated.py runs/candidates.csv --out runs/irw_triage.csv --retriage   # full run
+python irw_batch_updated.py runs/candidates.csv --out runs/irw_triage.csv --retriage --resume   # if interrupted
 ```
+
+**Pass `--retriage` on any scheduled or unattended run.** It chains Step 2b
+in-process over this run's `human_assistance` rows, writing
+`<out>.retriage_ha.csv`. Without it the step was reliably skipped — see
+Step 2b.
 
 - **Expect this to be slow.** Each candidate is a real network download plus
   a parse; a ~500-row candidate file has taken on the order of 2 hours
@@ -240,11 +245,24 @@ python irw_batch_updated.py runs/candidates.csv --out runs/irw_triage.csv --resu
   re-evaluate any future non-human candidate on content merits per the
   actual standard, not an invented species restriction.)
 
-## Step 2b — Retriage `human_assistance` (recommended before reviewing by hand)
+## Step 2b — Retriage `human_assistance` (REQUIRED, not optional)
+
+Normally you get this for free by passing `--retriage` to Step 2. Run it by
+hand only for a triage CSV that was produced without it:
 
 ```bash
-python irw_retriage_ha.py --input runs/irw_triage.csv --out runs/irw_retriage_ha.csv
+python irw_retriage_ha.py --input runs/irw_triage.csv --output runs/irw_retriage_ha.csv
 ```
+
+**A triage run is not finished until this has happened.** It was worded as
+"recommended" until 2026-09-07, and the scheduled routines duly skipped it
+week after week, committing triage CSVs with no `refined_flag` column at
+all. That is not a cosmetic gap: until the bucket is sub-classified, the
+`not_item_response` rows can't be dropped, the `human_review` rows can't be
+archived to `human_review/`, and the remainder can't be told apart from
+either — so the whole `human_assistance` bucket silently becomes nobody's
+job. If you are reporting on a run, "Step 2b: skipped" is a defect to state
+plainly, not a detail to omit.
 
 Sub-classifies each `human_assistance` row into `not_item_response` /
 `aggregate_continuous` / `wrong_file_selected` / `recoverable_format` /

--- a/automated_finding/README.md
+++ b/automated_finding/README.md
@@ -35,8 +35,8 @@ python irw_discover_updated.py "PHQ-9" "reading assessment" --out runs/candidate
 python irw_batch_updated.py runs/candidates.csv --limit 10 --out runs/triage_test.csv
 
 # 3. Full run — safe to interrupt and resume
-python irw_batch_updated.py runs/candidates.csv --out runs/irw_triage.csv
-python irw_batch_updated.py runs/candidates.csv --out runs/irw_triage.csv --resume
+python irw_batch_updated.py runs/candidates.csv --out runs/irw_triage.csv --retriage
+python irw_batch_updated.py runs/candidates.csv --out runs/irw_triage.csv --retriage --resume
 
 # 4. Open runs/irw_triage.csv, sort by flag ('good' first), review candidates.
 #    `good`/`worth_retrying` rows go straight to Step 2 (write a processing
@@ -125,7 +125,8 @@ After a full triage run the `human_assistance` bucket is usually large (hundreds
 of rows). Most of it is recoverable without re-downloading anything:
 
 ```bash
-python irw_retriage_ha.py --input runs/irw_triage.csv --out runs/irw_retriage_ha.csv
+python irw_retriage_ha.py --input runs/irw_triage.csv --output runs/irw_retriage_ha.csv
+# (normally unnecessary -- Step 2's --retriage chains this automatically)
 ```
 
 This reads the 400-char `reasons` strings already in the triage CSV and

--- a/automated_finding/irw_batch_updated.py
+++ b/automated_finding/irw_batch_updated.py
@@ -42,7 +42,9 @@ import re
 import csv
 import json
 import time
+import sys
 import argparse
+import subprocess
 from collections import defaultdict
 from urllib.parse import urlparse
 
@@ -750,6 +752,11 @@ def main():
                     help=f"don't consult/update {SEEN_KEYS_PATH} (the cross-run dedup "
                          "store shared with the scheduled repos routine) -- use to "
                          "deliberately re-triage a candidate, e.g. after a script fix")
+    ap.add_argument("--retriage", action="store_true",
+                    help="on finishing, run irw_retriage_ha.py over this run's "
+                         "human_assistance rows (Step 2b) and write "
+                         "<out>.retriage_ha.csv. Scheduled/unattended runs should "
+                         "always pass this -- see the note in main()")
     args = ap.parse_args()
 
     args.candidates_csv = resolve_in_path(args.candidates_csv)
@@ -775,8 +782,42 @@ def main():
     print("Work the 'good' rows first; they're sorted to the top.")
     # The queue sheet and irw_process_queue.py were retired (2026-06-24 /
     # 2026-08-12); pointing people at them was sending them to a dead end.
-    print("Refine the human_assistance rows with irw_retriage_ha.py, then")
-    print("write a per-dataset script in data/ for good / worth_retrying.")
+    print("Write a per-dataset script in data/ for good / worth_retrying.")
+
+    # Step 2b, chained rather than suggested. This used to be a one-line
+    # print telling the reader to "refine the human_assistance rows with
+    # irw_retriage_ha.py" -- and the scheduled routines simply didn't, run
+    # after run, committing triage CSVs with no refined_flag column and
+    # leaving the whole bucket unclassified (2026-09-07 is one of several).
+    # A hint that is ignored every week is not a hint that needs rewording,
+    # it needs to stop being optional: --retriage does the step in-process,
+    # and without it the reminder is now loud, names the exact command with
+    # this run's real paths, and says what is left undone.
+    n_ha = int(counts.get("human_assistance", 0))
+    if not n_ha:
+        return
+    retriage_out = os.path.splitext(args.out)[0] + ".retriage_ha.csv"
+    script = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                          "irw_retriage_ha.py")
+    cmd = [sys.executable, script, "--input", args.out, "--output", retriage_out]
+    if not args.retriage:
+        print(f"\n!! {n_ha} human_assistance row(s) are NOT yet sub-classified.",
+              file=sys.stderr)
+        print("   Step 2b is required before anyone reads this triage: without "
+              "it\n   there is no refined_flag column, so the not_item_response "
+              "rows\n   can't be dropped and the human_review rows can't be "
+              "archived.", file=sys.stderr)
+        print(f"   Run:  {' '.join(cmd)}", file=sys.stderr, flush=True)
+        return
+    print(f"\n[step 2b] retriaging {n_ha} human_assistance row(s) -> "
+          f"{retriage_out}", flush=True)
+    rc = subprocess.call(cmd)
+    if rc != 0:
+        print(f"\n!! Step 2b FAILED (exit {rc}). The triage at {args.out} is "
+              f"complete but its\n   human_assistance rows are still "
+              f"unclassified -- rerun the command above\n   before treating "
+              f"this run as done.", file=sys.stderr, flush=True)
+        sys.exit(rc)
 
 
 if __name__ == "__main__":

--- a/automated_finding/irw_discover_monthly.py
+++ b/automated_finding/irw_discover_monthly.py
@@ -456,6 +456,7 @@ def main():
         return [s for s in args.sources if s not in skip]
 
     starved = []
+    missing_by_source: dict[str, list[str]] = {}
     for term, since in since_by_term.items():
         print(f"\n[term] {term!r} (since {since})", flush=True)
         discover([term], exclude, relevance_on=True, sources=active_sources,
@@ -464,6 +465,8 @@ def main():
         missing = sorted(set(args.sources) - set(searched))
         if not searched:
             starved.append(term)
+        for src in missing:
+            missing_by_source.setdefault(src, []).append(term)
         miss_note = f"; not_searched={','.join(missing)}" if missing else ""
         append_log_rows([{
             "date": today,
@@ -489,6 +492,39 @@ def main():
         print(f"!! {len(starved)}/{len(terms)} term(s) had NO source complete a "
               f"search; their rows record 0 sources so no watermark moves: "
               f"{', '.join(starved)}", file=sys.stderr, flush=True)
+
+    # Per-source coverage. The two warnings above catch a source that failed
+    # for the WHOLE run (blocked) and a term that no source reached (starved).
+    # Neither catches the middle case: one source failing on some terms and
+    # succeeding on others. That is silent by construction -- each affected
+    # term logs an honest `not_searched=<src>` and its watermark correctly
+    # stays put, so nothing is corrupted, but nobody is told either, and the
+    # only trace is a substring buried in search_terms_log.csv.
+    #
+    # It is not hypothetical: the 2026-09-07 weekly repos run lost osf on 5 of
+    # 15 terms (self-efficacy, depression, perceived stress, work engagement,
+    # growth mindset) and reported success. A source quietly covering two
+    # thirds of a sweep, week after week, is exactly the kind of decay that
+    # only shows up much later as "discovery yield is down" with no cause
+    # attached. Print the coverage every run so a degraded source has to
+    # announce itself.
+    if missing_by_source:
+        print(f"\n!! INCOMPLETE SOURCE COVERAGE ({len(terms)} term(s) this run):",
+              file=sys.stderr, flush=True)
+        for src, terms_missed in sorted(missing_by_source.items(),
+                                        key=lambda kv: (-len(kv[1]), kv[0])):
+            shown = ', '.join(terms_missed[:8])
+            more = f", +{len(terms_missed) - 8} more" if len(terms_missed) > 8 else ""
+            print(f"   {src}: searched {len(terms) - len(terms_missed)}/{len(terms)} "
+                  f"term(s); MISSED {shown}{more}", file=sys.stderr, flush=True)
+        print("   Those terms' watermarks did not advance, so a later run "
+              "re-covers them -- but a source missing most of a run is a bug "
+              "to chase, not a transient to ignore. Re-run the missed terms "
+              "with --terms once the source is healthy.",
+              file=sys.stderr, flush=True)
+    elif args.sources:
+        print(f"Source coverage: all {len(args.sources)} source(s) completed "
+              f"all {len(terms)} term(s).", flush=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #2075. Both fixes come out of the 2026-09-07 weekly repos run, and both are the same shape: **a real problem the pipeline already knew about but never told anyone.**

## 1. Per-source coverage reporting (`irw_discover_monthly.py`)

The run already warns about two failure modes, and the design around them is careful — a source that fails is deliberately left out of the `sources=` log note so `last_run_date()` can't advance a watermark past an unqueried window. That part works.

What isn't covered is the **middle case**: one source failing on *some* terms and succeeding on others.

| case | detected? |
|---|---|
| source blocked for the whole run | ✅ `!! BLOCKED this run` |
| term reached by no source at all | ✅ `!! N/M term(s) had NO source` |
| **source fails on a subset of terms** | ❌ silent |

It's silent *by construction*: each affected term logs an honest `not_searched=osf` and correctly leaves its watermark put, so nothing is corrupted — and nothing is reported either. On 2026-09-07, OSF missed **5 of 15 terms** (`self-efficacy`, `depression`, `perceived stress`, `work engagement`, `growth mindset`) and the run reported success. The only trace was a substring buried in `search_terms_log.csv`.

That's the dangerous kind of failure: a source quietly covering two-thirds of a sweep, week after week, surfaces much later as "discovery yield is down" with no cause attached — and unlike the term-precision problem in #2075, there's no noisy output pointing at it.

Replaying the 2026-09-07 shape against the new code:

```
!! INCOMPLETE SOURCE COVERAGE (15 term(s) this run):
   osf: searched 10/15 term(s); MISSED self-efficacy, depression, perceived stress, work engagement, growth mindset
   Those terms' watermarks did not advance, so a later run re-covers them -- but a
   source missing most of a run is a bug to chase, not a transient to ignore.
```

A clean run now says so explicitly (`Source coverage: all 3 source(s) completed all 15 term(s).`), so silence stops being ambiguous.

## 2. Step 2b stops being optional (`irw_batch_updated.py --retriage`)

The end of a triage run already printed *"Refine the human_assistance rows with irw_retriage_ha.py"*, and SKILL.md titled the step *"recommended before reviewing by hand"*. The scheduled routines duly skipped it, run after run, committing triage CSVs with no `refined_flag` column.

A hint that's ignored every week doesn't need rewording — it needs to stop being optional. `--retriage` chains Step 2b in-process, writing `<out>.retriage_ha.csv`. Without the flag, the reminder is now loud, names the exact command with the run's real paths, and says what's left undone.

This matters more than it sounds: until the bucket is sub-classified, `not_item_response` rows can't be dropped, `human_review` rows can't be archived to `human_review/`, and the rest can't be told apart from either — so the whole `human_assistance` bucket silently becomes nobody's job.

Verified end-to-end against this week's three real HA rows: chains correctly and classifies 1 `recoverable_format` / 2 `human_review`. Both branches (flag present / absent) tested, including the non-zero exit when the chained step fails.

Also fixes the Step 2b examples in SKILL.md and README, which passed `--out` to a script whose flag is `--output` — it worked only as an argparse prefix match.

## Note on the routines themselves

These fixes land in the scripts and the skill, which is the leverage I have from here. The six standing cloud routines aren't editable from this session — but they invoke the skill, so the retitled Step 2b and the `--retriage` recipe should reach them. Worth confirming on next Sunday's run that the triage output has a `refined_flag` column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTiUnhWADzfgbMGMGGAtXm