### PR TITLE
Step 2b on the path the scheduled runs actually take (#2076 follow-up)

### DIFF
--- a/automated_finding/.claude/skills/irw-automated-finding/SKILL.md
+++ b/automated_finding/.claude/skills/irw-automated-finding/SKILL.md
@@ -247,8 +247,12 @@ Step 2b.
 
 ## Step 2b — Retriage `human_assistance` (REQUIRED, not optional)
 
-Normally you get this for free by passing `--retriage` to Step 2. Run it by
-hand only for a triage CSV that was produced without it:
+Normally you get this for free: `irw_batch_updated.py --retriage` chains it,
+and the two scheduled article connectors
+(`irw_discover_plos_monthly.py`, `irw_discover_pmc_monthly.py`), which
+triage in-process and never touch `irw_batch_updated.py`, run it
+unconditionally at the end of every run. Run it by hand only for a triage
+CSV that was produced without either:
 
 ```bash
 python irw_retriage_ha.py --input runs/irw_triage.csv --output runs/irw_retriage_ha.csv
@@ -257,7 +261,10 @@ python irw_retriage_ha.py --input runs/irw_triage.csv --output runs/irw_retriage
 **A triage run is not finished until this has happened.** It was worded as
 "recommended" until 2026-09-07, and the scheduled routines duly skipped it
 week after week, committing triage CSVs with no `refined_flag` column at
-all. That is not a cosmetic gap: until the bucket is sub-classified, the
+all. `#2076` fixed that on the `irw_batch_updated.py` path only, which is
+not the path the scheduled PLOS/PMC connectors take — so the 2026-09-08
+PLOS weekly run skipped the step again, nineteen hours after "REQUIRED"
+merged. Both connectors call it directly now. That is not a cosmetic gap: until the bucket is sub-classified, the
 `not_item_response` rows can't be dropped, the `human_review` rows can't be
 archived to `human_review/`, and the remainder can't be told apart from
 either — so the whole `human_assistance` bucket silently becomes nobody's

--- a/automated_finding/BATCH_LOG.md
+++ b/automated_finding/BATCH_LOG.md
@@ -13836,3 +13836,67 @@ at the top level as well as inside `runs/`. Five scheduled routines between
 2026-08-25 and 2026-09-07 had worked around the `runs/` rule by copying
 output up to `automated_finding/` or force-adding it; the ten strays that
 reached main are untracked.
+
+## 2026-09-08 — PLOS weekly run: "REQUIRED" was unreachable from the runner
+
+Scheduled weekly PLOS run (`irw_discover_plos_monthly.py --mode weekly`,
+`--per-term-cap=4`). Bookkeeping went straight to main as `a4b1cff`
+(`search_terms_log.csv` + 56 DOIs into `plos_seen_dois.csv`); the candidates
+CSV went to a branch as `#2109`.
+
+56 candidates triaged, all 15 terms visited, 14 at the per-term cap:
+40 `no_usable_file`, 13 `human_assistance`, 1 `below_min_n`, 1 `timeout`,
+1 `not_item_response`. **0 `good`.**
+
+### Step 2b was skipped nineteen hours after it was made required
+
+`#2076` retitled Step 2b REQUIRED and added `irw_batch_updated.py
+--retriage` to chain it, precisely so scheduled runs would stop skipping it.
+It merged at 01:12Z. This run started at 19:50Z and skipped Step 2b anyway,
+reporting "0 good" and stopping there.
+
+The routine was not ignoring the rule. `irw_discover_plos_monthly.py` and
+`irw_discover_pmc_monthly.py` triage in-process off `irw_triage_updated` and
+never call `irw_batch_updated` — so `--retriage` did not exist on either of
+the two paths that had ever needed compelling. The fix landed on the
+interactive path and missed both unattended ones. Fixed in `#2111`: the
+chaining logic moves to `irw_retriage_ha.chain_step2b` and both article
+connectors call it with `run=True` unconditionally, since an unattended run
+has nobody to read a reminder on stderr.
+
+This is the second consecutive week a run reported success while the step
+that produces its actual yield did not happen — and the first where the
+enforcement mechanism itself was on the wrong path. A rule that only reaches
+attended runs is not a rule for the runs that skip things.
+
+### Run retroactively: 12 of the 13 are machine-actionable
+
+`chain_step2b` over this run's CSV:
+
+| refined_flag | n |
+|---|---|
+| `recoverable_format` | 9 |
+| `worth_retrying` | 3 |
+| `human_review` | 1 |
+
+All 13 are `cc-by`. The 9 `recoverable_format` are one shape — `QC failed on
+resp_scale_mixed` plus a `multi_scale` warning, i.e. one deposit carrying
+several instruments, which the standard already answers with one table per
+scale. Largest by size: `pone.0310078` (873 × 161), `pone.0133254`
+(810 × 194), `pone.0182745` (706 × 107), `pone.0350219` (490 × 90),
+`pone.0246676` (867 × 56). The single genuine `human_review` is
+`pone.0311284`, where no column met the id heuristic.
+
+So "0 good" was never the story: the 2026-09-01 PLOS weekly bucket looked
+the same and became 21 tables / 280,971 responses. The 12 actionable DOIs
+are unworked as of this entry.
+
+### The per-run CSV came back
+
+`f7cbdda` force-added
+`automated_finding/plos_monthly_candidates_weekly_2026-09-08.csv`, which
+`.gitignore:59` (`plos_monthly_candidates_*.csv`) covers — the exact
+workaround `#2075` removed the day before, and the sixth scheduled routine
+to use it. `#2109` closed unmerged; this entry plus `a4b1cff` is the durable
+record, which is what the rule asks for. The routine also wrote no BATCH_LOG
+entry at all, which is the other half of what replaces the CSV.

--- a/automated_finding/irw_batch_updated.py
+++ b/automated_finding/irw_batch_updated.py
@@ -790,34 +790,13 @@ def main():
     # after run, committing triage CSVs with no refined_flag column and
     # leaving the whole bucket unclassified (2026-09-07 is one of several).
     # A hint that is ignored every week is not a hint that needs rewording,
-    # it needs to stop being optional: --retriage does the step in-process,
-    # and without it the reminder is now loud, names the exact command with
-    # this run's real paths, and says what is left undone.
-    n_ha = int(counts.get("human_assistance", 0))
-    if not n_ha:
-        return
-    retriage_out = os.path.splitext(args.out)[0] + ".retriage_ha.csv"
-    script = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                          "irw_retriage_ha.py")
-    cmd = [sys.executable, script, "--input", args.out, "--output", retriage_out]
-    if not args.retriage:
-        print(f"\n!! {n_ha} human_assistance row(s) are NOT yet sub-classified.",
-              file=sys.stderr)
-        print("   Step 2b is required before anyone reads this triage: without "
-              "it\n   there is no refined_flag column, so the not_item_response "
-              "rows\n   can't be dropped and the human_review rows can't be "
-              "archived.", file=sys.stderr)
-        print(f"   Run:  {' '.join(cmd)}", file=sys.stderr, flush=True)
-        return
-    print(f"\n[step 2b] retriaging {n_ha} human_assistance row(s) -> "
-          f"{retriage_out}", flush=True)
-    rc = subprocess.call(cmd)
-    if rc != 0:
-        print(f"\n!! Step 2b FAILED (exit {rc}). The triage at {args.out} is "
-              f"complete but its\n   human_assistance rows are still "
-              f"unclassified -- rerun the command above\n   before treating "
-              f"this run as done.", file=sys.stderr, flush=True)
-        sys.exit(rc)
+    # it needs to stop being optional.
+    #
+    # The implementation lives in irw_retriage_ha.chain_step2b so the three
+    # scheduled connectors, which never call this script, get the same step
+    # rather than a second copy that drifts (see that docstring).
+    from irw_retriage_ha import chain_step2b
+    chain_step2b(args.out, run=args.retriage)
 
 
 if __name__ == "__main__":

