### PR TITLE
fix(enem): filter absentees by INEP's presence flag, drop annulled items (#1942)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,6 +130,16 @@ jobs:
             --rpkg  _deps/Rpkg/R/redivis-config.R \
             --pypkg _deps/Python-pkg/src/irw/config.py
 
+      # The ENEM post-scoring checks (#1942). Base R only -- no microdata, no
+      # network -- so the thresholds that decide whether a 45-million-row table
+      # is publishable are exercised on every PR rather than only when someone
+      # has 13 years of INEP files on disk. The test that matters is the
+      # false-positive one: a legitimately HARD form must still pass, because
+      # difficulty alone must never fail a build.
+      - name: enem scoring checks
+        working-directory: data
+        run: Rscript tests/test_enem_checks.R
+
   # A PR to data/ contains a conversion SCRIPT, never a table --
   # automated_finding/irw_output/ is gitignored, so no output is ever in the
   # diff. This checks the script's contract; the data is checked by

--- a/data/enem_2013.R
+++ b/data/enem_2013.R
@@ -8,6 +8,20 @@ regular_prova_codes  <- c(167, 170, 171, 174, 176, 177, 178, 180, 181, 182, 189,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# the five that are actual answers; anything else in TX_GABARITO is not scorable
+ANSWER_KEYS <- c("A", "B", "C", "D", "E")
+
+# INEP's own per-area presence flag: 0 = absent, 1 = present, 2 = eliminated
+PRESENCE_COLS <- paste0("TP_PRESENCA_", c("CN", "CH", "LC", "MT"))
+
+# post-scoring sanity checks (#1942 finding 3). Resolved relative to THIS file
+# because the year scripts run with the microdata work dir as cwd, not data/.
+.enem_dir <- {
+  a <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+  if (length(a)) dirname(sub("^--file=", "", a[1])) else "."
+}
+source(file.path(.enem_dir, "enem_checks.R"))
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -20,17 +34,44 @@ resul  <- find_ci(data_dir, sprintf("^RESULTADOS_%s\\.csv$", year))
 if (file.exists(single)) {
   microdata <- vroom(single, delim = ";",
                      col_select = list(id = NU_INSCRICAO, tp_lingua = TP_LINGUA,
-                                       starts_with("CO_PROVA"), starts_with("TX_RESPOSTAS")),
-                     show_col_types = FALSE) |> drop_na()
+                                       starts_with("CO_PROVA"), starts_with("TP_PRESENCA"),
+                                       starts_with("TX_RESPOSTAS")),
+                     show_col_types = FALSE)
 } else if (file.exists(partic) && file.exists(resul)) {
   p <- vroom(partic, delim = ";", col_select = list(id = NU_INSCRICAO), show_col_types = FALSE)
   r <- vroom(resul, delim = ";",
              col_select = list(tp_lingua = TP_LINGUA, starts_with("CO_PROVA"),
-                               starts_with("TX_RESPOSTAS")),
+                               starts_with("TP_PRESENCA"), starts_with("TX_RESPOSTAS")),
              show_col_types = FALSE)
   stopifnot(nrow(p) == nrow(r))
-  microdata <- bind_cols(p, r) |> drop_na()
+  microdata <- bind_cols(p, r)
 } else stop(sprintf("No microdata found in %s", data_dir))
+
+# ---- absence filter (#1942) -------------------------------------------------
+# INEP encodes absence in TX_RESPOSTAS differently by year: all dots in 2013 and
+# 2014, an empty string from 2015 on. vroom reads "" as NA, so the drop_na() that
+# used to sit on the load silently removed absentees from 2015 on and kept them in
+# 2013/2014 -- where every "." was then scored 0. 31.1% of 2013 CH candidates came
+# out with a full block of zeros, which is coding, not ability.
+#
+# Filter on INEP's own flag instead, so every year behaves alike. Only presence 1
+# is kept, in all four areas: candidates INEP records as absent (0) or eliminated
+# (2) never enter the 1M sample. Verified per year in enem/fix1942_run that this
+# is exactly the set drop_na() already kept for 2015-2025, so those tables are
+# unchanged; 2013 and 2014 are the years that move.
+#
+# "." and "*" are still scored 0 for candidates who DID sit. That is INEP's own
+# scoring, and once absentees are gone it is only 0.2-0.5% of cells. resp_raw
+# ships alongside resp, so an analysis that wants them missing can do that itself.
+stopifnot(all(PRESENCE_COLS %in% names(microdata)))
+n_all <- nrow(microdata)
+keep <- rep(TRUE, n_all)
+for (.p in PRESENCE_COLS) keep <- keep & !is.na(microdata[[.p]]) & microdata[[.p]] == 1
+microdata <- microdata[keep, setdiff(names(microdata), PRESENCE_COLS), drop = FALSE]
+cat(sprintf("[%s] present in all four areas: %d of %d (%.4f)\n",
+            year, nrow(microdata), n_all, nrow(microdata) / n_all))
+microdata <- microdata |> drop_na()
+cat(sprintf("[%s] after drop_na(): %d\n", year, nrow(microdata)))
 
 # regular examinees, then 1M subsample
 regular_ids <- microdata$id[microdata$CO_PROVA_CH %in% regular_prova_codes]
@@ -45,6 +86,20 @@ items <- vroom(find_ci(data_dir, sprintf("^ITENS_PROVA_%s\\.csv$", year)), delim
                col_select = list(subj = SG_AREA, item = CO_ITEM, position = CO_POSICAO,
                                  booklet = CO_PROVA, key = TX_GABARITO, item_lingua = TP_LINGUA),
                show_col_types = FALSE)
+# ---- annulled items (#1942) -------------------------------------------------
+# INEP records TX_GABARITO "X" for an item it annulled after the exam. No response
+# letter can equal "X", so the item scores 0 for every candidate: a zero-variance
+# column that is useless for IRT and, downstream, indistinguishable from a keying
+# failure. Ten such items sit in the standard sets across 2018-2025. Drop them
+# before the item set is built, so they never reach a published table.
+.ann <- items |> filter(!key %in% ANSWER_KEYS) |> distinct(subj, item, key)
+if (nrow(.ann) > 0) {
+  cat(sprintf("[%s] dropping %d annulled item(s) (TX_GABARITO not A-E): %s\n",
+              year, nrow(.ann),
+              paste(sprintf("%s:%s(key=%s)", .ann$subj, .ann$item, .ann$key), collapse = ", ")))
+  items <- items |> filter(key %in% ANSWER_KEYS)
+}
+
 standard_items <- items |> filter(booklet %in% standard_prova_codes) |> distinct(subj, item)
 std_set <- function(area) standard_items$item[standard_items$subj == area]
 
@@ -138,6 +193,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2014.R
+++ b/data/enem_2014.R
@@ -8,6 +8,20 @@ regular_prova_codes  <- c(195, 198, 199, 202, 204, 205, 206, 208, 209, 210, 217,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# the five that are actual answers; anything else in TX_GABARITO is not scorable
+ANSWER_KEYS <- c("A", "B", "C", "D", "E")
+
+# INEP's own per-area presence flag: 0 = absent, 1 = present, 2 = eliminated
+PRESENCE_COLS <- paste0("TP_PRESENCA_", c("CN", "CH", "LC", "MT"))
+
+# post-scoring sanity checks (#1942 finding 3). Resolved relative to THIS file
+# because the year scripts run with the microdata work dir as cwd, not data/.
+.enem_dir <- {
+  a <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+  if (length(a)) dirname(sub("^--file=", "", a[1])) else "."
+}
+source(file.path(.enem_dir, "enem_checks.R"))
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -20,17 +34,44 @@ resul  <- find_ci(data_dir, sprintf("^RESULTADOS_%s\\.csv$", year))
 if (file.exists(single)) {
   microdata <- vroom(single, delim = ";",
                      col_select = list(id = NU_INSCRICAO, tp_lingua = TP_LINGUA,
-                                       starts_with("CO_PROVA"), starts_with("TX_RESPOSTAS")),
-                     show_col_types = FALSE) |> drop_na()
+                                       starts_with("CO_PROVA"), starts_with("TP_PRESENCA"),
+                                       starts_with("TX_RESPOSTAS")),
+                     show_col_types = FALSE)
 } else if (file.exists(partic) && file.exists(resul)) {
   p <- vroom(partic, delim = ";", col_select = list(id = NU_INSCRICAO), show_col_types = FALSE)
   r <- vroom(resul, delim = ";",
              col_select = list(tp_lingua = TP_LINGUA, starts_with("CO_PROVA"),
-                               starts_with("TX_RESPOSTAS")),
+                               starts_with("TP_PRESENCA"), starts_with("TX_RESPOSTAS")),
              show_col_types = FALSE)
   stopifnot(nrow(p) == nrow(r))
-  microdata <- bind_cols(p, r) |> drop_na()
+  microdata <- bind_cols(p, r)
 } else stop(sprintf("No microdata found in %s", data_dir))
+
+# ---- absence filter (#1942) -------------------------------------------------
+# INEP encodes absence in TX_RESPOSTAS differently by year: all dots in 2013 and
+# 2014, an empty string from 2015 on. vroom reads "" as NA, so the drop_na() that
+# used to sit on the load silently removed absentees from 2015 on and kept them in
+# 2013/2014 -- where every "." was then scored 0. 31.1% of 2013 CH candidates came
+# out with a full block of zeros, which is coding, not ability.
+#
+# Filter on INEP's own flag instead, so every year behaves alike. Only presence 1
+# is kept, in all four areas: candidates INEP records as absent (0) or eliminated
+# (2) never enter the 1M sample. Verified per year in enem/fix1942_run that this
+# is exactly the set drop_na() already kept for 2015-2025, so those tables are
+# unchanged; 2013 and 2014 are the years that move.
+#
+# "." and "*" are still scored 0 for candidates who DID sit. That is INEP's own
+# scoring, and once absentees are gone it is only 0.2-0.5% of cells. resp_raw
+# ships alongside resp, so an analysis that wants them missing can do that itself.
+stopifnot(all(PRESENCE_COLS %in% names(microdata)))
+n_all <- nrow(microdata)
+keep <- rep(TRUE, n_all)
+for (.p in PRESENCE_COLS) keep <- keep & !is.na(microdata[[.p]]) & microdata[[.p]] == 1
+microdata <- microdata[keep, setdiff(names(microdata), PRESENCE_COLS), drop = FALSE]
+cat(sprintf("[%s] present in all four areas: %d of %d (%.4f)\n",
+            year, nrow(microdata), n_all, nrow(microdata) / n_all))
+microdata <- microdata |> drop_na()
+cat(sprintf("[%s] after drop_na(): %d\n", year, nrow(microdata)))
 
 # regular examinees, then 1M subsample
 regular_ids <- microdata$id[microdata$CO_PROVA_CH %in% regular_prova_codes]
@@ -45,6 +86,20 @@ items <- vroom(find_ci(data_dir, sprintf("^ITENS_PROVA_%s\\.csv$", year)), delim
                col_select = list(subj = SG_AREA, item = CO_ITEM, position = CO_POSICAO,
                                  booklet = CO_PROVA, key = TX_GABARITO, item_lingua = TP_LINGUA),
                show_col_types = FALSE)
+# ---- annulled items (#1942) -------------------------------------------------
+# INEP records TX_GABARITO "X" for an item it annulled after the exam. No response
+# letter can equal "X", so the item scores 0 for every candidate: a zero-variance
+# column that is useless for IRT and, downstream, indistinguishable from a keying
+# failure. Ten such items sit in the standard sets across 2018-2025. Drop them
+# before the item set is built, so they never reach a published table.
+.ann <- items |> filter(!key %in% ANSWER_KEYS) |> distinct(subj, item, key)
+if (nrow(.ann) > 0) {
+  cat(sprintf("[%s] dropping %d annulled item(s) (TX_GABARITO not A-E): %s\n",
+              year, nrow(.ann),
+              paste(sprintf("%s:%s(key=%s)", .ann$subj, .ann$item, .ann$key), collapse = ", ")))
+  items <- items |> filter(key %in% ANSWER_KEYS)
+}
+
 standard_items <- items |> filter(booklet %in% standard_prova_codes) |> distinct(subj, item)
 std_set <- function(area) standard_items$item[standard_items$subj == area]
 
@@ -138,6 +193,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2015.R
+++ b/data/enem_2015.R
@@ -8,6 +8,20 @@ regular_prova_codes  <- c(231, 234, 235, 238, 240, 241, 242, 244, 245, 246, 253,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# the five that are actual answers; anything else in TX_GABARITO is not scorable
+ANSWER_KEYS <- c("A", "B", "C", "D", "E")
+
+# INEP's own per-area presence flag: 0 = absent, 1 = present, 2 = eliminated
+PRESENCE_COLS <- paste0("TP_PRESENCA_", c("CN", "CH", "LC", "MT"))
+
+# post-scoring sanity checks (#1942 finding 3). Resolved relative to THIS file
+# because the year scripts run with the microdata work dir as cwd, not data/.
+.enem_dir <- {
+  a <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+  if (length(a)) dirname(sub("^--file=", "", a[1])) else "."
+}
+source(file.path(.enem_dir, "enem_checks.R"))
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -20,17 +34,44 @@ resul  <- find_ci(data_dir, sprintf("^RESULTADOS_%s\\.csv$", year))
 if (file.exists(single)) {
   microdata <- vroom(single, delim = ";",
                      col_select = list(id = NU_INSCRICAO, tp_lingua = TP_LINGUA,
-                                       starts_with("CO_PROVA"), starts_with("TX_RESPOSTAS")),
-                     show_col_types = FALSE) |> drop_na()
+                                       starts_with("CO_PROVA"), starts_with("TP_PRESENCA"),
+                                       starts_with("TX_RESPOSTAS")),
+                     show_col_types = FALSE)
 } else if (file.exists(partic) && file.exists(resul)) {
   p <- vroom(partic, delim = ";", col_select = list(id = NU_INSCRICAO), show_col_types = FALSE)
   r <- vroom(resul, delim = ";",
              col_select = list(tp_lingua = TP_LINGUA, starts_with("CO_PROVA"),
-                               starts_with("TX_RESPOSTAS")),
+                               starts_with("TP_PRESENCA"), starts_with("TX_RESPOSTAS")),
              show_col_types = FALSE)
   stopifnot(nrow(p) == nrow(r))
-  microdata <- bind_cols(p, r) |> drop_na()
+  microdata <- bind_cols(p, r)
 } else stop(sprintf("No microdata found in %s", data_dir))
+
+# ---- absence filter (#1942) -------------------------------------------------
+# INEP encodes absence in TX_RESPOSTAS differently by year: all dots in 2013 and
+# 2014, an empty string from 2015 on. vroom reads "" as NA, so the drop_na() that
+# used to sit on the load silently removed absentees from 2015 on and kept them in
+# 2013/2014 -- where every "." was then scored 0. 31.1% of 2013 CH candidates came
+# out with a full block of zeros, which is coding, not ability.
+#
+# Filter on INEP's own flag instead, so every year behaves alike. Only presence 1
+# is kept, in all four areas: candidates INEP records as absent (0) or eliminated
+# (2) never enter the 1M sample. Verified per year in enem/fix1942_run that this
+# is exactly the set drop_na() already kept for 2015-2025, so those tables are
+# unchanged; 2013 and 2014 are the years that move.
+#
+# "." and "*" are still scored 0 for candidates who DID sit. That is INEP's own
+# scoring, and once absentees are gone it is only 0.2-0.5% of cells. resp_raw
+# ships alongside resp, so an analysis that wants them missing can do that itself.
+stopifnot(all(PRESENCE_COLS %in% names(microdata)))
+n_all <- nrow(microdata)
+keep <- rep(TRUE, n_all)
+for (.p in PRESENCE_COLS) keep <- keep & !is.na(microdata[[.p]]) & microdata[[.p]] == 1
+microdata <- microdata[keep, setdiff(names(microdata), PRESENCE_COLS), drop = FALSE]
+cat(sprintf("[%s] present in all four areas: %d of %d (%.4f)\n",
+            year, nrow(microdata), n_all, nrow(microdata) / n_all))
+microdata <- microdata |> drop_na()
+cat(sprintf("[%s] after drop_na(): %d\n", year, nrow(microdata)))
 
 # regular examinees, then 1M subsample
 regular_ids <- microdata$id[microdata$CO_PROVA_CH %in% regular_prova_codes]
@@ -45,6 +86,20 @@ items <- vroom(find_ci(data_dir, sprintf("^ITENS_PROVA_%s\\.csv$", year)), delim
                col_select = list(subj = SG_AREA, item = CO_ITEM, position = CO_POSICAO,
                                  booklet = CO_PROVA, key = TX_GABARITO, item_lingua = TP_LINGUA),
                show_col_types = FALSE)
+# ---- annulled items (#1942) -------------------------------------------------
+# INEP records TX_GABARITO "X" for an item it annulled after the exam. No response
+# letter can equal "X", so the item scores 0 for every candidate: a zero-variance
+# column that is useless for IRT and, downstream, indistinguishable from a keying
+# failure. Ten such items sit in the standard sets across 2018-2025. Drop them
+# before the item set is built, so they never reach a published table.
+.ann <- items |> filter(!key %in% ANSWER_KEYS) |> distinct(subj, item, key)
+if (nrow(.ann) > 0) {
+  cat(sprintf("[%s] dropping %d annulled item(s) (TX_GABARITO not A-E): %s\n",
+              year, nrow(.ann),
+              paste(sprintf("%s:%s(key=%s)", .ann$subj, .ann$item, .ann$key), collapse = ", ")))
+  items <- items |> filter(key %in% ANSWER_KEYS)
+}
+
 standard_items <- items |> filter(booklet %in% standard_prova_codes) |> distinct(subj, item)
 std_set <- function(area) standard_items$item[standard_items$subj == area]
 
@@ -138,6 +193,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2016.R
+++ b/data/enem_2016.R
@@ -8,6 +8,20 @@ regular_prova_codes  <- c(291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# the five that are actual answers; anything else in TX_GABARITO is not scorable
+ANSWER_KEYS <- c("A", "B", "C", "D", "E")
+
+# INEP's own per-area presence flag: 0 = absent, 1 = present, 2 = eliminated
+PRESENCE_COLS <- paste0("TP_PRESENCA_", c("CN", "CH", "LC", "MT"))
+
+# post-scoring sanity checks (#1942 finding 3). Resolved relative to THIS file
+# because the year scripts run with the microdata work dir as cwd, not data/.
+.enem_dir <- {
+  a <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+  if (length(a)) dirname(sub("^--file=", "", a[1])) else "."
+}
+source(file.path(.enem_dir, "enem_checks.R"))
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -20,17 +34,44 @@ resul  <- find_ci(data_dir, sprintf("^RESULTADOS_%s\\.csv$", year))
 if (file.exists(single)) {
   microdata <- vroom(single, delim = ";",
                      col_select = list(id = NU_INSCRICAO, tp_lingua = TP_LINGUA,
-                                       starts_with("CO_PROVA"), starts_with("TX_RESPOSTAS")),
-                     show_col_types = FALSE) |> drop_na()
+                                       starts_with("CO_PROVA"), starts_with("TP_PRESENCA"),
+                                       starts_with("TX_RESPOSTAS")),
+                     show_col_types = FALSE)
 } else if (file.exists(partic) && file.exists(resul)) {
   p <- vroom(partic, delim = ";", col_select = list(id = NU_INSCRICAO), show_col_types = FALSE)
   r <- vroom(resul, delim = ";",
              col_select = list(tp_lingua = TP_LINGUA, starts_with("CO_PROVA"),
-                               starts_with("TX_RESPOSTAS")),
+                               starts_with("TP_PRESENCA"), starts_with("TX_RESPOSTAS")),
              show_col_types = FALSE)
   stopifnot(nrow(p) == nrow(r))
-  microdata <- bind_cols(p, r) |> drop_na()
+  microdata <- bind_cols(p, r)
 } else stop(sprintf("No microdata found in %s", data_dir))
+
+# ---- absence filter (#1942) -------------------------------------------------
+# INEP encodes absence in TX_RESPOSTAS differently by year: all dots in 2013 and
+# 2014, an empty string from 2015 on. vroom reads "" as NA, so the drop_na() that
+# used to sit on the load silently removed absentees from 2015 on and kept them in
+# 2013/2014 -- where every "." was then scored 0. 31.1% of 2013 CH candidates came
+# out with a full block of zeros, which is coding, not ability.
+#
+# Filter on INEP's own flag instead, so every year behaves alike. Only presence 1
+# is kept, in all four areas: candidates INEP records as absent (0) or eliminated
+# (2) never enter the 1M sample. Verified per year in enem/fix1942_run that this
+# is exactly the set drop_na() already kept for 2015-2025, so those tables are
+# unchanged; 2013 and 2014 are the years that move.
+#
+# "." and "*" are still scored 0 for candidates who DID sit. That is INEP's own
+# scoring, and once absentees are gone it is only 0.2-0.5% of cells. resp_raw
+# ships alongside resp, so an analysis that wants them missing can do that itself.
+stopifnot(all(PRESENCE_COLS %in% names(microdata)))
+n_all <- nrow(microdata)
+keep <- rep(TRUE, n_all)
+for (.p in PRESENCE_COLS) keep <- keep & !is.na(microdata[[.p]]) & microdata[[.p]] == 1
+microdata <- microdata[keep, setdiff(names(microdata), PRESENCE_COLS), drop = FALSE]
+cat(sprintf("[%s] present in all four areas: %d of %d (%.4f)\n",
+            year, nrow(microdata), n_all, nrow(microdata) / n_all))
+microdata <- microdata |> drop_na()
+cat(sprintf("[%s] after drop_na(): %d\n", year, nrow(microdata)))
 
 # regular examinees, then 1M subsample
 regular_ids <- microdata$id[microdata$CO_PROVA_CH %in% regular_prova_codes]
@@ -45,6 +86,20 @@ items <- vroom(find_ci(data_dir, sprintf("^ITENS_PROVA_%s\\.csv$", year)), delim
                col_select = list(subj = SG_AREA, item = CO_ITEM, position = CO_POSICAO,
                                  booklet = CO_PROVA, key = TX_GABARITO, item_lingua = TP_LINGUA),
                show_col_types = FALSE)
+# ---- annulled items (#1942) -------------------------------------------------
+# INEP records TX_GABARITO "X" for an item it annulled after the exam. No response
+# letter can equal "X", so the item scores 0 for every candidate: a zero-variance
+# column that is useless for IRT and, downstream, indistinguishable from a keying
+# failure. Ten such items sit in the standard sets across 2018-2025. Drop them
+# before the item set is built, so they never reach a published table.
+.ann <- items |> filter(!key %in% ANSWER_KEYS) |> distinct(subj, item, key)
+if (nrow(.ann) > 0) {
+  cat(sprintf("[%s] dropping %d annulled item(s) (TX_GABARITO not A-E): %s\n",
+              year, nrow(.ann),
+              paste(sprintf("%s:%s(key=%s)", .ann$subj, .ann$item, .ann$key), collapse = ", ")))
+  items <- items |> filter(key %in% ANSWER_KEYS)
+}
+
 standard_items <- items |> filter(booklet %in% standard_prova_codes) |> distinct(subj, item)
 std_set <- function(area) standard_items$item[standard_items$subj == area]
 
@@ -138,6 +193,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2017.R
+++ b/data/enem_2017.R
@@ -8,6 +8,20 @@ regular_prova_codes  <- c(391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# the five that are actual answers; anything else in TX_GABARITO is not scorable
+ANSWER_KEYS <- c("A", "B", "C", "D", "E")
+
+# INEP's own per-area presence flag: 0 = absent, 1 = present, 2 = eliminated
+PRESENCE_COLS <- paste0("TP_PRESENCA_", c("CN", "CH", "LC", "MT"))
+
+# post-scoring sanity checks (#1942 finding 3). Resolved relative to THIS file
+# because the year scripts run with the microdata work dir as cwd, not data/.
+.enem_dir <- {
+  a <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+  if (length(a)) dirname(sub("^--file=", "", a[1])) else "."
+}
+source(file.path(.enem_dir, "enem_checks.R"))
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -20,17 +34,44 @@ resul  <- find_ci(data_dir, sprintf("^RESULTADOS_%s\\.csv$", year))
 if (file.exists(single)) {
   microdata <- vroom(single, delim = ";",
                      col_select = list(id = NU_INSCRICAO, tp_lingua = TP_LINGUA,
-                                       starts_with("CO_PROVA"), starts_with("TX_RESPOSTAS")),
-                     show_col_types = FALSE) |> drop_na()
+                                       starts_with("CO_PROVA"), starts_with("TP_PRESENCA"),
+                                       starts_with("TX_RESPOSTAS")),
+                     show_col_types = FALSE)
 } else if (file.exists(partic) && file.exists(resul)) {
   p <- vroom(partic, delim = ";", col_select = list(id = NU_INSCRICAO), show_col_types = FALSE)
   r <- vroom(resul, delim = ";",
              col_select = list(tp_lingua = TP_LINGUA, starts_with("CO_PROVA"),
-                               starts_with("TX_RESPOSTAS")),
+                               starts_with("TP_PRESENCA"), starts_with("TX_RESPOSTAS")),
              show_col_types = FALSE)
   stopifnot(nrow(p) == nrow(r))
