### PR TITLE
DART studies 3-5: one code per author, and a gate that sees it (#2052)

### DIFF
--- a/data/DART_Brysbaert_2020.R
+++ b/data/DART_Brysbaert_2020.R
@@ -92,11 +92,66 @@ for (artist in names(df5)[-1]) {
 }
 df5 <-  pivot_longer(df5, cols=-c(id), names_to='item', values_to='resp')
 
+# -------- Item-code convention --------
+# Studies 3 and 4 take `item` from a `Name` COLUMN in their workbooks, which
+# spells authors the way the deposit does ("Agatha Christie", "Jean M. Auel").
+# Study 5 has no such column: its authors are column HEADERS, pivoted into
+# `item` below, and that workbook renders the same names lossily -- spaces
+# become underscores ("Agatha_Christie"), middle-initial periods are dropped
+# ("Jean M Auel"), and double spaces collapse. Nothing reconciled the two before
+# bind_rows(), so the pooled table carried both renderings and 106 of its 158
+# authors appeared twice, once per convention, from disjoint samples (#2052).
+# The issue reported 90; that count saw only the underscored pairs. Six more
+# differ by a dropped middle-initial period or a collapsed double space, and ten
+# by initials run together ("J.K. Rowling" / "JK Rowling") -- 106 in all.
+#
+# No id+item key ever repeated, so no duplicate check could see it. The effect
+# was that an IRT model fitted to the pooled table estimated those 106 people
+# twice, as unrelated items -- for 106 of 158 authors the pooling this table
+# exists for silently did not happen.
+#
+# The repair maps each study-5 code onto the studies-3/4 spelling of the same
+# name, rather than picking a rendering of our own: that column is the deposit's
+# own and is what two of the three studies already shipped. Matching is on a
+# LETTERS-AND-DIGITS-ONLY key: the study-5 workbook does not merely swap one
+# separator for another, it deletes them ("J.K. Rowling" is spelled "JK
+# Rowling"), so a key that treated the period as a separator still missed ten
+# authors. Dropping every non-alphanumeric character and casefolding catches all
+# 106. That is safe here because these codes are personal names: the near-misses
+# the DART deliberately contains stay distinct under it ("Susan Smith" vs the
+# real "Susan Smit"), and the assertions below fail loudly if that stops holding.
+# Whitespace runs are collapsed in the output because a double space is not
+# information.
+#
+# A study-5 author with NO counterpart in studies 3 and 4 is one of the 25
+# replacements the paper's Study 5 section introduces (Haruki Murakami, Jeff
+# Kinney, ...). Those keep their own name, de-underscored.
+#
+# This runs AFTER study 5's answer-key lookup, which is keyed on the raw
+# underscored headers; normalising earlier would break all 132 of its joins.
+squash_ws     <- function(x) trimws(gsub("[[:space:]]+", " ", x))
+variant_key   <- function(x) tolower(gsub("[^[:alnum:]]", "", x))
+
+canon_names   <- squash_ws(unique(c(df3$item, df4$item)))
+canon_by_key  <- setNames(canon_names, variant_key(canon_names))
+
+canonicalise_item <- function(x) {
+  x   <- squash_ws(gsub("_", " ", x, fixed = TRUE))
+  hit <- canon_by_key[variant_key(x)]
+  ifelse(is.na(hit), x, hit)
+}
+
 stacked_df <- bind_rows(
   df3 %>% mutate(group = "Study 3"),
   df4 %>% mutate(group = "Study 4"),
   df5 %>% mutate(group = "Study 5")
-)
+) %>% mutate(item = canonicalise_item(item))
+
+# The pooling is only real if the renderings actually collapse onto each other,
+# and merging codes must not silently create a repeated id+item key. Assert both
+# rather than trust them.
+stopifnot(!any(duplicated(variant_key(unique(stacked_df$item)))))
+stopifnot(!any(duplicated(stacked_df[, c("id", "item")])))
 
 save(stacked_df, file="DART_Brysbaert_2020_3&4&5.Rdata")
 write.csv(stacked_df, "DART_Brysbaert_2020_3&4&5.csv", row.names=FALSE)

--- a/irw_validate/core.py
+++ b/irw_validate/core.py
@@ -202,7 +202,8 @@ def validate_frame(df, *, label: str = "", profile: str = "upload",
         for finding in (extra.check_name(table)
                         + extra.check_shape(df, table)
                         + extra.check_cov_range(df, table)
-                        + extra.check_resp_dtype(df, table)):
+                        + extra.check_resp_dtype(df, table)
+                        + extra.check_item_variants(df, table)):
             report.checks_run.append(finding.check)
             report.findings.append(finding)
 

--- a/irw_validate/extra.py
+++ b/irw_validate/extra.py
@@ -149,3 +149,93 @@ def check_resp_dtype(df: pd.DataFrame, table: str = "") -> list:
             "would upload as a string column. Coerce before writing.",
             table=table, group="core")]
     return []
+
+
+#: Separator characters that different source workbooks use interchangeably for
+#: the same item, and the digit runs that must NOT be merged across.
+_SEPARATORS = re.compile(r"[\s_\-.]+")
+_NON_ALNUM = re.compile(r"[^0-9A-Za-z]+")
+_DIGIT_RUN = re.compile(r"\d+")
+
+
+def _separator_key(item: str) -> str:
+    """Treat any run of separators as one, ignore case.
+
+    Substitutes rather than deletes, so "item_1_2" and "item_12" stay distinct:
+    collapsing those would be a false positive on every table that numbers its
+    items.
+    """
+    return _SEPARATORS.sub("\x00", item.strip()).casefold()
+
+
+def _squashed_key(item: str) -> str | None:
+    """Drop every non-alphanumeric character. `None` where that is unsafe.
+
+    Needed because a workbook does not only swap one separator for another, it
+    deletes them: `DART_Brysbaert_2020_3_4_5` spells "J.K. Rowling" as "JK
+    Rowling", which no separator-substituting key can match.
+
+    Guarded by the digit runs, which is what keeps "item_1_2" from merging into
+    "item_12": codes whose digit sequences differ are never compared this way.
+    A code carrying no digits at all -- the personal-name case this comes from
+    -- is always safe.
+    """
+    return _NON_ALNUM.sub("", item).casefold() + "|" + ",".join(_DIGIT_RUN.findall(item))
+
+
+def check_item_variants(df: pd.DataFrame, table: str = "") -> list:
+    """Two item codes that are renderings of one item (#2052).
+
+    Nothing else in the suite can see this. `dup_id_item` cannot, because the
+    whole defect is that the two codes are *different* -- no id+item key ever
+    repeats. The whole-row duplicate sweep cannot either. Yet the effect is that
+    one real item is estimated twice, from disjoint samples, as two unrelated
+    items.
+
+    `DART_Brysbaert_2020_3_4_5` is the case this comes from: studies 3 and 4
+    read author names from a workbook column ("Agatha Christie", "J.K.
+    Rowling"), study 5 pivoted them out of column headers ("Agatha_Christie",
+    "JK Rowling"), and nothing reconciled the two before the studies were
+    pooled. 106 of its 158 authors were doubled -- 264 codes in the published
+    table. That was introduced by our own ingest rather than carried in from the
+    deposit, which is why it belongs in the uploader rather than in triage.
+
+    Warn rather than error: like `dup_id_item` and `cov_range` before it, this
+    describes tables that are already published, and a blocking gate would stop
+    unrelated work on the strength of a defect nobody has triaged yet.
+    """
+    if "item" not in df.columns or df.empty:
+        return []
+    items = [str(v) for v in pd.Series(df["item"]).dropna().unique()]
+    if not items:
+        return []
+
+    groups: dict = {}
+    for keyfn in (_separator_key, _squashed_key):
+        buckets: dict = {}
+        for item in items:
+            buckets.setdefault(keyfn(item), []).append(item)
+        for members in buckets.values():
+            if len(members) > 1:
+                groups[tuple(sorted(members))] = sorted(members)
+
+    # A pair caught by both keys is one finding, not two.
+    merged: list = []
+    for members in sorted(groups.values()):
+        if not any(set(members) <= set(m) for m in merged):
+            merged = [m for m in merged if not set(m) < set(members)]
+            merged.append(members)
+    if not merged:
+        return []
+
+    doubled = sum(len(m) - 1 for m in merged)
+    examples = "; ".join(" || ".join(m) for m in merged[:3])
+    return [Finding(
+        "item_variants", "warn",
+        f"{len(merged)} item(s) appear under more than one code differing only "
+        f"in punctuation, spacing or case, so {len(items)} codes describe "
+        f"{len(items) - doubled} items: {examples}"
+        f"{' ...' if len(merged) > 3 else ''}. An IRT model fits each rendering "
+        "as a separate item (#2052). Normalise the codes in the processing "
+        "script.",
+        table=table, group="core")]

--- a/irw_validate/tests/test_item_variants.py
+++ b/irw_validate/tests/test_item_variants.py
@@ -1,0 +1,75 @@
+"""`check_item_variants` -- two codes that are renderings of one item (#2052).
+
+The false-positive guards are the point of this file. The check exists to catch
+a workbook that spells one author two ways, and the way it could go wrong is
+merging two items a table numbers apart ("item_1_2" and "item_12"), which would
+be a far worse defect than the one it fixes.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from irw_validate.extra import check_item_variants  # noqa: E402
+
+
+def _flag(items) -> bool:
+    df = pd.DataFrame({"id": range(len(items)), "item": list(items),
+                       "resp": [1] * len(items)})
+    return bool(check_item_variants(df, "t"))
+
+
+class ItemVariants(unittest.TestCase):
+
+    def test_flags_separator_style(self):
+        # The DART case: same name, space vs underscore.
+        self.assertTrue(_flag(["Agatha Christie", "Agatha_Christie"]))
+
+    def test_flags_case_only(self):
+        self.assertTrue(_flag(["Q1", "q1"]))
+
+    def test_flags_deleted_separator(self):
+        # Study 5 does not swap the period for a space, it deletes it.
+        self.assertTrue(_flag(["J.K. Rowling", "JK Rowling"]))
+
+    def test_flags_collapsed_double_space(self):
+        self.assertTrue(_flag(["Jorge  Remache", "Jorge Remache"]))
+
+    def test_keeps_numbered_items_apart(self):
+        # The guard that matters: these are two items, not one rendering.
+        self.assertFalse(_flag(["item_1_2", "item_12"]))
+
+    def test_keeps_regrouped_digits_apart(self):
+        self.assertFalse(_flag(["a1b2", "a12b"]))
+
+    def test_keeps_near_miss_names_apart(self):
+        # The DART's foils are deliberate near-misses of real authors; merging
+        # them would invert an item. "Susan Smith" is a typo for "Susan Smit"
+        # per the paper, but that is a ruling, not something a key may assume.
+        self.assertFalse(_flag(["Susan Smit", "Susan Smith"]))
+
+    def test_clean_table_is_silent(self):
+        self.assertFalse(_flag(["sbq1", "sbq2", "sbq3", "sbq4"]))
+
+    def test_no_item_column(self):
+        self.assertEqual(check_item_variants(pd.DataFrame({"id": [1]}), "t"), [])
+
+    def test_empty_frame(self):
+        self.assertEqual(
+            check_item_variants(pd.DataFrame({"id": [], "item": []}), "t"), [])
+
+    def test_counts_are_reported(self):
+        items = ["A B", "A_B", "C D", "C_D", "E"]
+        df = pd.DataFrame({"id": range(5), "item": items, "resp": [1] * 5})
+        msg = check_item_variants(df, "t")[0].message
+        self.assertIn("2 item(s)", msg)
+        self.assertIn("5 codes describe 3 items", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2052. The corrected table is **uploaded to `item_response_warehouse:next` and verified**; it awaits a release.

## The defect

`DART_Brysbaert_2020_3_4_5` exists to pool three studies. For **106 of its 158 authors the pooling silently did not happen** — the published table carries **264** item codes.

Studies 3 and 4 take `item` from a `Name` column in their workbooks; study 5 has no such column, so its authors are column *headers* pivoted into `item`. The two workbooks render the same name differently, and nothing reconciled them before `bind_rows()`:

```
Agatha Christie          ||  Agatha_Christie          (90 pairs)
Jean M. Auel             ||  Jean M Auel              ( 6 pairs)
Jorge Eudoro  Remache    ||  Jorge Eudoro Remache
J.K. Rowling             ||  JK Rowling               (10 pairs)
```

No `id`+`item` key ever repeats — the two codes are *different*, which is the whole defect — so `dup_id_item`, the #1816 whole-row sweep, and everything else in the suite are blind to it. An IRT model fitted to the pooled table estimates those 106 people twice, from disjoint samples, as unrelated items.

**The issue reported 90.** That count looked only for underscores. Six more pairs differ by a dropped middle-initial period or a collapsed double space, and ten by initials run together. The `item_variants` check in this PR is what found the extra 16 — it was run against its own output, and reported the fix incomplete.

## The repair

Study 5's codes are mapped onto the studies-3/4 spelling rather than a rendering of our own: that column is the deposit's own, and is what two of the three studies already shipped.

Matching is on a **letters-and-digits key**, because study 5 does not swap one separator for another, it deletes them — `J.K. Rowling` is spelled `JK Rowling`, which no separator-substituting key can match.

It runs *after* study 5's answer-key lookup, which is keyed on the raw underscored headers; normalising earlier would break all 132 of its joins.

## Verification

Rebuilt from the OSF deposit (`osf.io/u4vhs`, CC BY-NC-SA 4.0 — the licence already recorded in `biblio`). The unmodified script was run first and reproduced the published table exactly (28,908 rows, 219 ids, 264 items, group split 11,220 / 9,504 / 8,184), so the source is sound and the defect is ours.

| | published | rebuilt |
|---|---:|---:|
| rows | 28,908 | 28,908 |
| ids | 219 | 219 |
| **item codes** | **264** | **158** |
| underscored codes | 132 | 0 |
| duplicate `id`+`item` | 0 | 0 |

`id`, `resp` and `group` are byte-identical — this is a pure relabel, no response moved. Merging codes created no `id`+`item` collision, confirming the issue's finding that no respondent ever saw both spellings. The script now asserts both facts rather than trusting them.

Two independent corroborations that the *wider* fix is right:

- the 26 study-5 codes left unmatched are exactly the paper's 25 replacement authors (Study 5 section) plus `Susan Smith`;
- `Susan Smith` stays correctly distinct from the real `Susan Smit`. The DART deliberately contains near-miss foils, so a key that merged those would invert an item.

Confirmed on the draft after upload: `n_rows 28908, n_items 158, n_ids 219, underscored 0`.

## The gate

`irw_validate` grows `item_variants`. On the published table it reports `264 codes describe 158 items, 106 doubled`; on the rebuild, nothing.

It **warns rather than errors**, following `dup_id_item` and `cov_range` for the same reason: it describes tables that are already live, and a blocking gate would stop unrelated work on a defect nobody has triaged.

Two keys, the second guarded by digit runs, so `item_1_2` and `item_12` are **never** merged — that false positive would be a worse defect than the one being fixed. Eleven tests, including that guard and the `Susan Smit`/`Susan Smith` case.

Worth noting where this belongs: unlike #1950's `ja`→`1` damage, which was carried in from the deposit, this was introduced by our own ingest. That is why the check goes in the uploader rather than in triage.

## Not fixed here

The rebuild does not touch the **124 `NA` responses**, and they are worth their own issue. They are not missing data — they are real answers destroyed by a failed answer-key lookup in study 5, on two items that are 100% `NA` for all 62 respondents:

- `Susan_Smith` — the key workbook has `Susan_Smit`. The paper (footnote 3) calls this a typo for the author Susan Smit, so the `AUT` code is settled by evidence; 62 responses are recoverable.
- `Geronimo_Stilton` — the key has no entry, carrying an unmatched `Paulo_Coelho` instead. The paper says the slot was replaced by Coelho *after* these 62 people answered, and that Stilton "is a character rather than an author". That argues `NON`, but the slot was built as an author item. **Undetermined by the deposit — needs a ruling, not an inference.**

Separately: `resp` is a **string** column on both the published table and the draft, and those 124 are the literal `"NA"`. This makes the table a member of #2029's population that nothing had connected to it, and a clean illustration of that issue's blind spot — `check_resp_dtype` only fires when *every* value parses as a number, so the one token that breaks the column is the one that suppresses the check.

Refs #2052, #1950, #2029.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcHvUri46uBE2Zrotqu2AA
