### PR TITLE
Run the straggler watch as pipeline stage 12 (#1940)

### DIFF
--- a/.claude/skills/irw-site-update/scripts/run_pipeline.sh
+++ b/.claude/skills/irw-site-update/scripts/run_pipeline.sh
@@ -44,10 +44,27 @@
 # that date -- deliberate, and why the file is a history rather than a table
 # keyed on date.
 #
-# 12_stragglers.R is still NOT wired in. It is not an oversight repeated: unlike
-# 11 it must call Redivis (its question is which live tables are absent from
-# metadata.csv, so metadata.csv cannot be the catalog), and nothing yet consumes
-# its output. See #1940.
+# 12_stragglers.R (issue #1940, added 2026-09-08) runs after 11 and before 09.
+# It names tables that are live on Redivis and have had no metadata.csv row for
+# several runs. A table missing for one run is NORMAL -- 01 carries a
+# refresh.per.run throttle, and #1704 established that a snapshot count of
+# missing metadata measures throttle position, not pipeline health. So it alerts
+# on a NAMED table that has PERSISTED, never on a count, which is why it needs
+# cross-run memory: straggler_watch.tsv (table, first_seen, last_seen, cycles),
+# git-tracked for the same .tsv reason 11_status.R documents.
+#
+# Two things make it unlike 11:
+#
+#   * it MUST call Redivis (irw::irw_list_tables) -- the question is which live
+#     tables are absent from metadata.csv, so metadata.csv cannot be its own
+#     catalog. `--live-from FILE` is the offline escape hatch.
+#   * it EXITS 1 when a table is stuck. Under `set -e` that would abort the run
+#     and take 09 with it, turning a report into an outage. Hence ADVISORY_STAGE
+#     above: the exit is caught, recorded and surfaced, never fatal.
+#
+# Its --min-live guard (default 1000) refuses to touch the watch file when the
+# live fetch comes back short, so a truncated Redivis read cannot erase the
+# history that makes "persisted" meaningful. Leave it on.
 #
 # 08_itemtext.R (readability-stats metadata for item text) joined the
 # default order 2026-08-02. Split of responsibility, confirmed with Ben:
@@ -64,11 +81,12 @@
 # variant, see above) are out of scope per Ben (2026-07-27) -- ignored.
 #
 # Usage:
-#   scripts/run_pipeline.sh                 # full default sequence (01 02 03 05 06 07 08 10 11 09)
+#   scripts/run_pipeline.sh                 # full default sequence (01 02 03 05 06 07 08 10 11 12 09)
 #   scripts/run_pipeline.sh 01 03           # only metadata.csv + tags.csv
 #   scripts/run_pipeline.sh 08              # just the itemtext metadata stage
 #   scripts/run_pipeline.sh 10              # just the collections tables
 #   scripts/run_pipeline.sh 11              # just the corpus status numbers
+#   scripts/run_pipeline.sh 12              # just the straggler watch
 #   scripts/run_pipeline.sh --no-09         # everything except the hero JSON
 #
 # Requires: Redivis credentials configured externally (per root CLAUDE.md;
@@ -109,7 +127,16 @@ fi
 declare -A STAGE_SCRIPT=( [01]=01_metadata.R [02]=02_biblio.R [03]=03_tags.R
                           [05]=05_comps.R [06]=06_nominal.R [07]=07_simsyn.R
                           [08]=08_itemtext.R [10]=10_collections.R
-                          [11]=11_status.R [09]=09_hero_status.R )
+                          [11]=11_status.R [12]=12_stragglers.R
+                          [09]=09_hero_status.R )
+
+# Stages whose non-zero exit is a FINDING, not a failure. 12 exits 1 when a
+# table has been stuck for several runs -- that is the report doing its job, and
+# under `set -e` it would otherwise abort the run and take 09 down with it. The
+# run loop tolerates the exit and records it; the workflow turns it into a line
+# in the pull request body. Nothing else may be added here without the same
+# argument: a stage that can fail silently is worse than one that stops the run.
+declare -A ADVISORY_STAGE=( [12]=1 )
 # CSVs each stage is expected to touch (space-separated), for snapshot/diff.
 declare -A STAGE_OUTPUTS=(
   [01]="metadata.csv"
@@ -121,9 +148,10 @@ declare -A STAGE_OUTPUTS=(
   [08]="itemtext_metadata.csv"
   [10]="collections.csv collection_members.csv"
   [11]=""   # writes status.json + status_history.tsv -- reported separately below
+  [12]=""   # writes straggler_watch.tsv -- reported separately below
   [09]=""   # writes JSON, not a keyed CSV -- reported separately below
 )
-DEFAULT_ORDER=(01 02 03 05 06 07 08 10 11 09)
+DEFAULT_ORDER=(01 02 03 05 06 07 08 10 11 12 09)
 
 # Join key for the diff, per output file. Everything is keyed on `table` except
 # the two collections outputs (issue #1633): the registry is one row per
@@ -170,6 +198,7 @@ for stage in "${stages[@]}"; do
 done
 
 cd "$METADATA_DIR"
+ADVISORY_HIT=()
 for stage in "${stages[@]}"; do
   [[ -z "$stage" ]] && continue
   script="${STAGE_SCRIPT[$stage]:-}"
@@ -179,7 +208,23 @@ for stage in "${stages[@]}"; do
   fi
   echo ""
   echo "== Stage $stage: Rscript $script =="
-  Rscript "$script"
+  if [[ -n "${ADVISORY_STAGE[$stage]:-}" ]]; then
+    # Markers, not just an exit code: the workflow lifts what is between them
+    # into the pull request body, so the named tables travel with the review
+    # rather than being buried in a 40kB log tail.
+    echo "--- ADVISORY $stage BEGIN ---"
+    set +e
+    Rscript "$script"
+    stage_rc=$?
+    set -e
+    echo "--- ADVISORY $stage END ---"
+    if [[ $stage_rc -ne 0 ]]; then
+      echo "advisory: stage $stage exited $stage_rc -- a finding, not a failed run."
+      ADVISORY_HIT+=("$stage")
+    fi
+  else
+    Rscript "$script"
+  fi
 
   # Diff THIS stage's outputs immediately, not batched at the end -- if a
   # later stage fails, set -e aborts the script, and a batched-at-the-end
@@ -208,6 +253,13 @@ for stage in "${stages[@]}"; do
     python3 "$SCRIPT_DIR/diff_csv.py" "$SNAPSHOT_DIR/$f" "$METADATA_DIR/$f" \
       --key "${DIFF_KEY[$f]:-table}"
   done
+  if [[ "$stage" == "12" ]]; then
+    echo "straggler_watch.tsv rewritten -- table, first_seen, last_seen, cycles."
+    echo "A row here is a table live on Redivis with no metadata.csv row. That is"
+    echo "NORMAL while 01's refresh throttle works through the backlog; what is not"
+    echo "normal is the same table still there several runs later, which is the only"
+    echo "thing this stage reports."
+  fi
   if [[ "$stage" == "11" ]]; then
     echo "status.json rewritten and one row appended to status_history.tsv --"
     echo "neither is a keyed CSV, so read them directly. The number to check is"
@@ -221,5 +273,9 @@ for stage in "${stages[@]}"; do
 done
 
 echo ""
+if [[ ${#ADVISORY_HIT[@]} -gt 0 ]]; then
+  echo "Advisory stage(s) reported a finding: ${ADVISORY_HIT[*]} -- see above."
+  echo ""
+fi
 echo "Done. Nothing here uploads to Redivis or touches irw_site -- review the"
 echo ".diff.csv files above, then merge into Redivis / commit by hand."

--- a/.github/workflows/metadata-pipeline.yml
+++ b/.github/workflows/metadata-pipeline.yml
@@ -170,6 +170,25 @@ jobs:
             echo "   canonicalisation has regressed (see canonicalize_csv.py) -- do not"
             echo "   try to read it, file it as a bug."
             echo
+            echo "## Straggler watch"
+            echo
+            # Stage 12 names tables live on Redivis with no metadata.csv row for
+            # several runs. run_pipeline.sh brackets its output so the named
+            # tables reach the reviewer here rather than only inside the 40kB log
+            # tail below -- a finding nobody reads is not a finding. Its exit 1
+            # is advisory and does not fail the job; see ADVISORY_STAGE in
+            # run_pipeline.sh.
+            if grep -q -- "--- ADVISORY 12 BEGIN ---" pipeline.log; then
+              # Fenced: the straggler block is aligned plain text and markdown
+              # would eat its indentation.
+              echo '```'
+              sed -n '/--- ADVISORY 12 BEGIN ---/,/--- ADVISORY 12 END ---/p' pipeline.log \
+                | sed '1d;$d'
+              echo '```'
+            else
+              echo "_Stage 12 did not run._"
+            fi
+            echo
             echo "Known noise, safe to skim: \`collections.csv\` definitions rewrite"
             echo "themselves most runs because they embed live coverage counts in their"
             echo "prose. \`n_tables\` is the field there that means something."


### PR DESCRIPTION
Task A of #1940, and the last piece of the weekly side. No new runner: stage 12 rides inside the existing `metadata-pipeline.yml`.

## What it reports

Tables live on Redivis with no `metadata.csv` row for several runs. One run missing is **normal** — `01_metadata.R` throttles how many tables it describes per run, and #1704 established that a snapshot count of missing metadata measures throttle position, not pipeline health. Alerting on that count trains everyone to ignore the alert.

So it alerts on a **named table that has persisted**, never a count, keeping cross-run memory in `straggler_watch.tsv`.

## The part worth reviewing: it exits 1 on purpose

`run_pipeline.sh` runs under `set -e`. A stuck table would therefore abort the weekly run and take stage 09 with it — turning a report into an outage.

This adds `ADVISORY_STAGE`, a one-entry list of stages whose non-zero exit is a **finding, not a failure**. The exit is caught, named in the run summary, and never fatal. The comment says what the bar is for adding a second entry, because a stage that can fail silently is worse than one that stops the run.

The workflow then lifts the stage's output into the PR body between the markers `run_pipeline.sh` emits, so a named stuck table reaches the reviewer rather than being buried in the 40kB log tail.

## Verification

| | |
|---|---|
| three cycles, synthetic missing table | recorded `cycles=1` exit 0; flagged by name and exit 1 on the third |
| probe stage that always exits 1, via orchestrator | reported `advisory: stage 12 exited 1 -- a finding, not a failed run`, orchestrator exited **0** |
| PR-body extraction | `sed` range tested against a realistic log, fenced so the aligned text survives markdown |
| one real run against live Redivis | 4,237 live, 4,238 described, no stragglers |

The `--min-live` guard (default 1000) is left on: a truncated Redivis read refuses to touch the watch file rather than erasing the history that makes "persisted" meaningful.

`irw::irw_list_tables` is already installed in this workflow for `audit_tables.R`, so no dependency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9FqQ35TkthWeT5pPRTHHt