### PR TITLE
moe2025_scs: rebuild SCS25_pre from its reverse-scored twin (#2146)

### DIFF
--- a/data/moe2025_selfcompassion.py
+++ b/data/moe2025_selfcompassion.py
@@ -30,6 +30,23 @@ def convert():
     r = requests.get(FILE_URL, headers=UA, timeout=60)
     r.raise_for_status()
     raw = pd.read_spss(pd.io.common.BytesIO(r.content), convert_categoricals=False)
+
+    # SCS25_pre is not item 25's responses (irw#2146). The file carries a
+    # reverse-scored twin for all 13 negatively worded SCS items; twelve satisfy
+    # raw + rev == 6 for every respondent, but SCS25_pre disagrees with
+    # SCS25_pre_rev for 66 of 95. The _rev column is the real item: it
+    # correlates -.51 to -.63 with the other Isolation items (raw: -.12 to -.18),
+    # and regressing the author's own SelfCompassion composite on every item
+    # column weights SCS25_pre_rev 0.96 and SCS25_pre -0.06. So the raw item is
+    # recovered as 6 - SCS25_pre_rev.
+    rev_cols = [c for c in raw.columns if c.startswith("SCS") and c.endswith("_rev")]
+    for c in rev_cols:
+        if c == "SCS25_pre_rev":
+            continue
+        bad = int((raw[c.removesuffix("_rev")] + raw[c] != 6).sum())
+        assert bad == 0, f"{c}: {bad} rows break raw + rev == 6; recheck #2146 before trusting it"
+    raw["SCS25_pre"] = 6 - raw["SCS25_pre_rev"]
+
     # "Codice" has one duplicate value -- use row position instead.
     raw = raw.reset_index(drop=True)
     raw.insert(0, "id", raw.index + 1)


### PR DESCRIPTION
Refs #2146.

The deposit's raw `SCS25_pre` column holds values that are not item 25's responses. Its reverse-scored twin `SCS25_pre_rev` does hold item 25, so the script now ships `6 - SCS25_pre_rev`.

**Why the `_rev` column is the real item**
- The other twelve reverse-scored pairs satisfy `raw + rev == 6` for all 95 respondents. `SCS25_pre` disagrees with its twin for 66 of 95.
- The `_rev` column correlates −.51 to −.63 with the other Isolation items. The raw column correlates only −.12 to −.18.
- **The author's own scoring settles it.** The deposit includes a `SelfCompassion` composite. Regressing it on every item column gives `SCS25_pre_rev` a weight of **0.96** and `SCS25_pre` a weight of **−0.06**. Swapping the raw column in raises the residual sum of squares from 25.6 to 61.7.

The script also asserts that the other twelve pairs still sum to 6, so a changed deposit fails loudly.

**Verification**
- The rebuilt table matches the published one on all 2,470 `(id, item)` keys. It differs in exactly 66 `resp` values, all on `SCS25_pre`. Covariates are unchanged.
- It is uploaded to `item_response_warehouse_3:next`, and red_up's count check passed. Because the row count doesn't change, I also queried the draft: `SCS25_pre` shows `resp` 1–5 = 11/14/42/17/11, which matches the rebuild.
- The fix is **not live until the `_3` draft is released.**

**Not changed:** `SCS26_pre` also gets almost no weight in the author's composite (0.09). It has no `_rev` twin to check against, so it stays as published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhvqBGdAmKJQZpZbuqawjh