### PR TITLE
Fix the two scripts that published uninformative items (#2029)

### DIFF
--- a/data/Veterans Affairs SSVF Survey 2018-20.R
+++ b/data/Veterans Affairs SSVF Survey 2018-20.R
@@ -7,6 +7,18 @@ df <- df |>
   pivot_longer(cols = -responseid,
                names_to = 'item',
                values_to = 'resp')
+## 2026-09-08 (#2029): the last three columns of the source spreadsheet are
+## empty, so items 54-56 shipped as 26,347 rows of NA each -- against ~14% NA
+## for items 49-53. Nothing was destroyed here; they should simply never have
+## been published. Drop any item with no response at all before the ids are
+## assigned. They are the final three columns, so items 1-53 keep their
+## existing numbering and the published table stays comparable.
+informative <- df |>
+  group_by(item) |>
+  summarise(n_resp = sum(!is.na(resp)), .groups = 'drop') |>
+  filter(n_resp > 0) |>
+  pull(item)
+df <- df |> filter(item %in% informative)
 items <- as.data.frame(unique(df$item))
 items <- items |>
   mutate(item_id = row_number())

--- a/data/western_reserve_project.R
+++ b/data/western_reserve_project.R
@@ -3,6 +3,15 @@
 ##############################
 
 
+##############################
+##NOTE: 2026-09-08 from #2029. `item` here is a row number over
+##`unique(df$item)`, so it depends on which columns survive the drop_vars
+##loops. Fixing the ctp_wave4 loop below removes 202 columns, which means a
+##fresh run of this script does NOT reproduce the item ids in the published
+##table. The published table was repaired by deleting those 202 items from the
+##existing long file instead, precisely so every other item id stayed put.
+##############################
+
 library(tidyverse)
 library(readxl)
 library(janitor)
@@ -275,14 +284,19 @@ names(ctp_wave4) <- tolower(names(ctp_wave4))
 
 drop_vars <- c()
 
+## 2026-09-08 (#2029): this loop alone said `length(ctp_wave4)` -- the column
+## count of the whole frame, a constant -- where every other wave says
+## `length(unique_vals)`. `unique_len` therefore never equalled 1 or 2 and
+## NEITHER guard ever fired, so this one file kept its uninformative columns:
+## 81 items entirely NA and 121 with a single value plus NA, out of wave 4's
+## 1,004. The inner test was wrong too -- `ctp_wave4[1]` is the first COLUMN,
+## not `unique_vals[1]`. Both are restored to the shape the other waves use.
 for (i in 1:ncol(ctp_wave4)) {
   unique_vals <- unique(ctp_wave4[[i]])
-  unique_len <- length(ctp_wave4)
+  unique_len <- length(unique_vals)
   
-  if (unique_len == 1) {
-    if (is.na(unique(ctp_wave4[1]))) {
+  if (unique_len == 1 & is.na(unique(unique_vals[1]))) {
     drop_vars <- append(drop_vars, names(ctp_wave4)[i])
-    }
   }
   
   if (unique_len == 2 & (is.na(unique_vals[1]) | is.na(unique_vals[2]))) {


### PR DESCRIPTION
The two tables the `na_concentration` sweep (#2108) identified as having 100%-`NA` items caused by our own processing rather than by respondents. Scripts here; the rebuilt tables are staged as drafts on `item_response_warehouse:next`.

## `western_reserve_project.R`

The `ctp_wave4` drop-uninformative-columns loop said:

```r
unique_len <- length(ctp_wave4)      # column count of the frame -- a constant
                                     # every other wave: length(unique_vals)
```

`unique_len` therefore never equalled 1 or 2 and **neither guard ever fired** for that one file:

| wave | items | 0 distinct responses | 1 distinct response |
|---|---:|---:|---:|
| 4 | 1,004 | **81** | **141** |
| every other wave | 1,808 | 0 | 4 |

The inner `is.na(unique(ctp_wave4[1]))` was wrong too — that is the first *column*, not `unique_vals[1]`. Both restored to the shape the other eight loops use.

**Table repair: 202 items dropped, not 222.** 20 of the 141 single-value items have no `NA` at all, and the loop deliberately keeps those — other waves keep four of them too, so dropping them here would make wave 4 inconsistent with the rest. Faithful replication is the defensible repair.

`1,445,422 → 1,388,458 rows` (−56,964), `2,812 → 2,610 items`. None of the 202 appears in any other wave, so no other wave is touched.

## `Veterans Affairs SSVF Survey 2018-20.R`

No uninformative-column guard at all. The last three columns of the source spreadsheet are empty, so items 54–56 shipped as 26,347 rows of `NA` each, against ~14% for items 49–53 — a clean cliff at the end of the file. Nothing was destroyed here, unlike DART; they simply should not have been published.

`1,475,369 → 1,396,328 rows` (−79,041), items 54–56 gone. They are the final three columns, so items 1–53 keep the numbering they have today.

## Two things worth knowing

**Item ids are order-dependent.** In both scripts `item` is a row number over `unique(df$item)`, so it depends on which columns survive. A fresh run of the fixed `western_reserve_project.R` would renumber everything. The published table was therefore repaired by deleting the 202 items from the existing long file — precisely so every surviving item id stayed put. There is a note to that effect in the script.

**The `NA` rows themselves are deliberately untouched.** `resp` remains a string in both. Those are ordinary missing responses, and what to do with them corpus-wide is the open half of #2029 — not something to settle by side effect on two tables. Both rebuilds preserve them exactly.

Rebuilt offline from `data/pub/`, which matches the published tables exactly here (1,445,422 rows / 378,887 `NA`, and 1,475,369 / 476,509). Both pass `irw-validate` with pre-existing warnings only — and note that `resp_numeric` stays silent on 327,600 and 397,468 literal `NA`s, which is exactly the blind spot #2104 fixes.

Related: #2029, #2108, #2104, #2093.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPcxq8KkF6TmZrWf6xMtCb