--- a/automated_finding/irw_discover_plos_monthly.py
+++ b/automated_finding/irw_discover_plos_monthly.py
@@ -205,6 +205,12 @@ def main():
     print(f"{terms_visited}/{len(terms)} terms visited this run "
           f"({terms_capped} hit the per-term cap of {per_term_cap})")
 
+    # Step 2b, in-process. This connector triages off irw_triage_updated and
+    # never reaches irw_batch_updated's --retriage flag, so #2076's "REQUIRED"
+    # step had no way to run on a scheduled article sweep -- see chain_step2b.
+    from irw_retriage_ha import chain_step2b
+    chain_step2b(out_path, run=True)
+
     _append_log_rows([{
         "date": today,
         "query": f"[{args.mode}] {len(terms)} terms x journals={','.join(journals)}",

--- a/automated_finding/irw_discover_pmc_monthly.py
+++ b/automated_finding/irw_discover_pmc_monthly.py
@@ -186,6 +186,12 @@ def main():
     print(f"{terms_visited}/{len(terms)} terms visited this run "
           f"({terms_capped} hit the per-term cap of {per_term_cap})")
 
+    # Step 2b, in-process. This connector triages off irw_triage_updated and
+    # never reaches irw_batch_updated's --retriage flag, so #2076's "REQUIRED"
+    # step had no way to run on a scheduled article sweep -- see chain_step2b.
+    from irw_retriage_ha import chain_step2b
+    chain_step2b(out_path, run=True)
+
     _append_log_rows([{
         "date": today,
         "query": f"[{args.mode}] {len(terms)} terms x journals={','.join(journals)}",

--- a/automated_finding/irw_retriage_ha.py
+++ b/automated_finding/irw_retriage_ha.py
@@ -295,6 +295,62 @@ FLAG_ORDER = [
 ]
 
 
+def chain_step2b(triage_csv, *, run=True, stream=None):
+    """Run Step 2b over `triage_csv`'s human_assistance rows, or say it wasn't.
+
+    Step 2b was retitled REQUIRED on 2026-09-07 (#2076), which also gave
+    irw_batch_updated.py a --retriage flag to chain it in-process. That fix
+    reached exactly one of the four triage entry points: the three scheduled
+    connectors (irw_discover_plos_monthly.py, irw_discover_pmc_monthly.py,
+    irw_discover_monthly.py) import irw_triage_updated directly and never
+    touch irw_batch_updated, so the step stayed unreachable for precisely the
+    unattended runs it was written for -- the 2026-09-08 PLOS weekly run
+    committed 13 unclassified human_assistance rows nineteen hours after
+    #2076 merged. Sharing one implementation is what keeps the next entry
+    point from missing it too.
+
+    Returns the retriage output path, or None if there was nothing to do.
+    """
+    import os, subprocess, sys
+    stream = stream or sys.stderr
+    try:
+        df = pd.read_csv(triage_csv)
+    except Exception as exc:                    # a triage CSV we can't read is
+        print(f"\n!! Step 2b skipped: cannot read {triage_csv} ({exc})",
+              file=stream, flush=True)          # the caller's problem, not ours
+        return None
+    if "flag" not in df.columns:
+        return None
+    n_ha = int((df["flag"] == "human_assistance").sum())
+    if not n_ha:
+        return None
+
+    out = os.path.splitext(str(triage_csv))[0] + ".retriage_ha.csv"
+    script = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                          "irw_retriage_ha.py")
+    cmd = [sys.executable, script, "--input", str(triage_csv), "--output", out]
+    if not run:
+        print(f"\n!! {n_ha} human_assistance row(s) are NOT yet sub-classified.",
+              file=stream)
+        print("   Step 2b is required before anyone reads this triage: without "
+              "it\n   there is no refined_flag column, so the not_item_response "
+              "rows\n   can't be dropped and the human_review rows can't be "
+              "archived.", file=stream)
+        print(f"   Run:  {' '.join(cmd)}", file=stream, flush=True)
+        return None
+
+    print(f"\n[step 2b] retriaging {n_ha} human_assistance row(s) -> {out}",
+          flush=True)
+    rc = subprocess.call(cmd)
+    if rc != 0:
+        print(f"\n!! Step 2b FAILED (exit {rc}). The triage at {triage_csv} is "
+              f"complete but its\n   human_assistance rows are still "
+              f"unclassified -- rerun the command above\n   before treating "
+              f"this run as done.", file=stream, flush=True)
+        raise SystemExit(rc)
+    return out
+
+
 def main():
     import argparse, os, sys
     ap = argparse.ArgumentParser(description=__doc__)


### PR DESCRIPTION
## Why

`#2076` (merged 2026-09-08 01:12Z) retitled Step 2b **REQUIRED** and added `irw_batch_updated.py --retriage` to chain it in-process, because the scheduled routines had skipped it week after week. The PLOS weekly run at **19:50Z the same day** skipped it again and committed 13 unclassified `human_assistance` rows (`#2109`).

The routine wasn't ignoring the rule — it couldn't reach it. `irw_discover_plos_monthly.py` and `irw_discover_pmc_monthly.py` triage in-process off `irw_triage_updated` and never call `irw_batch_updated`, so `--retriage` did not exist on the only two paths that had ever needed compelling. `#2076` landed on the interactive path and missed both unattended ones.

(`irw_discover_monthly.py`, the repo connector, is discovery only — its candidates reach triage through `irw_batch_updated` and were already covered.)

## What changed

- `irw_retriage_ha.chain_step2b()` — the chaining logic, moved out of `irw_batch_updated.py`. One implementation, since a second copy is exactly how the two paths diverged.
- `irw_batch_updated.py` calls it with `run=args.retriage` (unchanged behaviour: chain, or print the loud reminder).
- Both article connectors call it with `run=True` **unconditionally**. An unattended run has nobody to read a reminder on stderr — that is the mechanism that lost the step in the first place.
- `SKILL.md` Step 2b says which paths now run it automatically, and records why "REQUIRED" wasn't enough on its own.

## Verification

Ran `chain_step2b` against this week's real 56-row PLOS CSV. The 13 `human_assistance` rows classify as:

| refined_flag | n |
|---|---|
| `recoverable_format` | 9 |
| `worth_retrying` | 3 |
| `human_review` | 1 |

So 12 of 13 are machine-actionable and only one is genuinely ambiguous — the same shape as the 2026-09-01 PLOS weekly bucket, which became 21 tables / 280,971 responses. Both the `run=True` and `run=False` branches were exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHfJzCpbPbewzxTYnicTkS
