### PR TITLE
lindstrom2021_conscientiousness is Collective Narcissism: rename (#2107)

### DIFF
--- a/data/lindstrom2021_soccer.py
+++ b/data/lindstrom2021_soccer.py
@@ -16,11 +16,20 @@ TITLE = ("Data and code for - Personality and Team Identification Predict "
          "Violent Intentions Among Soccer Supporters")
 UA    = {"User-Agent": "irw-batch/1.0 (research)"}
 
+##The CN block is COLLECTIVE NARCISSISM, not conscientiousness (irw#2107). The
+##deposit's own CodeBook_soccersupporterdata.csv heads it
+##"Collective narcissism;Scale (7 items);CN3", and the items are about the club
+##-- "Hammarby maste fa den respekt vi fortjanar". An earlier version of this
+##file read the CN prefix as Conscientiousness and named the table
+##lindstrom2021_conscientiousness; the study administered no conscientiousness
+##scale at all. The codebook lists exactly four: Honesty-Humility (10 items),
+##Hammarby identification (3), Collective narcissism (7), violent intentions (7).
+##The scale key IS the table name -- see `fname` below -- so do not rename it back.
 SCALES = {
     "honesty_humility": [f"HH{i}R" if i in (1,2,3,4,7,9) else f"HH{i}"
                          for i in range(1, 11)],
     "team_identification": ["H1", "H2", "H3"],
-    "conscientiousness":   ["CN3", "CN4", "CN5", "CN6", "CN7R", "CN8", "CN9"],
+    "collective_narcissism": ["CN3", "CN4", "CN5", "CN6", "CN7R", "CN8", "CN9"],
     "violent_intentions":  ["VI1", "VI2", "VI3", "VI4R", "VI5R", "VI6", "VI7R"],
 }
 


### PR DESCRIPTION
Closes #2107 on the code side.

The deposit's own `CodeBook_soccersupporterdata.csv` (figshare 14980251) heads the CN block `Collective narcissism;Scale (7 items);CN3`, its items are club statements — *"Hammarby måste få den respekt vi förtjänar"* — and the codebook lists exactly four scales: Honesty-Humility (10), Hammarby identification (3), Collective narcissism (7), violent intentions (7). **There is no conscientiousness scale in the deposit.**

`SCALES["conscientiousness"]` is what named the published table, because the scale key *is* the table name (see `fname`). This renames the key and adds a comment so it does not get renamed back.

**Verified before anything went to Redivis:** the regenerated CSV was compared cell for cell against the live `lindstrom2021_conscientiousness` — 1,561 rows, all seven columns, every cell equal. Only the name changes. A rename keeps the row count, so red_up's count check could not have shown this on its own.

**Already done outside this PR:**
- `lindstrom2021_collective_narcissism` uploaded to `item_response_warehouse_2:next`, and `lindstrom2021_collective_narcissism__items` to `irw_text_2:next`, both row-count verified.
- Item-text bookkeeping renamed on `itemtext/queue-rounds` (48d65cb): provenance, audit_report, notes, verification_merged, mapping_verification, queue_state.
- The item-text table was only ever in the draft, never published, so no wording was public under the wrong name and nothing is withdrawn.

**Still needs Ben:** delete `lindstrom2021_conscientiousness` from `item_response_warehouse_2` and `lindstrom2021_conscientiousness__items` from the `irw_text_2` draft; rename the dictionary row and correct its Description, which reads "Conscientiousness subscale (7 items; CN3-CN9)".

**Opens a rights question, not resolved here.** `availability_audit_full.csv` ruled this table AVAILABLE because *"Conscientiousness is a standard HEXACO-PI-R subscale and the full HEXACO item pool is freely published"* — a ruling about an instrument this table does not contain. The wording has never been checked against the Collective Narcissism Scale (Golec de Zavala et al., 2009) it actually is. Nothing is published, so there is no exposure today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyMmEFLmpZaoybzpsfWGow