### PR TITLE
Split irw_validate out of the irw-red-up distribution

### DIFF
--- a/.github/scripts/check_irw_validate_version.py
+++ b/.github/scripts/check_irw_validate_version.py
@@ -1,0 +1,53 @@
+"""Fail the release if the tag and irw_validate/pyproject.toml disagree.
+
+PyPI never allows a version to be re-uploaded, even after deletion, so a
+mismatch caught after the upload cannot be fixed -- only worked around with a
+version number nobody asked for. This runs before the build.
+
+Called with the tag name, or with "" for a workflow_dispatch run, where there
+is no tag to compare and the check is a no-op.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+PREFIX = "irw-validate-v"
+PYPROJECT = pathlib.Path(__file__).resolve().parents[2] / "irw_validate" / "pyproject.toml"
+
+
+def declared_version() -> str:
+    text = PYPROJECT.read_text(encoding="utf-8")
+    # Deliberately not tomllib: this must run on the oldest Python the workflow
+    # might pin, and the field is unambiguous.
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if match is None:
+        sys.exit(f"no version field found in {PYPROJECT}")
+    return match.group(1)
+
+
+def main(argv: list[str]) -> int:
+    version = declared_version()
+    tag = argv[1] if len(argv) > 1 else ""
+    if not tag:
+        print(f"no tag (workflow_dispatch); pyproject declares {version}")
+        return 0
+    if not tag.startswith(PREFIX):
+        sys.exit(
+            f"tag {tag!r} does not start with {PREFIX!r}. Only irw_validate is "
+            f"released from this repository, so its tags say so."
+        )
+    tagged = tag[len(PREFIX):]
+    if tagged != version:
+        sys.exit(
+            f"tag {tag!r} means version {tagged!r}, but "
+            f"irw_validate/pyproject.toml declares {version!r}. Bump the "
+            f"pyproject in a PR, merge it, then tag the merge commit."
+        )
+    print(f"tag {tag} matches pyproject version {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/workflows/release-irw-validate.yml
+++ b/.github/workflows/release-irw-validate.yml
@@ -1,0 +1,114 @@
+# Publishes `irw_validate` to PyPI as https://pypi.org/project/irw-validate/.
+#
+# This repository holds many things; only `irw_validate/` is a distributable
+# package, so the tag is namespaced -- `irw-validate-vX.Y.Z`, not `vX.Y.Z` --
+# and this workflow ignores every other tag. Nothing else here is released, and
+# a bare `v*` tag would claim otherwise.
+#
+# The tag IS the trigger, deliberately. Rpkg's release-prepare.yaml opens a
+# release PR and goes GREEN without opening it, because "GitHub Actions is not
+# permitted to create or approve pull requests" is downgraded to a warning
+# (Rpkg#136), so a successful run there is not evidence a release is in flight.
+# Here it is. This mirrors Python-pkg's release.yml, which was written for the
+# same reason.
+#
+# Release procedure: bump `version` in irw_validate/pyproject.toml in a PR,
+# merge it, then `git tag irw-validate-v1.0.1 && git push origin irw-validate-v1.0.1`.
+#
+# Authentication is PyPI Trusted Publishing (OIDC): no API token in this
+# repository, no `password:` below. Before the first release someone must add a
+# pending publisher on pypi.org for project `irw-validate`, owner
+# `ben-domingue`, repository `irw`, workflow `release-irw-validate.yml`,
+# environment `pypi`. Renaming this file or that environment breaks publishing
+# until the publisher is updated.
+#
+# workflow_dispatch runs everything except the upload. Use it to check that the
+# build and the version guard pass before burning a version number -- PyPI never
+# allows a version to be re-uploaded, even after deletion.
+
+name: release irw-validate
+
+on:
+  push:
+    tags: ["irw-validate-v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: irw_validate
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      # Before building, not after: a mismatch means the artifact would carry a
+      # version that disagrees with the tag people cite.
+      - name: Check tag and pyproject version agree
+        working-directory: .
+        run: python .github/scripts/check_irw_validate_version.py "${{ github.ref_type == 'tag' && github.ref_name || '' }}"
+
+      - run: python -m pip install --upgrade pip
+      - run: pip install build twine
+      - run: python -m build --outdir dist .
+
+      # Catches a README PyPI would reject, and an artifact whose metadata did
+      # not resolve (setuptools older than the pyproject floor names the package
+      # UNKNOWN rather than failing).
+      - run: python -m twine check dist/*
+
+      # The package must import and run with nothing but its declared
+      # dependencies, from outside the repository -- that is the whole point of
+      # splitting it out of irw-red-up. Installing the wheel into a bare venv
+      # and validating a file from /tmp proves it; doing it in the checkout
+      # would not, because the repo would be sitting there satisfying imports.
+      - name: The wheel works with no repository around it
+        working-directory: .
+        run: |
+          set -euo pipefail
+          python -m venv /tmp/vv
+          /tmp/vv/bin/pip install --quiet irw_validate/dist/*.whl
+          printf 'id,item,resp\n1,q1,1\n1,q1,0\n' > /tmp/dup.csv
+          cd /tmp
+          # Exit 1 on a blocking finding is the contract the gate depends on.
+          if /tmp/vv/bin/irw-validate /tmp/dup.csv; then
+            echo "expected a nonzero exit for a duplicate id+item row"; exit 1
+          fi
+          # The split exists so the validator does not drag the uploader in.
+          if /tmp/vv/bin/python -c "import redivis" 2>/dev/null; then
+            echo "redivis reached the venv: irw-validate has picked up a Redivis dependency"
+            exit 1
+          fi
+          /tmp/vv/bin/python -c "
+          import irw_validate
+          report = irw_validate.validate_file('/tmp/dup.csv')
+          assert not report.ok, 'duplicate id+item should block'
+          assert irw_validate.exit_code([report]) == 1
+          print('ok:', [f.check for f in report.errors])
+          "
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: irw_validate/dist/
+
+  publish:
+    needs: build
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      # The entire OIDC integration. Nothing else is needed and no secret is read.
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,12 @@ jobs:
           # with --no-deps left one pre-existing test unable to import cli.
           python -m pip install pandas
           python -m pip install -e .
+          # irw_validate is its own distribution now, not a rider on
+          # irw-red-up. Installing it here is also what checks its pyproject
+          # still builds -- the pipeline itself does not need the install,
+          # because red_up and irw_triage_updated both put the repo root on
+          # sys.path before importing it.
+          python -m pip install -e irw_validate
 
       - name: red_up
         run: python -m unittest discover -s red_up/tests -t . -v

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,13 @@ __pycache__/
 *.egg-info/
 irw_validate/results/.shard_index.json
 
+# irw_validate build artefacts. Its package directory IS its project
+# directory, so `python -m build` drops these inside the package itself --
+# where, uningored, they land in the next diff as a second copy of every
+# module.
+irw_validate/build/
+irw_validate/dist/
+
 ##Per-agent fetch caches for concurrent tagging runs (#1704, P5). Same reason
 ##tags/.claude/skills/irw-auto-tag/.cache is ignored: this is fetched source
 ##text, much of it copyrighted, and it is a scratch artifact of one run.

--- a/irw_validate/README.md
+++ b/irw_validate/README.md
@@ -9,10 +9,33 @@ irw-validate out/x.csv --json                # for CI
 
 Exit codes: `0` ok · `1` something blocks · `2` bad input. Same contract as `red_up`.
 
-`irw-validate` is a console script declared in `pyproject.toml`. If the command is not
-found, the editable install predates it — re-run `pip install -e .` from `src/` (this
-machine needs `--break-system-packages`, PEP 668). Otherwise `python3 -m irw_validate.cli`
-works, but only from `src/`.
+## Installing
+
+```
+pip install irw-validate                    # once published
+pip install -e /path/to/irw/src/irw_validate   # from a checkout
+```
+
+pandas and the standard library, nothing else — no Redivis, no credentials, no
+network. That is deliberate: this is the thing an outside contributor runs
+against their own file before depositing it, and they should not have to clone
+the pipeline or hold a token to do it.
+
+Two optional extras exist for cases that are not that:
+
+| Extra | Adds | Needed for |
+|---|---|---|
+| `[rdata]` | pyreadr | validating `.Rdata`/`.rda`/`.rds` directly. Converting to CSV first needs nothing. |
+| `[live]` | redivis | the `live_*` and `repair_*` modules, which read published tables. Pipeline tools; `validate_file` never touches the network. |
+
+Until 2026-09-09 this package shipped inside `irw-red-up`, the uploader
+distribution, so the only way to get the validator was to install the writer.
+That was an accident of packaging: `../pyproject.toml` keeps `red_up` out of
+Python-pkg because a write-scoped uploader would change what that package is,
+and none of that reasoning applies to a checker that opens a CSV.
+
+`irw-validate` is a console script. In a checkout without the install,
+`python3 -m irw_validate.cli` works from `src/`.
 
 ## Why this exists
 

--- a/irw_validate/core.py
+++ b/irw_validate/core.py
@@ -21,6 +21,20 @@ MAX_BYTES = 512 * 1024 ** 2
 TABLE_SUFFIXES = (".csv", ".tsv", ".txt", ".rdata", ".rda", ".rds")
 
 
+def _pipeline_root():
+    """The `irw` checkout this package sits inside, or None if there is none.
+
+    `irw_validate` is installable on its own (`pip install irw-validate`), and
+    a contributor who does that has the validator but not the pipeline around
+    it. Two loaders below need that pipeline; everything else -- every CSV, and
+    `validate_frame` on a frame the caller already has -- needs pandas and
+    nothing more. Checking rather than assuming turns an ImportError raised
+    from three frames down into a sentence saying what to do.
+    """
+    root = Path(__file__).resolve().parent.parent
+    return root if (root / "automated_finding" / "irw_triage_updated.py").is_file() else None
+
+
 def _table_name(label: str) -> str:
     stem = Path(label).name
     low = stem.lower()
@@ -273,7 +287,14 @@ def validate_file(path, *, label: str | None = None, profile: str = "upload",
         # The 922 legacy tables in ../data/pub/ (#1703 sub-item 1.5). Not
         # routed through irw_triage_updated.load_table because that pulls in
         # the whole discovery pipeline for a two-line read.
-        import pyreadr
+        try:
+            import pyreadr
+        except ImportError:
+            raise ValueError(
+                f"{path.name}: reading R data files needs pyreadr, which is "
+                "optional -- install it with `pip install 'irw-validate[rdata]'`, "
+                "or convert the table to CSV, which needs nothing extra."
+            ) from None
         objs = pyreadr.read_r(str(path))
         if not objs:
             raise ValueError(f"{path.name} holds no R object")
@@ -286,8 +307,18 @@ def validate_file(path, *, label: str | None = None, profile: str = "upload",
                 f"({', '.join(str(k) for k in objs)}); expected one table")
         df = next(iter(objs.values()))
     else:
+        # Anything else goes through the pipeline's own reader, which exists
+        # only in a checkout of ben-domingue/irw.
+        root = _pipeline_root()
+        if root is None:
+            raise ValueError(
+                f"{path.name}: '{path.suffix}' files are read by the IRW "
+                "pipeline's loader, which is not part of this package -- it "
+                "lives in a checkout of ben-domingue/irw. Convert the table to "
+                "CSV, or run irw-validate from inside a checkout."
+            )
         import sys
-        sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "automated_finding"))
+        sys.path.insert(0, str(root / "automated_finding"))
         from irw_triage_updated import load_table
         df = load_table(str(path))
     return validate_frame(df, label=label, profile=profile, context=context)

--- a/irw_validate/pyproject.toml
+++ b/irw_validate/pyproject.toml
@@ -1,0 +1,70 @@
+# Packaging for `irw_validate` alone.
+#
+# This package used to ship as a rider on `irw-red-up` (see ../pyproject.toml),
+# which meant the only way to get the validator was to install the uploader --
+# editable, pointed at a real `src` checkout, because red_up reads
+# metadata/redivis_config.R next to itself.
+#
+# That was an accident of packaging, not a design. red_up is write-scoped and
+# needs the repo; the validator needs pandas and the standard library, and
+# nothing else. It is the piece an outside contributor wants before depositing
+# a table, and they should not have to clone the pipeline to run it.
+#
+# Nothing moves. The package directory IS the project directory, because two
+# modules resolve paths relative to __file__: `core.py` reaches
+# ../automated_finding for its loader of last resort, and `contract.py` walks
+# up to the repo root for the pull-request gate. Moving the package would
+# break both, and neither is worth breaking to satisfy a layout convention.
+#
+# Installed from a wheel there is no repo above the package, so `core.py`
+# checks (`_pipeline_root()`) and says what to do instead of raising an
+# ImportError from three frames down. `contract.py` is a repo gate and is only
+# meaningful in a checkout; it is shipped because excluding one module from a
+# 16-module package costs more than it saves.
+#
+#   pip install /path/to/irw/src/irw_validate      # or, once published:
+#   pip install irw-validate
+#
+# The `live` extra adds redivis, which only the live_* and repair_* modules
+# need. They are pipeline tools and are not importable without it; the
+# validator itself never touches the network.
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "irw-validate"
+version = "1.0.0"
+description = "Check a table against the Item Response Warehouse format, with an exit code"
+readme = "README.md"
+requires-python = ">=3.9"
+license = {text = "MIT"}
+dependencies = ["pandas>=1.3.0"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering",
+]
+
+[project.urls]
+Homepage = "https://itemresponsewarehouse.org"
+Source = "https://github.com/ben-domingue/irw/tree/main/irw_validate"
+
+[project.optional-dependencies]
+# Only the live_* and repair_* modules, which are pipeline tools that read
+# published Redivis tables. `validate_file` and `validate_frame` never do.
+live = ["redivis>=0.18.0"]
+# Only for validating .Rdata/.rda/.rds directly. Converting to CSV first needs
+# nothing extra, and is what an outside contributor will usually do.
+rdata = ["pyreadr"]
+
+[project.scripts]
+irw-validate = "irw_validate.cli:main"
+
+[tool.setuptools]
+# The package directory IS the project directory. Nothing moves: see the note
+# above about __file__-relative paths.
+packages = ["irw_validate"]
+package-dir = {"irw_validate" = "."}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,14 @@
 # after which `red_up` is on PATH and `python3 -m red_up` works from anywhere.
 # The install must be editable and must point at a real `src` checkout: red_up
 # reads metadata/redivis_config.R next to itself for the dataset list.
+#
+# `irw_validate` used to ship here too, which meant the only way to get the
+# validator was to install the uploader. It is now its own distribution --
+# irw_validate/pyproject.toml -- because it needs pandas and nothing else, and
+# because the read/write line this file draws around red_up does not apply to
+# it. Install both from a checkout:
+#
+#   pip install -e /path/to/irw/src -e /path/to/irw/src/irw_validate
 
 [build-system]
 requires = ["setuptools>=61"]
@@ -27,7 +35,6 @@ dependencies = ["redivis>=0.18.0"]
 
 [project.scripts]
 red_up = "red_up.cli:main"
-irw-validate = "irw_validate.cli:main"
 
 [tool.setuptools]
-packages = ["red_up", "irw_validate"]
+packages = ["red_up"]


### PR DESCRIPTION
Makes the validator installable on its own. Prompted by itemresponsewarehouse/Python-pkg#27, which asks for "a way to check a table from Python" and is filed as a port from R — but there is no `irw_validate` in the R package, and the validator has been Python all along. The actual obstacle is that you cannot `pip install` it.

### The problem

`pyproject.toml` declares `packages = ["red_up", "irw_validate"]` under the distribution name `irw-red-up`. So the only way to get the validator is to install the **uploader** — editable, pointed at a real `src` checkout, because red_up reads `metadata/redivis_config.R` next to itself. An outside contributor with a CSV and pip cannot run it.

That is an accident of packaging. This file's own header keeps red_up out of Python-pkg because "a write-scoped uploader would change what it is" — correct, and it does not apply to a checker that opens a CSV. Seven modules import redivis (`live_*`, `repair_*`); all seven are pipeline tools. `validate_file` and `validate_frame` need pandas and the standard library.

### The change

- **`irw_validate/pyproject.toml`** — its own distribution, `irw-validate`, pandas-only, with `[live]` (redivis) and `[rdata]` (pyreadr) extras for the parts that are not that.
- **The package directory is the project directory, and nothing moves.** `core.py` reaches `../automated_finding` for its loader of last resort and `contract.py` walks to the repo root for the PR gate; relocating the package to satisfy a layout convention would break both.
- **The two loaders that need a repo now say so.** Installed from a wheel there is nothing above the package, so `core.py` checks (`_pipeline_root()`) and returns a sentence about converting to CSV instead of an `ImportError` from three frames down. `pyreadr` becomes a declared optional extra rather than an undeclared import.
- **`.github/workflows/release-irw-validate.yml`** — mirrors Python-pkg's `release.yml`, with the version guard running *before* the build because PyPI never allows a version to be re-uploaded.

### Nothing in the pipeline depended on the install

Worth stating plainly, because it looks like it should. `red_up/checks.py:110` and `automated_finding/irw_triage_updated.py:491` both put the repo root on `sys.path` before importing `irw_validate`, so the 58 `data/` scripts that call `run_qc`, red_up's pre-upload gate and the `contract` job all keep resolving it from the checkout. CI installs the new distribution anyway — that is what checks the pyproject still builds on every PR.

`red_up` and `irw_validate` test suites: 65 and 83 tests, both green.

### The tag is namespaced

`irw-validate-vX.Y.Z`, not `vX.Y.Z`. This repository has no tags at all today and holds many things of which exactly one is distributable; a bare `v*` tag would claim the repository was being released.

### Verified end to end

Built the wheel, installed it into a bare venv, and ran it on a duplicate-id CSV from `/tmp` with no repository anywhere near it:

```
$ irw-validate /tmp/dup.csv
1 blocking finding(s). Fix them, or waive with --override "<why>".
/tmp/dup.csv [upload]
  ERROR dup_id_item    1 duplicate id+item rows with no wave/timepoint/date column
  WARN  sample_floor   1 unique ids; datastandard.md sets a flat floor of 100 ...
exit=1
$ python -c "import redivis"
ModuleNotFoundError: No module named 'redivis'
```

The release workflow runs the same check on every build, including the assertion that redivis has not crept back into the dependency set.

### What this needs from you

Publishing is Trusted Publishing (OIDC), so **a pending publisher has to be created on pypi.org before the first release**: project `irw-validate`, owner `ben-domingue`, repository `irw`, workflow `release-irw-validate.yml`, environment `pypi`. The name is free — I checked all three spellings. Until that exists, `workflow_dispatch` runs everything except the upload, so the build and the guard can be exercised safely.

Once it is published, Python-pkg gets `irw.validate()` as a thin wrapper behind `pip install irw[validate]`, and Python-pkg#27 closes without anyone porting or vendoring anything.

Refs itemresponsewarehouse/Python-pkg#27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Midy9mDCdLo1TGBJbPffs2