-  microdata <- bind_cols(p, r) |> drop_na()
+  microdata <- bind_cols(p, r)
 } else stop(sprintf("No microdata found in %s", data_dir))
+
+# ---- absence filter (#1942) -------------------------------------------------
+# INEP encodes absence in TX_RESPOSTAS differently by year: all dots in 2013 and
+# 2014, an empty string from 2015 on. vroom reads "" as NA, so the drop_na() that
+# used to sit on the load silently removed absentees from 2015 on and kept them in
+# 2013/2014 -- where every "." was then scored 0. 31.1% of 2013 CH candidates came
+# out with a full block of zeros, which is coding, not ability.
+#
+# Filter on INEP's own flag instead, so every year behaves alike. Only presence 1
+# is kept, in all four areas: candidates INEP records as absent (0) or eliminated
+# (2) never enter the 1M sample. Verified per year in enem/fix1942_run that this
+# is exactly the set drop_na() already kept for 2015-2025, so those tables are
+# unchanged; 2013 and 2014 are the years that move.
+#
+# "." and "*" are still scored 0 for candidates who DID sit. That is INEP's own
+# scoring, and once absentees are gone it is only 0.2-0.5% of cells. resp_raw
+# ships alongside resp, so an analysis that wants them missing can do that itself.
+stopifnot(all(PRESENCE_COLS %in% names(microdata)))
+n_all <- nrow(microdata)
+keep <- rep(TRUE, n_all)
+for (.p in PRESENCE_COLS) keep <- keep & !is.na(microdata[[.p]]) & microdata[[.p]] == 1
+microdata <- microdata[keep, setdiff(names(microdata), PRESENCE_COLS), drop = FALSE]
+cat(sprintf("[%s] present in all four areas: %d of %d (%.4f)\n",
+            year, nrow(microdata), n_all, nrow(microdata) / n_all))
+microdata <- microdata |> drop_na()
+cat(sprintf("[%s] after drop_na(): %d\n", year, nrow(microdata)))
 
 # regular examinees, then 1M subsample
 regular_ids <- microdata$id[microdata$CO_PROVA_CH %in% regular_prova_codes]
@@ -45,6 +86,20 @@ items <- vroom(find_ci(data_dir, sprintf("^ITENS_PROVA_%s\\.csv$", year)), delim
                col_select = list(subj = SG_AREA, item = CO_ITEM, position = CO_POSICAO,
                                  booklet = CO_PROVA, key = TX_GABARITO, item_lingua = TP_LINGUA),
                show_col_types = FALSE)
+# ---- annulled items (#1942) -------------------------------------------------
+# INEP records TX_GABARITO "X" for an item it annulled after the exam. No response
+# letter can equal "X", so the item scores 0 for every candidate: a zero-variance
+# column that is useless for IRT and, downstream, indistinguishable from a keying
+# failure. Ten such items sit in the standard sets across 2018-2025. Drop them
+# before the item set is built, so they never reach a published table.
+.ann <- items |> filter(!key %in% ANSWER_KEYS) |> distinct(subj, item, key)
+if (nrow(.ann) > 0) {
+  cat(sprintf("[%s] dropping %d annulled item(s) (TX_GABARITO not A-E): %s\n",
+              year, nrow(.ann),
+              paste(sprintf("%s:%s(key=%s)", .ann$subj, .ann$item, .ann$key), collapse = ", ")))
+  items <- items |> filter(key %in% ANSWER_KEYS)
+}
+
 standard_items <- items |> filter(booklet %in% standard_prova_codes) |> distinct(subj, item)
 std_set <- function(area) standard_items$item[standard_items$subj == area]
 
@@ -138,6 +193,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2018.R
+++ b/data/enem_2018.R
@@ -8,6 +8,20 @@ regular_prova_codes  <- c(447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# the five that are actual answers; anything else in TX_GABARITO is not scorable
+ANSWER_KEYS <- c("A", "B", "C", "D", "E")
+
+# INEP's own per-area presence flag: 0 = absent, 1 = present, 2 = eliminated
+PRESENCE_COLS <- paste0("TP_PRESENCA_", c("CN", "CH", "LC", "MT"))
+
+# post-scoring sanity checks (#1942 finding 3). Resolved relative to THIS file
+# because the year scripts run with the microdata work dir as cwd, not data/.
+.enem_dir <- {
+  a <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+  if (length(a)) dirname(sub("^--file=", "", a[1])) else "."
+}
+source(file.path(.enem_dir, "enem_checks.R"))
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -20,17 +34,44 @@ resul  <- find_ci(data_dir, sprintf("^RESULTADOS_%s\\.csv$", year))
 if (file.exists(single)) {
   microdata <- vroom(single, delim = ";",
                      col_select = list(id = NU_INSCRICAO, tp_lingua = TP_LINGUA,
-                                       starts_with("CO_PROVA"), starts_with("TX_RESPOSTAS")),
-                     show_col_types = FALSE) |> drop_na()
+                                       starts_with("CO_PROVA"), starts_with("TP_PRESENCA"),
+                                       starts_with("TX_RESPOSTAS")),
+                     show_col_types = FALSE)
 } else if (file.exists(partic) && file.exists(resul)) {
   p <- vroom(partic, delim = ";", col_select = list(id = NU_INSCRICAO), show_col_types = FALSE)
   r <- vroom(resul, delim = ";",
              col_select = list(tp_lingua = TP_LINGUA, starts_with("CO_PROVA"),
-                               starts_with("TX_RESPOSTAS")),
+                               starts_with("TP_PRESENCA"), starts_with("TX_RESPOSTAS")),
              show_col_types = FALSE)
   stopifnot(nrow(p) == nrow(r))
-  microdata <- bind_cols(p, r) |> drop_na()
+  microdata <- bind_cols(p, r)
 } else stop(sprintf("No microdata found in %s", data_dir))
+
+# ---- absence filter (#1942) -------------------------------------------------
+# INEP encodes absence in TX_RESPOSTAS differently by year: all dots in 2013 and
+# 2014, an empty string from 2015 on. vroom reads "" as NA, so the drop_na() that
+# used to sit on the load silently removed absentees from 2015 on and kept them in
+# 2013/2014 -- where every "." was then scored 0. 31.1% of 2013 CH candidates came
+# out with a full block of zeros, which is coding, not ability.
+#
+# Filter on INEP's own flag instead, so every year behaves alike. Only presence 1
+# is kept, in all four areas: candidates INEP records as absent (0) or eliminated
+# (2) never enter the 1M sample. Verified per year in enem/fix1942_run that this
+# is exactly the set drop_na() already kept for 2015-2025, so those tables are
+# unchanged; 2013 and 2014 are the years that move.
+#
+# "." and "*" are still scored 0 for candidates who DID sit. That is INEP's own
+# scoring, and once absentees are gone it is only 0.2-0.5% of cells. resp_raw
+# ships alongside resp, so an analysis that wants them missing can do that itself.
+stopifnot(all(PRESENCE_COLS %in% names(microdata)))
+n_all <- nrow(microdata)
+keep <- rep(TRUE, n_all)
+for (.p in PRESENCE_COLS) keep <- keep & !is.na(microdata[[.p]]) & microdata[[.p]] == 1
+microdata <- microdata[keep, setdiff(names(microdata), PRESENCE_COLS), drop = FALSE]
+cat(sprintf("[%s] present in all four areas: %d of %d (%.4f)\n",
+            year, nrow(microdata), n_all, nrow(microdata) / n_all))
+microdata <- microdata |> drop_na()
+cat(sprintf("[%s] after drop_na(): %d\n", year, nrow(microdata)))
 
 # regular examinees, then 1M subsample
 regular_ids <- microdata$id[microdata$CO_PROVA_CH %in% regular_prova_codes]
@@ -45,6 +86,20 @@ items <- vroom(find_ci(data_dir, sprintf("^ITENS_PROVA_%s\\.csv$", year)), delim
                col_select = list(subj = SG_AREA, item = CO_ITEM, position = CO_POSICAO,
                                  booklet = CO_PROVA, key = TX_GABARITO, item_lingua = TP_LINGUA),
                show_col_types = FALSE)
+# ---- annulled items (#1942) -------------------------------------------------
+# INEP records TX_GABARITO "X" for an item it annulled after the exam. No response
+# letter can equal "X", so the item scores 0 for every candidate: a zero-variance
+# column that is useless for IRT and, downstream, indistinguishable from a keying
+# failure. Ten such items sit in the standard sets across 2018-2025. Drop them
+# before the item set is built, so they never reach a published table.
+.ann <- items |> filter(!key %in% ANSWER_KEYS) |> distinct(subj, item, key)
+if (nrow(.ann) > 0) {
+  cat(sprintf("[%s] dropping %d annulled item(s) (TX_GABARITO not A-E): %s\n",
+              year, nrow(.ann),
+              paste(sprintf("%s:%s(key=%s)", .ann$subj, .ann$item, .ann$key), collapse = ", ")))
+  items <- items |> filter(key %in% ANSWER_KEYS)
+}
+
 standard_items <- items |> filter(booklet %in% standard_prova_codes) |> distinct(subj, item)
 std_set <- function(area) standard_items$item[standard_items$subj == area]
 
@@ -138,6 +193,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2019.R
+++ b/data/enem_2019.R
@@ -8,6 +8,20 @@ regular_prova_codes  <- c(503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# the five that are actual answers; anything else in TX_GABARITO is not scorable
+ANSWER_KEYS <- c("A", "B", "C", "D", "E")
+
+# INEP's own per-area presence flag: 0 = absent, 1 = present, 2 = eliminated
+PRESENCE_COLS <- paste0("TP_PRESENCA_", c("CN", "CH", "LC", "MT"))
+
+# post-scoring sanity checks (#1942 finding 3). Resolved relative to THIS file
+# because the year scripts run with the microdata work dir as cwd, not data/.
+.enem_dir <- {
+  a <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+  if (length(a)) dirname(sub("^--file=", "", a[1])) else "."
+}
+source(file.path(.enem_dir, "enem_checks.R"))
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -20,17 +34,44 @@ resul  <- find_ci(data_dir, sprintf("^RESULTADOS_%s\\.csv$", year))
 if (file.exists(single)) {
   microdata <- vroom(single, delim = ";",
                      col_select = list(id = NU_INSCRICAO, tp_lingua = TP_LINGUA,
-                                       starts_with("CO_PROVA"), starts_with("TX_RESPOSTAS")),
-                     show_col_types = FALSE) |> drop_na()
+                                       starts_with("CO_PROVA"), starts_with("TP_PRESENCA"),
+                                       starts_with("TX_RESPOSTAS")),
+                     show_col_types = FALSE)
 } else if (file.exists(partic) && file.exists(resul)) {
   p <- vroom(partic, delim = ";", col_select = list(id = NU_INSCRICAO), show_col_types = FALSE)
   r <- vroom(resul, delim = ";",
              col_select = list(tp_lingua = TP_LINGUA, starts_with("CO_PROVA"),
-                               starts_with("TX_RESPOSTAS")),
+                               starts_with("TP_PRESENCA"), starts_with("TX_RESPOSTAS")),
              show_col_types = FALSE)
   stopifnot(nrow(p) == nrow(r))
-  microdata <- bind_cols(p, r) |> drop_na()
+  microdata <- bind_cols(p, r)
 } else stop(sprintf("No microdata found in %s", data_dir))
+
+# ---- absence filter (#1942) -------------------------------------------------
+# INEP encodes absence in TX_RESPOSTAS differently by year: all dots in 2013 and
+# 2014, an empty string from 2015 on. vroom reads "" as NA, so the drop_na() that
+# used to sit on the load silently removed absentees from 2015 on and kept them in
+# 2013/2014 -- where every "." was then scored 0. 31.1% of 2013 CH candidates came
+# out with a full block of zeros, which is coding, not ability.
+#
+# Filter on INEP's own flag instead, so every year behaves alike. Only presence 1
+# is kept, in all four areas: candidates INEP records as absent (0) or eliminated
+# (2) never enter the 1M sample. Verified per year in enem/fix1942_run that this
+# is exactly the set drop_na() already kept for 2015-2025, so those tables are
+# unchanged; 2013 and 2014 are the years that move.
+#
+# "." and "*" are still scored 0 for candidates who DID sit. That is INEP's own
+# scoring, and once absentees are gone it is only 0.2-0.5% of cells. resp_raw
+# ships alongside resp, so an analysis that wants them missing can do that itself.
+stopifnot(all(PRESENCE_COLS %in% names(microdata)))
+n_all <- nrow(microdata)
+keep <- rep(TRUE, n_all)
+for (.p in PRESENCE_COLS) keep <- keep & !is.na(microdata[[.p]]) & microdata[[.p]] == 1
+microdata <- microdata[keep, setdiff(names(microdata), PRESENCE_COLS), drop = FALSE]
+cat(sprintf("[%s] present in all four areas: %d of %d (%.4f)\n",
+            year, nrow(microdata), n_all, nrow(microdata) / n_all))
+microdata <- microdata |> drop_na()
+cat(sprintf("[%s] after drop_na(): %d\n", year, nrow(microdata)))
 
 # regular examinees, then 1M subsample
 regular_ids <- microdata$id[microdata$CO_PROVA_CH %in% regular_prova_codes]
@@ -45,6 +86,20 @@ items <- vroom(find_ci(data_dir, sprintf("^ITENS_PROVA_%s\\.csv$", year)), delim
                col_select = list(subj = SG_AREA, item = CO_ITEM, position = CO_POSICAO,
                                  booklet = CO_PROVA, key = TX_GABARITO, item_lingua = TP_LINGUA),
                show_col_types = FALSE)
+# ---- annulled items (#1942) -------------------------------------------------
+# INEP records TX_GABARITO "X" for an item it annulled after the exam. No response
+# letter can equal "X", so the item scores 0 for every candidate: a zero-variance
+# column that is useless for IRT and, downstream, indistinguishable from a keying
+# failure. Ten such items sit in the standard sets across 2018-2025. Drop them
+# before the item set is built, so they never reach a published table.
+.ann <- items |> filter(!key %in% ANSWER_KEYS) |> distinct(subj, item, key)
+if (nrow(.ann) > 0) {
+  cat(sprintf("[%s] dropping %d annulled item(s) (TX_GABARITO not A-E): %s\n",
+              year, nrow(.ann),
+              paste(sprintf("%s:%s(key=%s)", .ann$subj, .ann$item, .ann$key), collapse = ", ")))
+  items <- items |> filter(key %in% ANSWER_KEYS)
+}
+
 standard_items <- items |> filter(booklet %in% standard_prova_codes) |> distinct(subj, item)
 std_set <- function(area) standard_items$item[standard_items$subj == area]
 
@@ -138,6 +193,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2020.R
+++ b/data/enem_2020.R
@@ -8,6 +8,20 @@ regular_prova_codes  <- c(567, 568, 569, 570, 571, 572, 574, 575, 577, 578, 579,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# the five that are actual answers; anything else in TX_GABARITO is not scorable
+ANSWER_KEYS <- c("A", "B", "C", "D", "E")
+
+# INEP's own per-area presence flag: 0 = absent, 1 = present, 2 = eliminated
+PRESENCE_COLS <- paste0("TP_PRESENCA_", c("CN", "CH", "LC", "MT"))
+
+# post-scoring sanity checks (#1942 finding 3). Resolved relative to THIS file
+# because the year scripts run with the microdata work dir as cwd, not data/.
+.enem_dir <- {
+  a <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+  if (length(a)) dirname(sub("^--file=", "", a[1])) else "."
+}
+source(file.path(.enem_dir, "enem_checks.R"))
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -20,17 +34,44 @@ resul  <- find_ci(data_dir, sprintf("^RESULTADOS_%s\\.csv$", year))
 if (file.exists(single)) {
   microdata <- vroom(single, delim = ";",
                      col_select = list(id = NU_INSCRICAO, tp_lingua = TP_LINGUA,
-                                       starts_with("CO_PROVA"), starts_with("TX_RESPOSTAS")),
-                     show_col_types = FALSE) |> drop_na()
+                                       starts_with("CO_PROVA"), starts_with("TP_PRESENCA"),
+                                       starts_with("TX_RESPOSTAS")),
+                     show_col_types = FALSE)
 } else if (file.exists(partic) && file.exists(resul)) {
   p <- vroom(partic, delim = ";", col_select = list(id = NU_INSCRICAO), show_col_types = FALSE)
   r <- vroom(resul, delim = ";",
              col_select = list(tp_lingua = TP_LINGUA, starts_with("CO_PROVA"),
-                               starts_with("TX_RESPOSTAS")),
+                               starts_with("TP_PRESENCA"), starts_with("TX_RESPOSTAS")),
              show_col_types = FALSE)
   stopifnot(nrow(p) == nrow(r))
-  microdata <- bind_cols(p, r) |> drop_na()
+  microdata <- bind_cols(p, r)
 } else stop(sprintf("No microdata found in %s", data_dir))
+
+# ---- absence filter (#1942) -------------------------------------------------
+# INEP encodes absence in TX_RESPOSTAS differently by year: all dots in 2013 and
+# 2014, an empty string from 2015 on. vroom reads "" as NA, so the drop_na() that
+# used to sit on the load silently removed absentees from 2015 on and kept them in
+# 2013/2014 -- where every "." was then scored 0. 31.1% of 2013 CH candidates came
+# out with a full block of zeros, which is coding, not ability.
+#
+# Filter on INEP's own flag instead, so every year behaves alike. Only presence 1
+# is kept, in all four areas: candidates INEP records as absent (0) or eliminated
+# (2) never enter the 1M sample. Verified per year in enem/fix1942_run that this
+# is exactly the set drop_na() already kept for 2015-2025, so those tables are
+# unchanged; 2013 and 2014 are the years that move.
+#
+# "." and "*" are still scored 0 for candidates who DID sit. That is INEP's own
+# scoring, and once absentees are gone it is only 0.2-0.5% of cells. resp_raw
+# ships alongside resp, so an analysis that wants them missing can do that itself.
+stopifnot(all(PRESENCE_COLS %in% names(microdata)))
+n_all <- nrow(microdata)
+keep <- rep(TRUE, n_all)
+for (.p in PRESENCE_COLS) keep <- keep & !is.na(microdata[[.p]]) & microdata[[.p]] == 1
+microdata <- microdata[keep, setdiff(names(microdata), PRESENCE_COLS), drop = FALSE]
+cat(sprintf("[%s] present in all four areas: %d of %d (%.4f)\n",
+            year, nrow(microdata), n_all, nrow(microdata) / n_all))
+microdata <- microdata |> drop_na()
+cat(sprintf("[%s] after drop_na(): %d\n", year, nrow(microdata)))
 
 # regular examinees, then 1M subsample
 regular_ids <- microdata$id[microdata$CO_PROVA_CH %in% regular_prova_codes]
@@ -45,6 +86,20 @@ items <- vroom(find_ci(data_dir, sprintf("^ITENS_PROVA_%s\\.csv$", year)), delim
                col_select = list(subj = SG_AREA, item = CO_ITEM, position = CO_POSICAO,
                                  booklet = CO_PROVA, key = TX_GABARITO, item_lingua = TP_LINGUA),
                show_col_types = FALSE)
+# ---- annulled items (#1942) -------------------------------------------------
+# INEP records TX_GABARITO "X" for an item it annulled after the exam. No response
+# letter can equal "X", so the item scores 0 for every candidate: a zero-variance
+# column that is useless for IRT and, downstream, indistinguishable from a keying
+# failure. Ten such items sit in the standard sets across 2018-2025. Drop them
+# before the item set is built, so they never reach a published table.
+.ann <- items |> filter(!key %in% ANSWER_KEYS) |> distinct(subj, item, key)
+if (nrow(.ann) > 0) {
+  cat(sprintf("[%s] dropping %d annulled item(s) (TX_GABARITO not A-E): %s\n",
+              year, nrow(.ann),
+              paste(sprintf("%s:%s(key=%s)", .ann$subj, .ann$item, .ann$key), collapse = ", ")))
+  items <- items |> filter(key %in% ANSWER_KEYS)
+}
+
 standard_items <- items |> filter(booklet %in% standard_prova_codes) |> distinct(subj, item)
 std_set <- function(area) standard_items$item[standard_items$subj == area]
 
@@ -138,6 +193,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2021.R
+++ b/data/enem_2021.R
@@ -8,6 +8,20 @@ regular_prova_codes  <- c(879, 880, 881, 882, 885, 886, 887, 889, 890, 891, 892,
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# the five that are actual answers; anything else in TX_GABARITO is not scorable
+ANSWER_KEYS <- c("A", "B", "C", "D", "E")
+
+# INEP's own per-area presence flag: 0 = absent, 1 = present, 2 = eliminated
+PRESENCE_COLS <- paste0("TP_PRESENCA_", c("CN", "CH", "LC", "MT"))
+
+# post-scoring sanity checks (#1942 finding 3). Resolved relative to THIS file
+# because the year scripts run with the microdata work dir as cwd, not data/.
+.enem_dir <- {
+  a <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+  if (length(a)) dirname(sub("^--file=", "", a[1])) else "."
+}
+source(file.path(.enem_dir, "enem_checks.R"))
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -20,17 +34,44 @@ resul  <- find_ci(data_dir, sprintf("^RESULTADOS_%s\\.csv$", year))
 if (file.exists(single)) {
   microdata <- vroom(single, delim = ";",
                      col_select = list(id = NU_INSCRICAO, tp_lingua = TP_LINGUA,
-                                       starts_with("CO_PROVA"), starts_with("TX_RESPOSTAS")),
-                     show_col_types = FALSE) |> drop_na()
+                                       starts_with("CO_PROVA"), starts_with("TP_PRESENCA"),
+                                       starts_with("TX_RESPOSTAS")),
+                     show_col_types = FALSE)
 } else if (file.exists(partic) && file.exists(resul)) {
   p <- vroom(partic, delim = ";", col_select = list(id = NU_INSCRICAO), show_col_types = FALSE)
   r <- vroom(resul, delim = ";",
              col_select = list(tp_lingua = TP_LINGUA, starts_with("CO_PROVA"),
-                               starts_with("TX_RESPOSTAS")),
+                               starts_with("TP_PRESENCA"), starts_with("TX_RESPOSTAS")),
              show_col_types = FALSE)
   stopifnot(nrow(p) == nrow(r))
-  microdata <- bind_cols(p, r) |> drop_na()
+  microdata <- bind_cols(p, r)
 } else stop(sprintf("No microdata found in %s", data_dir))
+
+# ---- absence filter (#1942) -------------------------------------------------
+# INEP encodes absence in TX_RESPOSTAS differently by year: all dots in 2013 and
+# 2014, an empty string from 2015 on. vroom reads "" as NA, so the drop_na() that
+# used to sit on the load silently removed absentees from 2015 on and kept them in
+# 2013/2014 -- where every "." was then scored 0. 31.1% of 2013 CH candidates came
+# out with a full block of zeros, which is coding, not ability.
+#
+# Filter on INEP's own flag instead, so every year behaves alike. Only presence 1
+# is kept, in all four areas: candidates INEP records as absent (0) or eliminated
+# (2) never enter the 1M sample. Verified per year in enem/fix1942_run that this
+# is exactly the set drop_na() already kept for 2015-2025, so those tables are
+# unchanged; 2013 and 2014 are the years that move.
+#
+# "." and "*" are still scored 0 for candidates who DID sit. That is INEP's own
+# scoring, and once absentees are gone it is only 0.2-0.5% of cells. resp_raw
+# ships alongside resp, so an analysis that wants them missing can do that itself.
+stopifnot(all(PRESENCE_COLS %in% names(microdata)))
+n_all <- nrow(microdata)
+keep <- rep(TRUE, n_all)
+for (.p in PRESENCE_COLS) keep <- keep & !is.na(microdata[[.p]]) & microdata[[.p]] == 1
+microdata <- microdata[keep, setdiff(names(microdata), PRESENCE_COLS), drop = FALSE]
+cat(sprintf("[%s] present in all four areas: %d of %d (%.4f)\n",
+            year, nrow(microdata), n_all, nrow(microdata) / n_all))
+microdata <- microdata |> drop_na()
+cat(sprintf("[%s] after drop_na(): %d\n", year, nrow(microdata)))
 
 # regular examinees, then 1M subsample
 regular_ids <- microdata$id[microdata$CO_PROVA_CH %in% regular_prova_codes]
@@ -45,6 +86,20 @@ items <- vroom(find_ci(data_dir, sprintf("^ITENS_PROVA_%s\\.csv$", year)), delim
                col_select = list(subj = SG_AREA, item = CO_ITEM, position = CO_POSICAO,
                                  booklet = CO_PROVA, key = TX_GABARITO, item_lingua = TP_LINGUA),
                show_col_types = FALSE)
+# ---- annulled items (#1942) -------------------------------------------------
+# INEP records TX_GABARITO "X" for an item it annulled after the exam. No response
+# letter can equal "X", so the item scores 0 for every candidate: a zero-variance
+# column that is useless for IRT and, downstream, indistinguishable from a keying
+# failure. Ten such items sit in the standard sets across 2018-2025. Drop them
+# before the item set is built, so they never reach a published table.
+.ann <- items |> filter(!key %in% ANSWER_KEYS) |> distinct(subj, item, key)
+if (nrow(.ann) > 0) {
+  cat(sprintf("[%s] dropping %d annulled item(s) (TX_GABARITO not A-E): %s\n",
+              year, nrow(.ann),
+              paste(sprintf("%s:%s(key=%s)", .ann$subj, .ann$item, .ann$key), collapse = ", ")))
+  items <- items |> filter(key %in% ANSWER_KEYS)
+}
+
 standard_items <- items |> filter(booklet %in% standard_prova_codes) |> distinct(subj, item)
 std_set <- function(area) standard_items$item[standard_items$subj == area]
 
@@ -138,6 +193,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2022.R
+++ b/data/enem_2022.R
@@ -8,6 +8,20 @@ regular_prova_codes  <- c(1055, 1056, 1057, 1058, 1062, 1063, 1065, 1066, 1067, 
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# the five that are actual answers; anything else in TX_GABARITO is not scorable
+ANSWER_KEYS <- c("A", "B", "C", "D", "E")
+
+# INEP's own per-area presence flag: 0 = absent, 1 = present, 2 = eliminated
+PRESENCE_COLS <- paste0("TP_PRESENCA_", c("CN", "CH", "LC", "MT"))
+
+# post-scoring sanity checks (#1942 finding 3). Resolved relative to THIS file
+# because the year scripts run with the microdata work dir as cwd, not data/.
+.enem_dir <- {
+  a <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+  if (length(a)) dirname(sub("^--file=", "", a[1])) else "."
+}
+source(file.path(.enem_dir, "enem_checks.R"))
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -20,17 +34,44 @@ resul  <- find_ci(data_dir, sprintf("^RESULTADOS_%s\\.csv$", year))
 if (file.exists(single)) {
   microdata <- vroom(single, delim = ";",
                      col_select = list(id = NU_INSCRICAO, tp_lingua = TP_LINGUA,
-                                       starts_with("CO_PROVA"), starts_with("TX_RESPOSTAS")),
-                     show_col_types = FALSE) |> drop_na()
+                                       starts_with("CO_PROVA"), starts_with("TP_PRESENCA"),
+                                       starts_with("TX_RESPOSTAS")),
+                     show_col_types = FALSE)
 } else if (file.exists(partic) && file.exists(resul)) {
   p <- vroom(partic, delim = ";", col_select = list(id = NU_INSCRICAO), show_col_types = FALSE)
   r <- vroom(resul, delim = ";",
              col_select = list(tp_lingua = TP_LINGUA, starts_with("CO_PROVA"),
-                               starts_with("TX_RESPOSTAS")),
+                               starts_with("TP_PRESENCA"), starts_with("TX_RESPOSTAS")),
              show_col_types = FALSE)
   stopifnot(nrow(p) == nrow(r))
-  microdata <- bind_cols(p, r) |> drop_na()
+  microdata <- bind_cols(p, r)
 } else stop(sprintf("No microdata found in %s", data_dir))
+
+# ---- absence filter (#1942) -------------------------------------------------
+# INEP encodes absence in TX_RESPOSTAS differently by year: all dots in 2013 and
+# 2014, an empty string from 2015 on. vroom reads "" as NA, so the drop_na() that
+# used to sit on the load silently removed absentees from 2015 on and kept them in
+# 2013/2014 -- where every "." was then scored 0. 31.1% of 2013 CH candidates came
+# out with a full block of zeros, which is coding, not ability.
+#
+# Filter on INEP's own flag instead, so every year behaves alike. Only presence 1
+# is kept, in all four areas: candidates INEP records as absent (0) or eliminated
+# (2) never enter the 1M sample. Verified per year in enem/fix1942_run that this
+# is exactly the set drop_na() already kept for 2015-2025, so those tables are
+# unchanged; 2013 and 2014 are the years that move.
+#
+# "." and "*" are still scored 0 for candidates who DID sit. That is INEP's own
+# scoring, and once absentees are gone it is only 0.2-0.5% of cells. resp_raw
+# ships alongside resp, so an analysis that wants them missing can do that itself.
+stopifnot(all(PRESENCE_COLS %in% names(microdata)))
+n_all <- nrow(microdata)
+keep <- rep(TRUE, n_all)
+for (.p in PRESENCE_COLS) keep <- keep & !is.na(microdata[[.p]]) & microdata[[.p]] == 1
+microdata <- microdata[keep, setdiff(names(microdata), PRESENCE_COLS), drop = FALSE]
+cat(sprintf("[%s] present in all four areas: %d of %d (%.4f)\n",
+            year, nrow(microdata), n_all, nrow(microdata) / n_all))
+microdata <- microdata |> drop_na()
+cat(sprintf("[%s] after drop_na(): %d\n", year, nrow(microdata)))
 
 # regular examinees, then 1M subsample
 regular_ids <- microdata$id[microdata$CO_PROVA_CH %in% regular_prova_codes]
@@ -45,6 +86,20 @@ items <- vroom(find_ci(data_dir, sprintf("^ITENS_PROVA_%s\\.csv$", year)), delim
                col_select = list(subj = SG_AREA, item = CO_ITEM, position = CO_POSICAO,
                                  booklet = CO_PROVA, key = TX_GABARITO, item_lingua = TP_LINGUA),
                show_col_types = FALSE)
+# ---- annulled items (#1942) -------------------------------------------------
+# INEP records TX_GABARITO "X" for an item it annulled after the exam. No response
+# letter can equal "X", so the item scores 0 for every candidate: a zero-variance
+# column that is useless for IRT and, downstream, indistinguishable from a keying
+# failure. Ten such items sit in the standard sets across 2018-2025. Drop them
+# before the item set is built, so they never reach a published table.
+.ann <- items |> filter(!key %in% ANSWER_KEYS) |> distinct(subj, item, key)
+if (nrow(.ann) > 0) {
+  cat(sprintf("[%s] dropping %d annulled item(s) (TX_GABARITO not A-E): %s\n",
+              year, nrow(.ann),
+              paste(sprintf("%s:%s(key=%s)", .ann$subj, .ann$item, .ann$key), collapse = ", ")))
+  items <- items |> filter(key %in% ANSWER_KEYS)
+}
+
 standard_items <- items |> filter(booklet %in% standard_prova_codes) |> distinct(subj, item)
 std_set <- function(area) standard_items$item[standard_items$subj == area]
 
@@ -138,6 +193,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2023.R
+++ b/data/enem_2023.R
@@ -8,6 +8,20 @@ regular_prova_codes  <- c(1191, 1192, 1193, 1194, 1195, 1196, 1197, 1198, 1199, 
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# the five that are actual answers; anything else in TX_GABARITO is not scorable
+ANSWER_KEYS <- c("A", "B", "C", "D", "E")
+
+# INEP's own per-area presence flag: 0 = absent, 1 = present, 2 = eliminated
+PRESENCE_COLS <- paste0("TP_PRESENCA_", c("CN", "CH", "LC", "MT"))
+
+# post-scoring sanity checks (#1942 finding 3). Resolved relative to THIS file
+# because the year scripts run with the microdata work dir as cwd, not data/.
+.enem_dir <- {
+  a <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+  if (length(a)) dirname(sub("^--file=", "", a[1])) else "."
+}
+source(file.path(.enem_dir, "enem_checks.R"))
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -20,17 +34,44 @@ resul  <- find_ci(data_dir, sprintf("^RESULTADOS_%s\\.csv$", year))
 if (file.exists(single)) {
   microdata <- vroom(single, delim = ";",
                      col_select = list(id = NU_INSCRICAO, tp_lingua = TP_LINGUA,
-                                       starts_with("CO_PROVA"), starts_with("TX_RESPOSTAS")),
-                     show_col_types = FALSE) |> drop_na()
+                                       starts_with("CO_PROVA"), starts_with("TP_PRESENCA"),
+                                       starts_with("TX_RESPOSTAS")),
+                     show_col_types = FALSE)
 } else if (file.exists(partic) && file.exists(resul)) {
   p <- vroom(partic, delim = ";", col_select = list(id = NU_INSCRICAO), show_col_types = FALSE)
   r <- vroom(resul, delim = ";",
              col_select = list(tp_lingua = TP_LINGUA, starts_with("CO_PROVA"),
-                               starts_with("TX_RESPOSTAS")),
+                               starts_with("TP_PRESENCA"), starts_with("TX_RESPOSTAS")),
              show_col_types = FALSE)
   stopifnot(nrow(p) == nrow(r))
-  microdata <- bind_cols(p, r) |> drop_na()
+  microdata <- bind_cols(p, r)
 } else stop(sprintf("No microdata found in %s", data_dir))
+
+# ---- absence filter (#1942) -------------------------------------------------
+# INEP encodes absence in TX_RESPOSTAS differently by year: all dots in 2013 and
+# 2014, an empty string from 2015 on. vroom reads "" as NA, so the drop_na() that
+# used to sit on the load silently removed absentees from 2015 on and kept them in
+# 2013/2014 -- where every "." was then scored 0. 31.1% of 2013 CH candidates came
+# out with a full block of zeros, which is coding, not ability.
+#
+# Filter on INEP's own flag instead, so every year behaves alike. Only presence 1
+# is kept, in all four areas: candidates INEP records as absent (0) or eliminated
+# (2) never enter the 1M sample. Verified per year in enem/fix1942_run that this
+# is exactly the set drop_na() already kept for 2015-2025, so those tables are
+# unchanged; 2013 and 2014 are the years that move.
+#
+# "." and "*" are still scored 0 for candidates who DID sit. That is INEP's own
+# scoring, and once absentees are gone it is only 0.2-0.5% of cells. resp_raw
+# ships alongside resp, so an analysis that wants them missing can do that itself.
+stopifnot(all(PRESENCE_COLS %in% names(microdata)))
+n_all <- nrow(microdata)
+keep <- rep(TRUE, n_all)
+for (.p in PRESENCE_COLS) keep <- keep & !is.na(microdata[[.p]]) & microdata[[.p]] == 1
+microdata <- microdata[keep, setdiff(names(microdata), PRESENCE_COLS), drop = FALSE]
+cat(sprintf("[%s] present in all four areas: %d of %d (%.4f)\n",
+            year, nrow(microdata), n_all, nrow(microdata) / n_all))
+microdata <- microdata |> drop_na()
+cat(sprintf("[%s] after drop_na(): %d\n", year, nrow(microdata)))
 
 # regular examinees, then 1M subsample
 regular_ids <- microdata$id[microdata$CO_PROVA_CH %in% regular_prova_codes]
@@ -45,6 +86,20 @@ items <- vroom(find_ci(data_dir, sprintf("^ITENS_PROVA_%s\\.csv$", year)), delim
                col_select = list(subj = SG_AREA, item = CO_ITEM, position = CO_POSICAO,
                                  booklet = CO_PROVA, key = TX_GABARITO, item_lingua = TP_LINGUA),
                show_col_types = FALSE)
+# ---- annulled items (#1942) -------------------------------------------------
+# INEP records TX_GABARITO "X" for an item it annulled after the exam. No response
+# letter can equal "X", so the item scores 0 for every candidate: a zero-variance
+# column that is useless for IRT and, downstream, indistinguishable from a keying
+# failure. Ten such items sit in the standard sets across 2018-2025. Drop them
+# before the item set is built, so they never reach a published table.
+.ann <- items |> filter(!key %in% ANSWER_KEYS) |> distinct(subj, item, key)
+if (nrow(.ann) > 0) {
+  cat(sprintf("[%s] dropping %d annulled item(s) (TX_GABARITO not A-E): %s\n",
+              year, nrow(.ann),
+              paste(sprintf("%s:%s(key=%s)", .ann$subj, .ann$item, .ann$key), collapse = ", ")))
+  items <- items |> filter(key %in% ANSWER_KEYS)
+}
+
 standard_items <- items |> filter(booklet %in% standard_prova_codes) |> distinct(subj, item)
 std_set <- function(area) standard_items$item[standard_items$subj == area]
 
@@ -138,6 +193,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2024.R
+++ b/data/enem_2024.R
@@ -8,6 +8,20 @@ regular_prova_codes  <- c(1383, 1384, 1385, 1386, 1387, 1388, 1390, 1395, 1396, 
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# the five that are actual answers; anything else in TX_GABARITO is not scorable
+ANSWER_KEYS <- c("A", "B", "C", "D", "E")
+
+# INEP's own per-area presence flag: 0 = absent, 1 = present, 2 = eliminated
+PRESENCE_COLS <- paste0("TP_PRESENCA_", c("CN", "CH", "LC", "MT"))
+
+# post-scoring sanity checks (#1942 finding 3). Resolved relative to THIS file
+# because the year scripts run with the microdata work dir as cwd, not data/.
+.enem_dir <- {
+  a <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+  if (length(a)) dirname(sub("^--file=", "", a[1])) else "."
+}
+source(file.path(.enem_dir, "enem_checks.R"))
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -20,17 +34,44 @@ resul  <- find_ci(data_dir, sprintf("^RESULTADOS_%s\\.csv$", year))
 if (file.exists(single)) {
   microdata <- vroom(single, delim = ";",
                      col_select = list(id = NU_INSCRICAO, tp_lingua = TP_LINGUA,
-                                       starts_with("CO_PROVA"), starts_with("TX_RESPOSTAS")),
-                     show_col_types = FALSE) |> drop_na()
+                                       starts_with("CO_PROVA"), starts_with("TP_PRESENCA"),
+                                       starts_with("TX_RESPOSTAS")),
+                     show_col_types = FALSE)
 } else if (file.exists(partic) && file.exists(resul)) {
   p <- vroom(partic, delim = ";", col_select = list(id = NU_INSCRICAO), show_col_types = FALSE)
   r <- vroom(resul, delim = ";",
              col_select = list(tp_lingua = TP_LINGUA, starts_with("CO_PROVA"),
-                               starts_with("TX_RESPOSTAS")),
+                               starts_with("TP_PRESENCA"), starts_with("TX_RESPOSTAS")),
              show_col_types = FALSE)
   stopifnot(nrow(p) == nrow(r))
-  microdata <- bind_cols(p, r) |> drop_na()
+  microdata <- bind_cols(p, r)
 } else stop(sprintf("No microdata found in %s", data_dir))
+
+# ---- absence filter (#1942) -------------------------------------------------
+# INEP encodes absence in TX_RESPOSTAS differently by year: all dots in 2013 and
+# 2014, an empty string from 2015 on. vroom reads "" as NA, so the drop_na() that
+# used to sit on the load silently removed absentees from 2015 on and kept them in
+# 2013/2014 -- where every "." was then scored 0. 31.1% of 2013 CH candidates came
+# out with a full block of zeros, which is coding, not ability.
+#
+# Filter on INEP's own flag instead, so every year behaves alike. Only presence 1
+# is kept, in all four areas: candidates INEP records as absent (0) or eliminated
+# (2) never enter the 1M sample. Verified per year in enem/fix1942_run that this
+# is exactly the set drop_na() already kept for 2015-2025, so those tables are
+# unchanged; 2013 and 2014 are the years that move.
+#
+# "." and "*" are still scored 0 for candidates who DID sit. That is INEP's own
+# scoring, and once absentees are gone it is only 0.2-0.5% of cells. resp_raw
+# ships alongside resp, so an analysis that wants them missing can do that itself.
+stopifnot(all(PRESENCE_COLS %in% names(microdata)))
+n_all <- nrow(microdata)
+keep <- rep(TRUE, n_all)
+for (.p in PRESENCE_COLS) keep <- keep & !is.na(microdata[[.p]]) & microdata[[.p]] == 1
+microdata <- microdata[keep, setdiff(names(microdata), PRESENCE_COLS), drop = FALSE]
+cat(sprintf("[%s] present in all four areas: %d of %d (%.4f)\n",
+            year, nrow(microdata), n_all, nrow(microdata) / n_all))
+microdata <- microdata |> drop_na()
+cat(sprintf("[%s] after drop_na(): %d\n", year, nrow(microdata)))
 
 # regular examinees, then 1M subsample
 regular_ids <- microdata$id[microdata$CO_PROVA_CH %in% regular_prova_codes]
@@ -45,6 +86,20 @@ items <- vroom(find_ci(data_dir, sprintf("^ITENS_PROVA_%s\\.csv$", year)), delim
                col_select = list(subj = SG_AREA, item = CO_ITEM, position = CO_POSICAO,
                                  booklet = CO_PROVA, key = TX_GABARITO, item_lingua = TP_LINGUA),
                show_col_types = FALSE)
+# ---- annulled items (#1942) -------------------------------------------------
+# INEP records TX_GABARITO "X" for an item it annulled after the exam. No response
+# letter can equal "X", so the item scores 0 for every candidate: a zero-variance
+# column that is useless for IRT and, downstream, indistinguishable from a keying
+# failure. Ten such items sit in the standard sets across 2018-2025. Drop them
+# before the item set is built, so they never reach a published table.
+.ann <- items |> filter(!key %in% ANSWER_KEYS) |> distinct(subj, item, key)
+if (nrow(.ann) > 0) {
+  cat(sprintf("[%s] dropping %d annulled item(s) (TX_GABARITO not A-E): %s\n",
+              year, nrow(.ann),
+              paste(sprintf("%s:%s(key=%s)", .ann$subj, .ann$item, .ann$key), collapse = ", ")))
+  items <- items |> filter(key %in% ANSWER_KEYS)
+}
+
 standard_items <- items |> filter(booklet %in% standard_prova_codes) |> distinct(subj, item)
 std_set <- function(area) standard_items$item[standard_items$subj == area]
 
@@ -138,6 +193,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_2025.R
+++ b/data/enem_2025.R
@@ -8,6 +8,20 @@ regular_prova_codes  <- c(1447, 1448, 1449, 1450, 1451, 1452, 1454, 1459, 1460, 
 # INEP response codes: A-E, "." blank, "*" double mark
 ALPHABET <- c("A", "B", "C", "D", "E", ".", "*")
 
+# the five that are actual answers; anything else in TX_GABARITO is not scorable
+ANSWER_KEYS <- c("A", "B", "C", "D", "E")
+
+# INEP's own per-area presence flag: 0 = absent, 1 = present, 2 = eliminated
+PRESENCE_COLS <- paste0("TP_PRESENCA_", c("CN", "CH", "LC", "MT"))
+
+# post-scoring sanity checks (#1942 finding 3). Resolved relative to THIS file
+# because the year scripts run with the microdata work dir as cwd, not data/.
+.enem_dir <- {
+  a <- grep("^--file=", commandArgs(FALSE), value = TRUE)
+  if (length(a)) dirname(sub("^--file=", "", a[1])) else "."
+}
+source(file.path(.enem_dir, "enem_checks.R"))
+
 # some years ship PARTICIPANTES + RESULTADOS instead of one MICRODADOS file
 find_ci <- function(dir, pattern) {
   hits <- list.files(dir, pattern = pattern, ignore.case = TRUE, full.names = TRUE)
@@ -20,17 +34,44 @@ resul  <- find_ci(data_dir, sprintf("^RESULTADOS_%s\\.csv$", year))
 if (file.exists(single)) {
   microdata <- vroom(single, delim = ";",
                      col_select = list(id = NU_INSCRICAO, tp_lingua = TP_LINGUA,
-                                       starts_with("CO_PROVA"), starts_with("TX_RESPOSTAS")),
-                     show_col_types = FALSE) |> drop_na()
+                                       starts_with("CO_PROVA"), starts_with("TP_PRESENCA"),
+                                       starts_with("TX_RESPOSTAS")),
+                     show_col_types = FALSE)
 } else if (file.exists(partic) && file.exists(resul)) {
   p <- vroom(partic, delim = ";", col_select = list(id = NU_INSCRICAO), show_col_types = FALSE)
   r <- vroom(resul, delim = ";",
              col_select = list(tp_lingua = TP_LINGUA, starts_with("CO_PROVA"),
-                               starts_with("TX_RESPOSTAS")),
+                               starts_with("TP_PRESENCA"), starts_with("TX_RESPOSTAS")),
              show_col_types = FALSE)
   stopifnot(nrow(p) == nrow(r))
-  microdata <- bind_cols(p, r) |> drop_na()
+  microdata <- bind_cols(p, r)
 } else stop(sprintf("No microdata found in %s", data_dir))
+
+# ---- absence filter (#1942) -------------------------------------------------
+# INEP encodes absence in TX_RESPOSTAS differently by year: all dots in 2013 and
+# 2014, an empty string from 2015 on. vroom reads "" as NA, so the drop_na() that
+# used to sit on the load silently removed absentees from 2015 on and kept them in
+# 2013/2014 -- where every "." was then scored 0. 31.1% of 2013 CH candidates came
+# out with a full block of zeros, which is coding, not ability.
+#
+# Filter on INEP's own flag instead, so every year behaves alike. Only presence 1
+# is kept, in all four areas: candidates INEP records as absent (0) or eliminated
+# (2) never enter the 1M sample. Verified per year in enem/fix1942_run that this
+# is exactly the set drop_na() already kept for 2015-2025, so those tables are
+# unchanged; 2013 and 2014 are the years that move.
+#
+# "." and "*" are still scored 0 for candidates who DID sit. That is INEP's own
+# scoring, and once absentees are gone it is only 0.2-0.5% of cells. resp_raw
+# ships alongside resp, so an analysis that wants them missing can do that itself.
+stopifnot(all(PRESENCE_COLS %in% names(microdata)))
+n_all <- nrow(microdata)
+keep <- rep(TRUE, n_all)
+for (.p in PRESENCE_COLS) keep <- keep & !is.na(microdata[[.p]]) & microdata[[.p]] == 1
+microdata <- microdata[keep, setdiff(names(microdata), PRESENCE_COLS), drop = FALSE]
+cat(sprintf("[%s] present in all four areas: %d of %d (%.4f)\n",
+            year, nrow(microdata), n_all, nrow(microdata) / n_all))
+microdata <- microdata |> drop_na()
+cat(sprintf("[%s] after drop_na(): %d\n", year, nrow(microdata)))
 
 # regular examinees, then 1M subsample
 regular_ids <- microdata$id[microdata$CO_PROVA_CH %in% regular_prova_codes]
@@ -45,6 +86,20 @@ items <- vroom(find_ci(data_dir, sprintf("^ITENS_PROVA_%s\\.csv$", year)), delim
                col_select = list(subj = SG_AREA, item = CO_ITEM, position = CO_POSICAO,
                                  booklet = CO_PROVA, key = TX_GABARITO, item_lingua = TP_LINGUA),
                show_col_types = FALSE)
+# ---- annulled items (#1942) -------------------------------------------------
+# INEP records TX_GABARITO "X" for an item it annulled after the exam. No response
+# letter can equal "X", so the item scores 0 for every candidate: a zero-variance
+# column that is useless for IRT and, downstream, indistinguishable from a keying
+# failure. Ten such items sit in the standard sets across 2018-2025. Drop them
+# before the item set is built, so they never reach a published table.
+.ann <- items |> filter(!key %in% ANSWER_KEYS) |> distinct(subj, item, key)
+if (nrow(.ann) > 0) {
+  cat(sprintf("[%s] dropping %d annulled item(s) (TX_GABARITO not A-E): %s\n",
+              year, nrow(.ann),
+              paste(sprintf("%s:%s(key=%s)", .ann$subj, .ann$item, .ann$key), collapse = ", ")))
+  items <- items |> filter(key %in% ANSWER_KEYS)
+}
+
 standard_items <- items |> filter(booklet %in% standard_prova_codes) |> distinct(subj, item)
 std_set <- function(area) standard_items$item[standard_items$subj == area]
 
@@ -138,6 +193,7 @@ for (area in names(AREAS)) {
   df <- process_area(area)
   dups <- sum(duplicated(df[, c("id", "item")]))
   if (dups > 0) stop(sprintf("enem_%d_1mil_%s: %d duplicate id+item rows -- booklet/position join produced ambiguous matches; investigate before trusting output", year, suf, dups))
+  enem_check_scored(df, sprintf("enem_%d_1mil_%s", year, suf))
   save(df, file = sprintf("enem_%d_1mil_%s.Rdata", year, suf))
   write.csv(df, sprintf("enem_%d_1mil_%s.csv", year, suf), row.names = FALSE)
 }

--- a/data/enem_checks.R
+++ b/data/enem_checks.R
@@ -1,0 +1,152 @@
+## Post-scoring sanity checks for the ENEM ingest (#1942, finding 3).
+##
+## Adapted from @ben-domingue's fix/1942-enem-blank-scoring with two changes,
+## both noted at the point they occur: `complete` is keyed off the modal
+## answered-count so the all-wrong check is not blind to LC, and the
+## zero-variance stop() is sound because annulled items are now dropped upstream.
+##
+## Everything the year scripts guarded before this file was a guard on the
+## INPUTS and the JOINS: off-length response strings, raw codes outside the
+## expected alphabet, `9` padding surviving the language mapping, duplicate
+## id+item rows after the booklet/position join. Both defects #1942 reports get
+## past all of them, because both produce structurally valid output that is
+## psychometrically impossible:
+##
+##   * blanks and double marks scored as wrong answers -- 45% of candidates in
+##     the 2013/2014 tables score exactly zero on 45 answered five-option
+##     items, which has probability ~4e-5 each;
+##   * enem_2019_1mil_lc, where five items are scored 0 for all 1,504
+##     candidates who answered them and 73% of items correlate below .05 with
+##     the rest of the form.
+##
+## Both are one-line summaries of the SCORED output. This file computes them.
+##
+## Sourced by each enem_<year>.R. Self-tested offline against synthetic data:
+##
+##     Rscript tests/test_enem_checks.R
+
+## ENEM is five-option multiple choice throughout, so a candidate who knows
+## nothing still scores 1/5 by guessing. Everything below is calibrated to that.
+ENEM_N_OPTIONS <- 5
+ENEM_CHANCE    <- 1 / ENEM_N_OPTIONS
+
+## Thresholds. Deliberately far from the healthy tables rather than tight: the
+## point is to catch a form that is mis-keyed, not to police difficulty. Across
+## the ten healthy tables measured in #1942 the median item-rest correlation
+## runs .09-.49 and no table has more than 27% of items below .05.
+ENEM_MAX_SHARE_BELOW_CHANCE <- 0.50   # items with p < 1/5
+ENEM_MIN_MEDIAN_ITEM_REST   <- 0.05
+ENEM_MAX_SHARE_LOW_ITEM_REST<- 0.60
+ENEM_MAX_SHARE_ALL_WRONG    <- 0.05   # candidates at exactly zero, all answered
+
+## Item-rest correlations on 45,000,000 rows are not free. A sample of
+## candidates is enough for a statistic used as a floor, and the seed makes the
+## build reproducible.
+ENEM_CHECK_SAMPLE_IDS <- 5000
+ENEM_CHECK_SEED       <- 1942
+
+## Returns a named list of statistics; `enem_check_scored()` decides what to do
+## about them. Split so the thresholds can be tested without a build.
+enem_scored_stats <- function(df, sample_ids = ENEM_CHECK_SAMPLE_IDS,
+                              seed = ENEM_CHECK_SEED) {
+  stopifnot(all(c("id", "item", "resp") %in% names(df)))
+  scored <- df[!is.na(df$resp), c("id", "item", "resp")]
+  if (nrow(scored) == 0) stop("no scored responses")
+
+  p <- tapply(scored$resp, scored$item, mean)
+  n <- tapply(scored$resp, scored$item, length)
+
+  ids <- unique(scored$id)
+  if (length(ids) > sample_ids) {
+    set.seed(seed)
+    ids <- sample(ids, sample_ids)
+  }
+  s <- scored[scored$id %in% ids, ]
+  w <- tapply(s$resp, list(as.character(s$id), as.character(s$item)), sum)
+
+  ## Item-rest: correlate each item with the total of the OTHER items, so a
+  ## mis-keyed item cannot prop up its own correlation.
+  tot <- rowSums(w, na.rm = TRUE)
+  rest <- vapply(colnames(w), function(j) {
+    x <- w[, j]
+    ok <- !is.na(x)
+    r <- tot[ok] - x[ok]
+    if (length(unique(x[ok])) < 2 || length(unique(r)) < 2) return(NA_real_)
+    stats::cor(x[ok], r)
+  }, numeric(1))
+
+  ## "All wrong" counts only candidates with NO missing item on the form --
+  ## a candidate who answered three items and got them wrong is not evidence.
+  ##
+  ## `complete` is keyed off the MODAL answered-count, not ncol(w). On LC the two
+  ## elective language blocks are mutually exclusive, so every candidate answers
+  ## 45 of 50 columns and `answered == ncol(w)` is never true -- which would force
+  ## share_all_wrong to 0 for every LC table and silence this check exactly where
+  ## #1942 found the problem (enem_2013_1mil_lc, 44.7% all-wrong). For CH/CN/MT
+  ## the mode is ncol(w) and this is identical to the original.
+  answered <- rowSums(!is.na(w))
+  form_len <- as.integer(names(sort(table(answered), decreasing = TRUE))[1])
+  complete <- answered == form_len
+  all_wrong <- if (any(complete)) mean(tot[complete] == 0) else 0
+
+  list(n_items          = length(p),
+       median_p         = stats::median(p),
+       share_below_chance = mean(p < ENEM_CHANCE),
+       zero_variance    = names(p)[p == 0 | p == 1],
+       median_item_rest = stats::median(rest, na.rm = TRUE),
+       share_low_item_rest = mean(rest < ENEM_MIN_MEDIAN_ITEM_REST, na.rm = TRUE),
+       share_all_wrong  = all_wrong,
+       n_complete       = sum(complete),
+       form_len         = form_len,
+       min_n_per_item   = min(n))
+}
+
+## `label` is used in every message so a failing build says which table.
+## Stops on the two conditions that cannot be produced by difficulty; warns on
+## the rest, because a warning that fires on a legitimately hard form is worse
+## than useless.
+enem_check_scored <- function(df, label, stats = NULL) {
+  st <- if (is.null(stats)) enem_scored_stats(df) else stats
+  cat(sprintf("  %s scored: %d items, median p=%.3f, %.0f%% below chance, ",
+              label, st$n_items, st$median_p, 100 * st$share_below_chance))
+  cat(sprintf("median item-rest=%.3f, %.1f%% of candidates all-wrong\n",
+              st$median_item_rest, 100 * st$share_all_wrong))
+
+  ## Sound as a hard stop only because the year scripts now DROP annulled items
+  ## (TX_GABARITO "X") before scoring -- see the annulled-items block in
+  ## enem_<year>.R. Ten such items sit in the standard sets across 2018-2025 and
+  ## each scores 0 for every candidate, so without that drop this stop() would
+  ## halt the build for 7 of the 13 years. With it, p == 0 really does mean a
+  ## keying failure.
+  if (length(st$zero_variance) > 0) {
+    stop(sprintf("%s: %d item(s) scored identically for every candidate (%s). ",
+                 label, length(st$zero_variance),
+                 paste(utils::head(st$zero_variance, 8), collapse = ", ")),
+         "An item nobody gets right is a keying failure, not a hard item.")
+  }
+  if (!is.na(st$median_item_rest) &&
+      st$median_item_rest < ENEM_MIN_MEDIAN_ITEM_REST &&
+      st$share_low_item_rest > ENEM_MAX_SHARE_LOW_ITEM_REST) {
+    stop(sprintf(paste0("%s: median item-rest correlation %.3f with %.0f%% of ",
+                        "items below %.2f. A correctly keyed item correlates ",
+                        "positively with the rest of the form regardless of ",
+                        "difficulty."),
+                 label, st$median_item_rest, 100 * st$share_low_item_rest,
+                 ENEM_MIN_MEDIAN_ITEM_REST))
+  }
+  if (st$share_below_chance > ENEM_MAX_SHARE_BELOW_CHANCE) {
+    warning(sprintf("%s: %.0f%% of items sit below the 1/%d chance floor.",
+                    label, 100 * st$share_below_chance, ENEM_N_OPTIONS),
+            call. = FALSE)
+  }
+  if (st$share_all_wrong > ENEM_MAX_SHARE_ALL_WRONG) {
+    warning(sprintf(paste0("%s: %.1f%% of candidates who answered every item ",
+                           "scored exactly zero. On %d five-option items that ",
+                           "has probability ~%.0e each -- suspect non-responses ",
+                           "being scored as wrong (#1942)."),
+                    label, 100 * st$share_all_wrong, st$n_items,
+                    (1 - ENEM_CHANCE)^st$n_items),
+            call. = FALSE)
+  }
+  invisible(st)
+}

--- a/data/tests/test_enem_checks.R
+++ b/data/tests/test_enem_checks.R
@@ -1,0 +1,186 @@
+## Tests for data/enem_checks.R (#1942, finding 3).
+##
+## Started from @ben-domingue's fix/1942-enem-blank-scoring. The LC-shaped
+## fixtures at the end are additions: they cover the elective-block form, which
+## the original `complete <- answered == ncol(w)` was structurally blind to.
+##
+## Offline and deterministic: the checks touch no INEP microdata, so the
+## thresholds are exercised on synthetic forms built to look like the two
+## defects the issue reports and like a healthy table. Run from `data/`:
+##
+##     Rscript tests/test_enem_checks.R
+
+source("enem_checks.R")
+
+failures <- 0L
+ok    <- function(what) cat("  ok   -", what, "\n")
+check <- function(cond, what) {
+  if (isTRUE(cond)) ok(what)
+  else { cat("  FAIL -", what, "\n"); failures <<- failures + 1L }
+}
+expect_stop <- function(expr, pattern, what) {
+  e <- tryCatch({ suppressWarnings(force(expr)); NULL }, error = conditionMessage)
+  if (is.null(e)) { cat("  FAIL -", what, "(no error)\n"); failures <<- failures + 1L }
+  else check(grepl(pattern, e, fixed = TRUE), what)
+}
+expect_warn <- function(expr, pattern, what) {
+  w <- character(0)
+  withCallingHandlers(suppressMessages(capture.output(force(expr))),
+                      warning = function(x) { w <<- c(w, conditionMessage(x));
+                                              invokeRestart("muffleWarning") })
+  check(any(grepl(pattern, w, fixed = TRUE)), what)
+}
+quiet <- function(expr) suppressWarnings(capture.output(force(expr)))
+
+## ------------------------------------------------------------- fixtures ---
+## A healthy five-option form: one latent ability, items of varying difficulty,
+## and a chance floor -- what every ENEM table should look like.
+make_form <- function(n_ids = 400, n_items = 45, seed = 1) {
+  set.seed(seed)
+  theta <- stats::rnorm(n_ids)
+  b     <- seq(-1.5, 1.5, length.out = n_items)
+  g     <- 1 / 5
+  out <- expand.grid(id = seq_len(n_ids), item = seq_len(n_items))
+  pr   <- g + (1 - g) * stats::plogis(theta[out$id] - b[out$item])
+  out$resp <- stats::rbinom(nrow(out), 1, pr)
+  out
+}
+
+healthy <- make_form()
+
+cat("a healthy form passes\n")
+local({
+  st <- enem_scored_stats(healthy)
+  check(st$median_p > ENEM_CHANCE, "median p is above the chance floor")
+  check(st$median_item_rest > ENEM_MIN_MEDIAN_ITEM_REST,
+        "median item-rest clears the floor")
+  check(st$share_all_wrong <= ENEM_MAX_SHARE_ALL_WRONG,
+        "almost nobody scores exactly zero")
+  quiet(enem_check_scored(healthy, "healthy"))
+  ok("enem_check_scored() does not stop on it")
+})
+
+cat("finding 1 -- non-responses scored as wrong answers\n")
+local({
+  ## 40% of candidates sat the form but left it blank; scoring blanks as 0
+  ## puts them at exactly zero with every item present.
+  d <- healthy
+  absent <- 1:160
+  d$resp[d$id %in% absent] <- 0
+  st <- enem_scored_stats(d)
+  check(st$share_all_wrong > 0.3,
+        "the all-wrong share detects the block (this is the 45% in the issue)")
+  expect_warn(enem_check_scored(d, "blank-scored"),
+              "scored exactly zero",
+              "and enem_check_scored() warns, naming #1942")
+})
+
+local({
+  ## Once the blanks are NA rather than 0, the same candidates are simply
+  ## absent from the form and the statistic returns to normal.
+  d <- healthy
+  d$resp[d$id %in% 1:160] <- NA
+  st <- enem_scored_stats(d)
+  check(st$share_all_wrong <= ENEM_MAX_SHARE_ALL_WRONG,
+        "dropping them clears it -- the check tracks the fix, not the sample")
+})
+
+cat("finding 2 -- a mis-keyed form\n")
+local({
+  ## enem_2019_1mil_lc: five items scored 0 for everyone who answered them.
+  d <- healthy
+  d$resp[d$item %in% 1:5] <- 0
+  expect_stop(enem_check_scored(d, "dead-items"),
+              "scored identically for every candidate",
+              "an item nobody gets right stops the build")
+})
+
+local({
+  ## The wider defect: responses joined to the wrong keys, so scoring is
+  ## near-random and item-rest correlations collapse toward zero.
+  set.seed(9)
+  d <- healthy
+  d$resp <- stats::rbinom(nrow(d), 1, 0.16)   # median p .16, as observed
+  expect_stop(enem_check_scored(d, "mis-keyed"),
+              "median item-rest correlation",
+              "a form with no item-total structure stops the build")
+})
+
+local({
+  ## The check must not fire on a merely HARD form. Same latent structure,
+  ## every item shifted well above the sample's ability.
+  d <- make_form(seed = 3)
+  set.seed(4)
+  theta <- stats::rnorm(400); b <- seq(1.5, 4.0, length.out = 45)
+  pr <- 1/5 + (1 - 1/5) * stats::plogis(theta[d$id] - b[d$item])
+  d$resp <- stats::rbinom(nrow(d), 1, pr)
+  st <- enem_scored_stats(d)
+  check(st$median_p < 0.35, "the fixture really is a hard form")
+  check(st$median_item_rest > ENEM_MIN_MEDIAN_ITEM_REST,
+        "a hard form still has item-total structure")
+  quiet(enem_check_scored(d, "hard"))
+  ok("and is not stopped -- difficulty alone never fails the build")
+})
+
+cat("shape\n")
+local({
+  d <- healthy
+  set.seed(11)
+  d$resp[sample(nrow(d), 500)] <- NA   # scattered, so no item empties out
+  st <- enem_scored_stats(d)
+  check(st$n_items == 45, "NA responses are excluded, not counted as items")
+  check(st$min_n_per_item > 0, "every item keeps respondents")
+})
+
+## ------------------------------------------------- LC elective-block form ---
+## The reason `complete` is keyed off the modal answered-count and not ncol(w).
+##
+## An LC form has 40 shared items plus TWO mutually exclusive 5-item language
+## blocks, so every candidate answers 45 of 50 columns and NO candidate has a
+## response for all of them. Under `answered == ncol(w)` the complete set is
+## empty, `share_all_wrong` is forced to 0, and the finding-1 warning cannot
+## fire on any LC table -- including enem_2013_1mil_lc, which #1942 reports at
+## 44.7% all-wrong.
+make_lc_form <- function(n_ids = 400, seed = 7, all_wrong = FALSE) {
+  set.seed(seed)
+  shared <- paste0("s", 1:40)
+  eng    <- paste0("en", 1:5)
+  esp    <- paste0("es", 1:5)
+  theta  <- stats::rnorm(n_ids)
+  out <- do.call(rbind, lapply(seq_len(n_ids), function(i) {
+    its <- c(shared, if (i %% 2 == 0) eng else esp)
+    data.frame(id = i, item = its, stringsAsFactors = FALSE)
+  }))
+  b  <- stats::setNames(seq(-1.5, 1.5, length.out = 50), c(shared, eng, esp))
+  pr <- (1/5) + (1 - 1/5) * stats::plogis(theta[out$id] - b[out$item])
+  out$resp <- if (all_wrong) 0L else stats::rbinom(nrow(out), 1, pr)
+  out
+}
+
+cat("LC elective-block form (the ncol(w) blind spot)\n")
+local({
+  lc <- make_lc_form()
+  st <- enem_scored_stats(lc)
+  check(st$n_items == 50, "all 50 items are counted, both language blocks")
+  check(st$form_len == 45, "form_len is the modal answered-count (45), not ncol (50)")
+  check(st$n_complete > 0,
+        "candidates count as complete -> the all-wrong check is live on LC")
+  quiet(enem_check_scored(lc, "lc-healthy"))
+  ok("a healthy LC form still passes")
+})
+
+cat("LC form where every response is wrong -> all-wrong must fire\n")
+local({
+  lc0 <- make_lc_form(all_wrong = TRUE)
+  st <- enem_scored_stats(lc0)
+  check(st$share_all_wrong == 1, "share_all_wrong is 1.000, not 0.000")
+  ## every item is also zero-variance here, so the stop() fires first; that is
+  ## the stronger signal and the right one.
+  expect_stop(enem_check_scored(lc0, "lc-allzero"),
+              "scored identically for every candidate",
+              "enem_check_scored() stops on it")
+})
+
+cat("\n")
+if (failures > 0L) { cat(failures, "FAILURE(S)\n"); quit(status = 1L) }
+cat("all tests passed\n")


### PR DESCRIPTION
Fixes findings 1 and 3 of #1942, and adds the post-scoring guard that would have caught both. **All 13 years rebuilt** and diffed against the pre-fix build of the same code base.

Finding 2 is **not** in this commit: it was already fixed by `4478e89` and is simply unpublished — see the section at the bottom.

## Finding 1 — the cause is the absence *encoding*, not the scoring rule

I did **not** take the proposed `case_when(raw %in% c(".","*") ~ NA_real_)`. Scoring `.` and `*` as 0 is INEP's own scoring and this keeps it. The 45% has a different cause:

| years | absent candidate's `TX_RESPOSTAS` | effect |
|---|---|---|
| **2013, 2014 only** | **all dots** (100% of absentees, all four areas, both years) | not NA → survives `drop_na()` → every `.` scores 0 |
| **2015–2025** | **empty string** | vroom reads `""` as NA → `drop_na()` already removed them |

The absence *rates* are similar (31% in 2013, 22% in 2019). Only the encoding differs, so **the blast radius is 8 tables, not 52.**

The fix uses INEP's own per-area flag `TP_PRESENCA_{CN,CH,LC,MT}` (0 absent / 1 present / 2 eliminated), keeping only presence 1 in all four areas. Omissions by candidates who *did* sit are only 0.2–0.5% of cells once absentees are gone, and `resp_raw` ships alongside `resp` for anyone who wants them missing.

**The frame was audited on the full file for all 13 years before any code changed**, because the load-bearing claim is that 2015–2025 are untouched:

- **11 of 13 years: the presence-1 set is *exactly* the set `drop_na()` already kept.**
- 2013: 2,165,629 rows drop, **0 added**. 2014: 2,774,337 drop, 2 added — and those 2 are candidates INEP marks present but ships empty strings for, so `drop_na()` still removes them.
- Every year's regular pool stays ≥ 1M (smallest 2.14M, 2021).

Confirmed in the rebuild: **id sets identical for all 44 tables in 2015–2025**, differing only for 2013×4 and 2014×4.

Share of candidates scoring exactly zero:

| table | old → new | median item p |
|---|---|---|
| `enem_2013_1mil_lc` | 44.8% → **0.07%** | 0.216 → 0.387 |
| `enem_2013_1mil_ch` | 43.1% → **0.01%** | 0.201 → 0.355 |
| `enem_2013_1mil_cn` | 43.1% → **0.03%** | 0.121 → 0.214 |
| `enem_2013_1mil_mt` | 44.8% → **0.11%** | 0.127 → 0.230 |
| `enem_2014_1mil_lc` | 46.8% → **0.09%** | 0.198 → 0.371 |
| `enem_2014_1mil_ch` | 45.4% → **0.01%** | 0.214 → 0.394 |
| `enem_2014_1mil_cn` | 45.4% → **0.03%** | 0.143 → 0.262 |
| `enem_2014_1mil_mt` | 46.8% → **0.14%** | 0.115 → 0.216 |

## Annulled items dropped

INEP records `TX_GABARITO = "X"` for an item it annulled after the exam. No response letter can equal `X`, so it scores 0 for every candidate — a zero-variance column, useless for IRT and indistinguishable downstream from a keying failure. Ten sit in the standard item sets and are now dropped before the item set is built:

`2018 MT 30294` · `2020 CN 32352, MT 44322` · `2021 MT 117674` · `2022 MT 39443` · `2023 MT 14887` · `2024 CN 61076` · `2025 CN 141557, CN 141774, MT 31350`

Nine tables lose one item; 2025 CN loses two.

## Finding 3 — @ben-domingue's checks, with two changes

`data/enem_checks.R` and `data/tests/test_enem_checks.R` are from `fix/1942-enem-blank-scoring`, with two changes, each commented at the point it occurs:

**1. The `zero_variance` `stop()` would have halted 7 of 13 builds.** The ten annulled items above each score 0 for every candidate. As written the build stops for 2018 and 2020–2025, and the message — *"an item nobody gets right is a keying failure, not a hard item"* — would be wrong: it's neither. Dropping them upstream is what makes the hard stop sound, so `p == 0` really does mean a keying failure.

**2. `share_all_wrong` was structurally blind to every LC table.** `complete <- answered == ncol(w)` is never true on LC, where the two elective language blocks are mutually exclusive and every candidate answers 45 of 50 columns — so `all_wrong` was forced to 0, silencing finding 1 exactly where it was reported (`enem_2013_1mil_lc`, 44.7%). Now keyed off the modal answered-count; identical to `ncol(w)` for CH/CN/MT. Two LC fixtures added to the test file. The rebuilt 2013 LC reports **0.2%**, a number the original would have printed as `0.0%`.

Wired into the existing `tests.yml` — base R, no microdata, no network. **The false-positive test holds on real data:** `enem_2013_1mil_cn` has 47% of items below the 1/5 chance floor with median item-rest 0.092 and was *not* failed. Difficulty alone never fails a build.

## Safety

**`resp` is unchanged on every `id`+`item` cell shared with the previous build, across all 52 tables.** The fix changes *which candidates are sampled*, never how a response is scored. That's the assertion I'd most want checked.

No build was stopped by the new checks, so across all 52 tables there is no zero-variance item and no form lacking item-total structure.

The 13 scripts remain **byte-identical apart from `year` and their two prova-code lines**, so the patch is verifiable the way #1942 asked. No refactor, for the reason given there.

## Finding 2 is not here

The LC 1:1-split bug was already fixed by `4478e89` and is simply unpublished. It affects **six** live LC tables, not one — 2015, 2016, 2018, 2019, 2020, 2021, every year where `TX_RESPOSTAS_LC` is 50 wide over a 45-position span. (2017 is genuinely 50/50; 2013/2014 are 45/45, which is why 2013 LC looks healthy.) The rebuilt `enem_2019_1mil_lc` gives median p **0.392** and median item-rest **0.330**, against 0.16 and 0.010 on the live table. The positional hypothesis in the issue isn't it: the LC electives *are* at positions 1–5 exactly where the branch assumes.

## Needs a separate step

**The 52 rebuilt tables need re-uploading** — this PR is only the code. That also makes `resp_raw` public for the first time (so the Dict/metadata needs the extra column), and the **nominal set must be regenerated**, since `data/nominal/enem.R` derives it from the published tables via `irw_fetch`.

Incidental: the 2020 absence rate is a real outlier — 44.8% present against 66–73% every other year. The COVID administration, now visible in the build log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
